### PR TITLE
[codex] Copy images into Pages build

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -164,6 +164,7 @@ Completed so far:
 - Archived the previous jQuery/Material legacy page as `legacy.html` for one migration step.
 - Updated Vite and Playwright to build and exercise `/` as the production app route.
 - Added a GitHub Actions Pages workflow that tests, builds, uploads `dist/`, and deploys the static Vite output.
+- Updated the production build to copy the runtime `images/` tree into `dist/images/` so card and icon paths resolve on GitHub Pages.
 
 Acceptance criteria:
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && npm run copy:images",
+    "copy:images": "mkdir -p dist/images && cp -R images/. dist/images/",
     "dev": "vite --host 127.0.0.1",
     "preview": "vite preview --host 127.0.0.1",
     "start": "npm run dev",


### PR DESCRIPTION
## Summary

Fixes broken image assets on the GitHub Pages deployment by copying the repository's runtime images directory into the Vite build output.

The modern app references card art and icon paths such as images/icons/rolling.png at runtime. The Pages workflow deploys dist/, so those static assets need to be present under dist/images/.

## Validation

- npm run build -> passed
- verified dist/images/icons/rolling.png exists
- verified dist/images/attack-modifiers/base/player/am-p-01.png exists
- production preview served both image paths with HTTP 200
- npm test -> 44 passed
- npm run test:e2e -> 10 passed
