### PR TITLE
[codex] Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,65 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+  pages: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          cache: npm
+          node-version: 22
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run unit tests
+        run: npm test
+
+      - name: Build static site
+        run: npm run build
+
+      - name: Run browser tests
+        run: npm run test:e2e
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -163,6 +163,7 @@ Completed so far:
 - Promoted the Svelte/Vite app from `modern.html` to the primary `index.html` entrypoint.
 - Archived the previous jQuery/Material legacy page as `legacy.html` for one migration step.
 - Updated Vite and Playwright to build and exercise `/` as the production app route.
+- Added a GitHub Actions Pages workflow that tests, builds, uploads `dist/`, and deploys the static Vite output.
 
 Acceptance criteria:
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to build and deploy the modern Vite app to GitHub Pages from the generated dist/ directory.

The workflow runs on pushes to master and manual dispatches. It:

- installs Node 22 dependencies with npm ci
- installs Chromium for Playwright
- runs npm test
- runs npm run build
- runs npm run test:e2e
- uploads dist as a Pages artifact
- deploys with actions/deploy-pages

## Why

The repository's Pages configuration currently serves the root of master with the legacy Pages builder. The modern Vite app needs the built dist output to be deployed instead of serving source files directly.

## Validation

- npm test -> 44 passed
- npm run build -> passed
- npm run test:e2e -> 10 passed

## Follow-up

After this PR is merged, switch the repository Pages source from branch/root to GitHub Actions in Settings > Pages, or run the equivalent Pages API update.