### PR TITLE
[codex] Add deck session undo and character slots

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -122,6 +122,9 @@ Completed so far:
 - Restored perk symbol rendering in the modern perks panel using existing icon assets for tokens such as rolling, wound, push, and elements.
 - Tightened mobile draw-stage layout so attack modifier cards keep their landscape ratio, avoid horizontal overflow, and display two-card draws side by side.
 - Improved the mobile perks layout by switching the icon-heavy perk list to a single readable column on narrow screens.
+- Added four independent character slots to the modern UI so class, perk, deck, discard, and scenario modifier state can be managed per character.
+- Added global undo for the latest mutating deck/session action.
+- Added reset controls for scenario state, the active base deck, and the active character slot.
 
 Acceptance criteria:
 
@@ -142,6 +145,7 @@ Completed so far:
 
 - Added `@playwright/test`, `playwright.config.ts`, and `npm run test:e2e`.
 - Covered class selection, perk reset, drawing, manual shuffling, scenario modifier buttons, perk toggling, and terminal-card auto-shuffle.
+- Covered undo, independent character slots, and scenario/base-deck/character reset controls.
 
 Acceptance criteria:
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import type { AttackModifierCard, CharacterClassId } from "./domain/index.ts";
   import { assetPath, loadAppData } from "./browser-data.ts";
+  import CharacterTabs from "./components/CharacterTabs.svelte";
   import ClassPicker from "./components/ClassPicker.svelte";
   import DrawStage from "./components/DrawStage.svelte";
   import PerksPanel from "./components/PerksPanel.svelte";
@@ -35,6 +36,15 @@
 
     errorMessage = "";
     snapshot = controller.selectClass(classId);
+  }
+
+  function selectCharacter(index: number): void {
+    if (!controller) {
+      return;
+    }
+
+    errorMessage = "";
+    snapshot = controller.selectCharacter(index);
   }
 
   function runAction(action: DeckSessionAction): void {
@@ -100,6 +110,12 @@
     {#if isLoading}
       <div class="status" role="status">Loading deck data...</div>
     {:else if snapshot}
+      <CharacterTabs
+        characters={snapshot.characters}
+        activeCharacterIndex={snapshot.activeCharacterIndex}
+        onSelect={selectCharacter}
+      />
+
       <div class="deck-layout">
         <DrawStage
           {snapshot}

--- a/src/components/CharacterTabs.svelte
+++ b/src/components/CharacterTabs.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { CharacterSlotSnapshot } from "../state/deck-session.ts";
+
+  export let characters: CharacterSlotSnapshot[];
+  export let activeCharacterIndex = 0;
+  export let onSelect: (index: number) => void = () => {};
+</script>
+
+<nav class="character-tabs" aria-label="Characters" data-testid="character-tabs">
+  {#each characters as character}
+    <button
+      type="button"
+      class:active={character.index === activeCharacterIndex}
+      aria-current={character.index === activeCharacterIndex ? "page" : undefined}
+      data-testid={`character-slot-${character.index}`}
+      on:click={() => onSelect(character.index)}
+    >
+      <span>{character.name}</span>
+      <strong>{character.selectedClass.name}</strong>
+      {#if character.activePerks.length > 0}
+        <small>{character.activePerks.length} perks</small>
+      {/if}
+    </button>
+  {/each}
+</nav>

--- a/src/components/DrawStage.svelte
+++ b/src/components/DrawStage.svelte
@@ -56,6 +56,26 @@
     </button>
   </div>
 
+  <div class="reset-actions" aria-label="Reset and history controls">
+    <button
+      type="button"
+      data-testid="undo-action"
+      disabled={!snapshot.canUndo}
+      on:click={() => onAction("undo")}
+    >
+      Undo
+    </button>
+    <button type="button" data-testid="reset-scenario" on:click={() => onAction("resetScenario")}>
+      Reset scenario
+    </button>
+    <button type="button" data-testid="reset-base-deck" on:click={() => onAction("resetBaseDeck")}>
+      Reset base deck
+    </button>
+    <button type="button" data-testid="reset-character" on:click={() => onAction("resetCharacter")}>
+      Reset character
+    </button>
+  </div>
+
   {#if errorMessage}
     <p class="error" role="alert">{errorMessage}</p>
   {/if}

--- a/src/state/deck-session.ts
+++ b/src/state/deck-session.ts
@@ -10,7 +10,18 @@ import {
   type Perk,
 } from "../domain/index.ts";
 
+export interface CharacterSlotSnapshot {
+  index: number;
+  name: string;
+  selectedClassId: CharacterClassId;
+  selectedClass: CharacterClassOption;
+  stats: DeckStats;
+  activePerks: number[];
+}
+
 export interface DeckSessionSnapshot {
+  activeCharacterIndex: number;
+  characters: CharacterSlotSnapshot[];
   selectedClassId: CharacterClassId;
   selectedClass: CharacterClassOption;
   stats: DeckStats;
@@ -18,6 +29,7 @@ export interface DeckSessionSnapshot {
   discardPile: AttackModifierCard[];
   perks: Perk[];
   activePerks: number[];
+  canUndo: boolean;
 }
 
 export type DeckSessionAction =
@@ -26,82 +38,250 @@ export type DeckSessionAction =
   | "shuffle"
   | "bless"
   | "curse"
-  | "minusOne";
+  | "minusOne"
+  | "resetScenario"
+  | "resetBaseDeck"
+  | "resetCharacter"
+  | "undo";
 
 const classOptions = getCharacterClassOptions();
+const defaultCharacterCount = 4;
+const defaultClassId: CharacterClassId = "brute";
+
+interface SerializedCharacterState {
+  selectedClassId: CharacterClassId;
+  activePerks: number[];
+  drawPile: string[];
+  discardPile: string[];
+  modPile: string[];
+  globalModCards: string[];
+  lastDrawnCards: string[];
+  shuffleNeeded: boolean;
+}
+
+interface SerializedControllerState {
+  activeCharacterIndex: number;
+  characters: SerializedCharacterState[];
+}
 
 export class DeckSessionController {
   readonly classOptions: CharacterClassOption[];
-  private readonly session: GameSession;
-  private selectedClassId: CharacterClassId;
+  private readonly cardsByName: Map<string, AttackModifierCard>;
+  private readonly history: SerializedControllerState[];
+  private readonly sessions: GameSession[];
+  private activeCharacterIndex: number;
+  private selectedClassIds: CharacterClassId[];
 
-  constructor(data: AppData, selectedClassId: CharacterClassId = "brute") {
+  constructor(data: AppData, selectedClassId: CharacterClassId = defaultClassId, characterCount = defaultCharacterCount) {
     this.classOptions = classOptions;
-    this.session = createGameSession(data, { characterName: "modern-shell" });
-    this.selectedClassId = selectedClassId;
-    this.session.selectClassById(selectedClassId);
+    this.cardsByName = new Map(data.cards.map((card) => [card.name, card]));
+    this.history = [];
+    this.sessions = Array.from({ length: characterCount }, (_, index) =>
+      createGameSession(data, { characterName: `Character ${index + 1}` }),
+    );
+    this.activeCharacterIndex = 0;
+    this.selectedClassIds = this.sessions.map(() => selectedClassId);
+
+    for (const session of this.sessions) {
+      session.selectClassById(selectedClassId);
+    }
   }
 
   selectClass(classId: CharacterClassId): DeckSessionSnapshot {
-    this.selectedClassId = classId;
-    this.session.selectClassById(classId);
+    return this.withHistory(() => {
+      this.selectedClassIds[this.activeCharacterIndex] = classId;
+      this.activeSession.selectClassById(classId);
+    });
+  }
+
+  selectCharacter(index: number): DeckSessionSnapshot {
+    if (!this.sessions[index]) {
+      throw new Error(`Character index out of range: ${index}`);
+    }
+
+    this.activeCharacterIndex = index;
     return this.snapshot;
   }
 
   run(action: DeckSessionAction): DeckSessionSnapshot {
-    switch (action) {
-      case "draw":
-        this.session.drawCard();
-        break;
-      case "drawTwo":
-        this.session.drawCards(2);
-        break;
-      case "shuffle":
-        this.session.shuffle();
-        break;
-      case "bless":
-        this.session.addBless();
-        break;
-      case "curse":
-        this.session.addCurse();
-        break;
-      case "minusOne":
-        this.session.addMinusOne();
-        break;
+    if (action === "undo") {
+      return this.undo();
     }
 
-    return this.snapshot;
+    return this.withHistory(() => {
+      switch (action) {
+        case "draw":
+          this.activeSession.drawCard();
+          break;
+        case "drawTwo":
+          this.activeSession.drawCards(2);
+          break;
+        case "shuffle":
+          this.activeSession.shuffle();
+          break;
+        case "bless":
+          this.activeSession.addBless();
+          break;
+        case "curse":
+          this.activeSession.addCurse();
+          break;
+        case "minusOne":
+          this.activeSession.addMinusOne();
+          break;
+        case "resetScenario":
+          this.resetScenario();
+          break;
+        case "resetBaseDeck":
+          this.resetBaseDeck();
+          break;
+        case "resetCharacter":
+          this.resetCharacter();
+          break;
+      }
+    });
   }
 
   applyPerk(perkIndex: number): DeckSessionSnapshot {
-    this.session.applyPerk(perkIndex);
-    return this.snapshot;
+    return this.withHistory(() => {
+      this.activeSession.applyPerk(perkIndex);
+    });
   }
 
   togglePerk(perkIndex: number): DeckSessionSnapshot {
-    const nextPerks = this.session.character.activePerks.includes(perkIndex)
-      ? this.session.character.activePerks.filter((activePerk) => activePerk !== perkIndex)
-      : [...this.session.character.activePerks, perkIndex];
+    return this.withHistory(() => {
+      const nextPerks = this.activeSession.character.activePerks.includes(perkIndex)
+        ? this.activeSession.character.activePerks.filter((activePerk) => activePerk !== perkIndex)
+        : [...this.activeSession.character.activePerks, perkIndex];
 
-    this.session.setActivePerks(nextPerks);
-    return this.snapshot;
+      this.activeSession.setActivePerks(nextPerks);
+    });
   }
 
   get snapshot(): DeckSessionSnapshot {
-    const selectedClass = this.classOptions.find((option) => option.id === this.selectedClassId);
-
-    if (!selectedClass) {
-      throw new Error(`Unknown class id: ${this.selectedClassId}`);
-    }
+    const selectedClassId = this.selectedClassIds[this.activeCharacterIndex];
+    const selectedClass = this.getSelectedClass(selectedClassId);
+    const session = this.activeSession;
 
     return {
-      selectedClassId: this.selectedClassId,
+      activeCharacterIndex: this.activeCharacterIndex,
+      characters: this.sessions.map((characterSession, index) => {
+        const characterClassId = this.selectedClassIds[index];
+
+        return {
+          index,
+          name: characterSession.character.name,
+          selectedClassId: characterClassId,
+          selectedClass: this.getSelectedClass(characterClassId),
+          stats: characterSession.stats,
+          activePerks: [...characterSession.character.activePerks],
+        };
+      }),
+      selectedClassId,
       selectedClass,
-      stats: this.session.stats,
-      lastDrawnCards: [...this.session.lastDrawnCards],
-      discardPile: this.session.discardPile,
-      perks: this.session.character.sheet?.perks ?? [],
-      activePerks: [...this.session.character.activePerks],
+      stats: session.stats,
+      lastDrawnCards: [...session.lastDrawnCards],
+      discardPile: session.discardPile,
+      perks: session.character.sheet?.perks ?? [],
+      activePerks: [...session.character.activePerks],
+      canUndo: this.history.length > 0,
     };
+  }
+
+  private get activeSession(): GameSession {
+    return this.sessions[this.activeCharacterIndex];
+  }
+
+  private getSelectedClass(classId: CharacterClassId): CharacterClassOption {
+    const selectedClass = this.classOptions.find((option) => option.id === classId);
+
+    if (!selectedClass) {
+      throw new Error(`Unknown class id: ${classId}`);
+    }
+
+    return selectedClass;
+  }
+
+  private resetScenario(): void {
+    const activePerks = [...this.activeSession.character.activePerks];
+    this.activeSession.setActivePerks(activePerks);
+  }
+
+  private resetBaseDeck(): void {
+    const selectedClassId = this.selectedClassIds[this.activeCharacterIndex];
+    this.activeSession.selectClassById(selectedClassId);
+  }
+
+  private resetCharacter(): void {
+    this.selectedClassIds[this.activeCharacterIndex] = defaultClassId;
+    this.activeSession.selectClassById(defaultClassId);
+  }
+
+  private undo(): DeckSessionSnapshot {
+    const previousState = this.history.pop();
+
+    if (previousState) {
+      this.restore(previousState);
+    }
+
+    return this.snapshot;
+  }
+
+  private withHistory(action: () => void): DeckSessionSnapshot {
+    const previousState = this.serialize();
+
+    try {
+      action();
+      this.history.push(previousState);
+      return this.snapshot;
+    } catch (error) {
+      this.restore(previousState);
+      throw error;
+    }
+  }
+
+  private serialize(): SerializedControllerState {
+    return {
+      activeCharacterIndex: this.activeCharacterIndex,
+      characters: this.sessions.map((session, index) => ({
+        selectedClassId: this.selectedClassIds[index],
+        activePerks: [...session.character.activePerks],
+        drawPile: session.character.deck.drawPile.map((card) => card.name),
+        discardPile: session.character.deck.discardPile.map((card) => card.name),
+        modPile: session.character.deck.modPile.map((card) => card.name),
+        globalModCards: session.character.deck.globalModCards.map((card) => card.name),
+        lastDrawnCards: session.lastDrawnCards.map((card) => card.name),
+        shuffleNeeded: session.character.deck.shuffleNeeded,
+      })),
+    };
+  }
+
+  private restore(state: SerializedControllerState): void {
+    this.activeCharacterIndex = state.activeCharacterIndex;
+
+    state.characters.forEach((characterState, index) => {
+      const session = this.sessions[index];
+
+      this.selectedClassIds[index] = characterState.selectedClassId;
+      session.selectClassById(characterState.selectedClassId);
+      session.character.activePerks = [...characterState.activePerks];
+      session.character.deck.drawPile = this.resolveCards(characterState.drawPile);
+      session.character.deck.discardPile = this.resolveCards(characterState.discardPile);
+      session.character.deck.modPile = this.resolveCards(characterState.modPile);
+      session.character.deck.globalModCards = this.resolveCards(characterState.globalModCards);
+      session.character.deck.shuffleNeeded = characterState.shuffleNeeded;
+      session.lastDrawnCards = this.resolveCards(characterState.lastDrawnCards);
+    });
+  }
+
+  private resolveCards(cardNames: string[]): AttackModifierCard[] {
+    return cardNames.map((cardName) => {
+      const card = this.cardsByName.get(cardName);
+
+      if (!card) {
+        throw new Error(`Card not found while restoring session: ${cardName}`);
+      }
+
+      return card;
+    });
   }
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -55,6 +55,7 @@ button:disabled {
 }
 
 .topbar,
+.character-tabs,
 .deck-layout,
 .perks {
   background: rgb(255 252 244 / 94%);
@@ -69,6 +70,52 @@ button:disabled {
   gap: 1rem;
   padding: 20px;
   border-radius: 8px 8px 0 0;
+}
+
+.character-tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+  padding: 12px 20px;
+  border-top: 0;
+  box-shadow: 0 10px 26px rgb(30 24 18 / 8%);
+}
+
+.character-tabs button {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  justify-items: start;
+  gap: 0.2rem;
+  min-width: 0;
+  min-height: 70px;
+  padding: 0.65rem 0.75rem;
+  text-align: left;
+}
+
+.character-tabs button.active {
+  border-color: #2f5f63;
+  background: #e0f0ed;
+}
+
+.character-tabs span,
+.character-tabs strong,
+.character-tabs small {
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.character-tabs span,
+.character-tabs small {
+  color: #6d645c;
+  font-size: 0.78rem;
+  font-weight: 800;
+}
+
+.character-tabs strong {
+  text-transform: capitalize;
 }
 
 .eyebrow,
@@ -224,6 +271,20 @@ h2 {
   display: grid;
   grid-template-columns: 1.3fr repeat(5, minmax(70px, 1fr));
   gap: 0.6rem;
+}
+
+.reset-actions {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.6rem;
+}
+
+.reset-actions button {
+  min-height: 40px;
+  padding: 0.55rem 0.7rem;
+  border-color: rgb(58 48 41 / 32%);
+  background: #fffdf8;
+  font-weight: 700;
 }
 
 .actions .primary {
@@ -410,6 +471,10 @@ h2 {
     flex-direction: column;
   }
 
+  .character-tabs {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .deck-layout {
     grid-template-columns: 1fr;
   }
@@ -420,6 +485,10 @@ h2 {
   }
 
   .actions {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reset-actions {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/tests/e2e/modern-shell.spec.ts
+++ b/tests/e2e/modern-shell.spec.ts
@@ -81,6 +81,65 @@ test("adds scenario modifiers to the draw pile", async ({ page }) => {
   await expect(page.getByTestId("global-modifier-pile-count")).toHaveText("32");
 });
 
+test("undo restores the previous active character deck state", async ({ page }) => {
+  await expect(page.getByTestId("undo-action")).toBeDisabled();
+
+  await page.getByTestId("draw-card").click();
+
+  await expect(page.getByTestId("draw-pile-count")).toHaveText("19");
+  await expect(page.getByTestId("undo-action")).toBeEnabled();
+
+  await page.getByTestId("undo-action").click();
+
+  await expect(page.getByTestId("draw-pile-count")).toHaveText("20");
+  await expect(page.getByText("No cards discarded.")).toBeVisible();
+  await expect(page.getByTestId("undo-action")).toBeDisabled();
+});
+
+test("keeps separate state for multiple characters", async ({ page }) => {
+  await page.getByTestId("class-picker").selectOption("spellweaver");
+  await page.getByTestId("perk-0").getByRole("checkbox").check();
+
+  await page.getByTestId("character-slot-1").click();
+
+  await expect(
+    page.getByLabel("Draw controls and current card").getByText("brute", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("0 active")).toBeVisible();
+
+  await page.getByTestId("character-slot-0").click();
+
+  await expect(
+    page.getByLabel("Draw controls and current card").getByText("spellweaver", { exact: true }),
+  ).toBeVisible();
+  await expect(page.getByText("1 active")).toBeVisible();
+});
+
+test("resets scenario, base deck, and active character state", async ({ page }) => {
+  await page.getByTestId("perk-0").getByRole("checkbox").check();
+  await page.getByTestId("add-bless").click();
+  await page.getByTestId("draw-card").click();
+
+  await page.getByTestId("reset-scenario").click();
+
+  await expect(page.getByTestId("draw-pile-count")).toHaveText("18");
+  await expect(page.getByTestId("discard-pile-count")).toHaveText("0");
+  await expect(page.getByTestId("global-modifier-pile-count")).toHaveText("35");
+  await expect(page.getByText("1 active")).toBeVisible();
+
+  await page.getByTestId("reset-base-deck").click();
+
+  await expect(page.getByTestId("draw-pile-count")).toHaveText("20");
+  await expect(page.getByText("0 active")).toBeVisible();
+
+  await page.getByTestId("class-picker").selectOption("spellweaver");
+  await page.getByTestId("reset-character").click();
+
+  await expect(
+    page.getByLabel("Draw controls and current card").getByText("brute", { exact: true }),
+  ).toBeVisible();
+});
+
 test("toggles perks on and off", async ({ page }) => {
   const firstPerk = page.getByTestId("perk-0").getByRole("checkbox");
 

--- a/tests/state/deck-session.test.ts
+++ b/tests/state/deck-session.test.ts
@@ -6,10 +6,13 @@ import { loadAppData } from "../support/load-json-data.ts";
 test("controller creates a UI snapshot for the default class", () => {
   const controller = createController();
 
+  assert.equal(controller.snapshot.characters.length, 4);
+  assert.equal(controller.snapshot.activeCharacterIndex, 0);
   assert.equal(controller.snapshot.selectedClassId, "brute");
   assert.equal(controller.snapshot.selectedClass.name, "brute");
   assert.equal(controller.snapshot.stats.drawPile, 20);
   assert.equal(controller.snapshot.perks.length > 0, true);
+  assert.equal(controller.snapshot.canUndo, false);
 });
 
 test("controller updates snapshot after drawing and shuffling", () => {
@@ -49,6 +52,22 @@ test("controller exposes scenario modifier actions", () => {
   assert.equal(snapshot.stats.globalModifierPile, 32);
 });
 
+test("controller supports independent character slots", () => {
+  const controller = createController();
+
+  controller.selectClass("spellweaver");
+  controller.togglePerk(0);
+  const secondCharacter = controller.selectCharacter(1);
+
+  assert.equal(secondCharacter.selectedClassId, "brute");
+  assert.deepEqual(secondCharacter.activePerks, []);
+
+  const firstCharacter = controller.selectCharacter(0);
+
+  assert.equal(firstCharacter.selectedClassId, "spellweaver");
+  assert.deepEqual(firstCharacter.activePerks, [0]);
+});
+
 test("controller changes class and applies active perks", () => {
   const controller = createController();
 
@@ -75,6 +94,57 @@ test("controller toggles active perks on and off", () => {
 
   assert.deepEqual(disabled.activePerks, []);
   assert.equal(disabled.stats.drawPile, 20);
+});
+
+test("controller can undo the last mutating action", () => {
+  const controller = createController();
+
+  controller.run("draw");
+  assert.equal(controller.snapshot.stats.drawPile, 19);
+  assert.equal(controller.snapshot.canUndo, true);
+
+  const undone = controller.run("undo");
+
+  assert.equal(undone.stats.drawPile, 20);
+  assert.equal(undone.stats.discardPile, 0);
+  assert.equal(undone.lastDrawnCards.length, 0);
+  assert.equal(undone.canUndo, false);
+});
+
+test("controller resets scenario modifiers while preserving character perks", () => {
+  const controller = createController();
+
+  controller.togglePerk(0);
+  controller.run("bless");
+  controller.run("curse");
+  controller.run("draw");
+  const reset = controller.run("resetScenario");
+
+  assert.deepEqual(reset.activePerks, [0]);
+  assert.equal(reset.stats.drawPile, 18);
+  assert.equal(reset.stats.discardPile, 0);
+  assert.equal(reset.stats.globalModifierPile, 35);
+  assert.equal(reset.lastDrawnCards.length, 0);
+});
+
+test("controller resets the active base deck and active character", () => {
+  const controller = createController();
+
+  controller.togglePerk(0);
+  controller.run("bless");
+  const baseDeck = controller.run("resetBaseDeck");
+
+  assert.equal(baseDeck.selectedClassId, "brute");
+  assert.deepEqual(baseDeck.activePerks, []);
+  assert.equal(baseDeck.stats.drawPile, 20);
+  assert.equal(baseDeck.stats.globalModifierPile, 35);
+
+  controller.selectClass("spellweaver");
+  const character = controller.run("resetCharacter");
+
+  assert.equal(character.selectedClassId, "brute");
+  assert.deepEqual(character.activePerks, []);
+  assert.equal(character.stats.drawPile, 20);
 });
 
 function createController(): DeckSessionController {

--- a/to-do.md
+++ b/to-do.md
@@ -1,12 +1,11 @@
 # to-do
 
--Add global undo functionality
--Add support for multiple characters
--Add "Reset Button"
---Scenario
---Base Deck
---Character
--Add auto removal of curse and bless cards when drawn
--Add a value attribute to all attack modifier cards
--Add a conditions array attribute to all attack modifier cards
--
+- [x] Add global undo functionality
+- [x] Add support for multiple characters
+- [x] Add reset buttons
+  - [x] Scenario
+  - [x] Base deck
+  - [x] Character
+- [x] Add auto removal of curse and bless cards when drawn
+- [ ] Add a value attribute to all attack modifier cards
+- [ ] Add a conditions array attribute to all attack modifier cards


### PR DESCRIPTION
## Summary

- Add four independent character slots for class, perk, deck, discard, and scenario modifier state.
- Add global undo for the latest mutating session action.
- Add reset controls for scenario state, active base deck, and the active character slot.
- Update modernization/to-do tracking and expand unit and Playwright coverage.

## Validation

- `npm test`
- `npm run build`
- `npm run test:e2e`
- Local browser smoke check at `http://127.0.0.1:5174/`