### PR TITLE
[codex] Normalize catalog data and attack modifier metadata

### DIFF
--- a/MODERNIZATION.md
+++ b/MODERNIZATION.md
@@ -72,7 +72,7 @@ Acceptance criteria:
 
 ### Phase 3: Data Normalization
 
-Status: Complete for the current modern deck workflow.
+Status: Complete for the current modern deck workflow and normalized catalog imports.
 
 Goals:
 
@@ -91,15 +91,13 @@ Completed so far:
 - Added cross-data validation so class metadata, character perk sheets, and class attack modifier card prefixes stay in sync.
 - Documented the modern/legacy data boundary in `src/data/README.md`.
 - Added parity tests to keep the modern JSON files in sync with the legacy JSON-shaped `.js` files while both app entrypoints exist.
-
-Remaining deferred work:
-
-- Broader non-deck datasets such as items, events, monsters, ability cards, and map assets can be normalized when the modern UI starts consuming them.
+- Filled attack modifier `value` and `conditions` metadata for every normalized attack modifier card, including a corrected `am-p-17` `-2` value.
+- Added canonical JSON copies, typed imports, and shape/image-path validation for broader catalog datasets: items, events, monster cards, ability cards, map tiles, and world map assets.
 
 Acceptance criteria:
 
 - Domain/session initialization uses typed data imports. Complete for deck workflow.
-- Tests validate data shape and key cross-references. Complete for deck workflow.
+- Tests validate data shape and key cross-references. Complete for deck workflow and broader catalog data.
 - Legacy data consumers are either migrated or explicitly preserved. Complete; legacy `.js` data files are preserved and parity-tested.
 
 ### Phase 4: Component Rewrite

--- a/data/attack-modifiers.js
+++ b/data/attack-modifiers.js
@@ -3,180 +3,240 @@
     "name": "am-m-01",
     "points": 0,
     "image": "attack-modifiers/base/monster/am-m-01.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm01"
   },
   {
     "name": "am-m-02",
     "points": 1,
     "image": "attack-modifiers/base/monster/am-m-02.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm02"
   },
   {
     "name": "am-m-03",
     "points": 2,
     "image": "attack-modifiers/base/monster/am-m-03.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm03"
   },
   {
     "name": "am-m-04",
     "points": 3,
     "image": "attack-modifiers/base/monster/am-m-04.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm04"
   },
   {
     "name": "am-m-05",
     "points": 4,
     "image": "attack-modifiers/base/monster/am-m-05.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm05"
   },
   {
     "name": "am-m-06",
     "points": 5,
     "image": "attack-modifiers/base/monster/am-m-06.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm06"
   },
   {
     "name": "am-m-07",
     "points": 6,
     "image": "attack-modifiers/base/monster/am-m-07.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm07"
   },
   {
     "name": "am-m-08",
     "points": 7,
     "image": "attack-modifiers/base/monster/am-m-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm08"
   },
   {
     "name": "am-m-09",
     "points": 8,
     "image": "attack-modifiers/base/monster/am-m-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm09"
   },
   {
     "name": "am-m-10",
     "points": 9,
     "image": "attack-modifiers/base/monster/am-m-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm10"
   },
   {
     "name": "am-m-11",
     "points": 10,
     "image": "attack-modifiers/base/monster/am-m-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm11"
   },
   {
     "name": "am-m-12",
     "points": 11,
     "image": "attack-modifiers/base/monster/am-m-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm12"
   },
   {
     "name": "am-m-13",
     "points": 12,
     "image": "attack-modifiers/base/monster/am-m-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm13"
   },
   {
     "name": "am-m-14",
     "points": 13,
     "image": "attack-modifiers/base/monster/am-m-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm14"
   },
   {
     "name": "am-m-15",
     "points": 14,
     "image": "attack-modifiers/base/monster/am-m-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm15"
   },
   {
     "name": "am-m-16",
     "points": 15,
     "image": "attack-modifiers/base/monster/am-m-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm16"
   },
   {
     "name": "am-m-17",
     "points": 16,
     "image": "attack-modifiers/base/monster/am-m-17.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amm17"
   },
   {
     "name": "am-m-18",
     "points": 17,
     "image": "attack-modifiers/base/monster/am-m-18.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amm18"
   },
   {
     "name": "am-m-19",
     "points": 18,
     "image": "attack-modifiers/base/monster/am-m-19.png",
+    "value": "miss",
+    "conditions": [],
     "xws": "amm19"
   },
   {
     "name": "am-m-20",
     "points": 19,
     "image": "attack-modifiers/base/monster/am-m-20.png",
+    "value": "x2",
+    "conditions": [],
     "xws": "amm20"
   },
   {
     "name": "am-mm-01",
     "points": 20,
     "image": "attack-modifiers/base/monster-mod/am-mm-01.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm01"
   },
   {
     "name": "am-mm-02",
     "points": 21,
     "image": "attack-modifiers/base/monster-mod/am-mm-02.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm02"
   },
   {
     "name": "am-mm-03",
     "points": 22,
     "image": "attack-modifiers/base/monster-mod/am-mm-03.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm03"
   },
   {
     "name": "am-mm-04",
     "points": 23,
     "image": "attack-modifiers/base/monster-mod/am-mm-04.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm04"
   },
   {
     "name": "am-mm-05",
     "points": 24,
     "image": "attack-modifiers/base/monster-mod/am-mm-05.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm05"
   },
   {
     "name": "am-mm-06",
     "points": 25,
     "image": "attack-modifiers/base/monster-mod/am-mm-06.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm06"
   },
   {
     "name": "am-mm-07",
     "points": 26,
     "image": "attack-modifiers/base/monster-mod/am-mm-07.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm07"
   },
   {
     "name": "am-mm-08",
     "points": 27,
     "image": "attack-modifiers/base/monster-mod/am-mm-08.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm08"
   },
   {
     "name": "am-mm-09",
     "points": 28,
     "image": "attack-modifiers/base/monster-mod/am-mm-09.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm09"
   },
   {
     "name": "am-mm-10",
     "points": 29,
     "image": "attack-modifiers/base/monster-mod/am-mm-10.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm10"
   },
   {
@@ -184,6 +244,7 @@
     "points": 30,
     "image": "attack-modifiers/base/player/am-p-01.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp01"
   },
   {
@@ -191,6 +252,7 @@
     "points": 31,
     "image": "attack-modifiers/base/player/am-p-02.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp02"
   },
   {
@@ -198,6 +260,7 @@
     "points": 32,
     "image": "attack-modifiers/base/player/am-p-03.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp03"
   },
   {
@@ -205,6 +268,7 @@
     "points": 33,
     "image": "attack-modifiers/base/player/am-p-04.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp04"
   },
   {
@@ -212,6 +276,7 @@
     "points": 34,
     "image": "attack-modifiers/base/player/am-p-05.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp05"
   },
   {
@@ -219,6 +284,7 @@
     "points": 35,
     "image": "attack-modifiers/base/player/am-p-06.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp06"
   },
   {
@@ -226,6 +292,7 @@
     "points": 36,
     "image": "attack-modifiers/base/player/am-p-07.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp07"
   },
   {
@@ -233,6 +300,7 @@
     "points": 37,
     "image": "attack-modifiers/base/player/am-p-08.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp08"
   },
   {
@@ -240,6 +308,7 @@
     "points": 38,
     "image": "attack-modifiers/base/player/am-p-09.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp09"
   },
   {
@@ -247,6 +316,7 @@
     "points": 39,
     "image": "attack-modifiers/base/player/am-p-10.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp10"
   },
   {
@@ -254,6 +324,7 @@
     "points": 40,
     "image": "attack-modifiers/base/player/am-p-11.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp11"
   },
   {
@@ -261,6 +332,7 @@
     "points": 41,
     "image": "attack-modifiers/base/player/am-p-12.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp12"
   },
   {
@@ -268,6 +340,7 @@
     "points": 42,
     "image": "attack-modifiers/base/player/am-p-13.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp13"
   },
   {
@@ -275,6 +348,7 @@
     "points": 43,
     "image": "attack-modifiers/base/player/am-p-14.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp14"
   },
   {
@@ -282,6 +356,7 @@
     "points": 44,
     "image": "attack-modifiers/base/player/am-p-15.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp15"
   },
   {
@@ -289,13 +364,15 @@
     "points": 45,
     "image": "attack-modifiers/base/player/am-p-16.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp16"
   },
   {
     "name": "am-p-17",
     "points": 46,
     "image": "attack-modifiers/base/player/am-p-17.png",
-    "value": -1,
+    "value": -2,
+    "conditions": [],
     "xws": "amp17"
   },
   {
@@ -303,6 +380,7 @@
     "points": 47,
     "image": "attack-modifiers/base/player/am-p-18.png",
     "value": 2,
+    "conditions": [],
     "xws": "amp18"
   },
   {
@@ -310,6 +388,7 @@
     "points": 48,
     "image": "attack-modifiers/base/player/am-p-19.png",
     "value": "miss",
+    "conditions": [],
     "xws": "amp19"
   },
   {
@@ -317,6 +396,7 @@
     "points": 49,
     "image": "attack-modifiers/base/player/am-p-20.png",
     "value": "x2",
+    "conditions": [],
     "xws": "amp20"
   },
   {
@@ -324,6 +404,7 @@
     "points": 50,
     "image": "attack-modifiers/base/player-mod/am-pm-01.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm01"
   },
   {
@@ -331,6 +412,7 @@
     "points": 51,
     "image": "attack-modifiers/base/player-mod/am-pm-02.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm02"
   },
   {
@@ -338,6 +420,7 @@
     "points": 52,
     "image": "attack-modifiers/base/player-mod/am-pm-03.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm03"
   },
   {
@@ -345,6 +428,7 @@
     "points": 53,
     "image": "attack-modifiers/base/player-mod/am-pm-04.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm04"
   },
   {
@@ -352,6 +436,7 @@
     "points": 54,
     "image": "attack-modifiers/base/player-mod/am-pm-05.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm05"
   },
   {
@@ -359,6 +444,7 @@
     "points": 55,
     "image": "attack-modifiers/base/player-mod/am-pm-06.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm06"
   },
   {
@@ -366,6 +452,7 @@
     "points": 56,
     "image": "attack-modifiers/base/player-mod/am-pm-07.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm07"
   },
   {
@@ -373,6 +460,7 @@
     "points": 57,
     "image": "attack-modifiers/base/player-mod/am-pm-08.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm08"
   },
   {
@@ -380,6 +468,7 @@
     "points": 58,
     "image": "attack-modifiers/base/player-mod/am-pm-09.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm09"
   },
   {
@@ -387,6 +476,7 @@
     "points": 59,
     "image": "attack-modifiers/base/player-mod/am-pm-10.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm10"
   },
   {
@@ -394,6 +484,7 @@
     "points": 60,
     "image": "attack-modifiers/base/player-mod/am-pm-11.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm11"
   },
   {
@@ -401,6 +492,7 @@
     "points": 61,
     "image": "attack-modifiers/base/player-mod/am-pm-12.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm12"
   },
   {
@@ -408,6 +500,7 @@
     "points": 62,
     "image": "attack-modifiers/base/player-mod/am-pm-13.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm13"
   },
   {
@@ -415,6 +508,7 @@
     "points": 63,
     "image": "attack-modifiers/base/player-mod/am-pm-14.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm14"
   },
   {
@@ -422,6 +516,7 @@
     "points": 64,
     "image": "attack-modifiers/base/player-mod/am-pm-15.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm15"
   },
   {
@@ -429,6 +524,7 @@
     "points": 65,
     "image": "attack-modifiers/base/player-mod/am-pm-16.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm16"
   },
   {
@@ -436,6 +532,7 @@
     "points": 66,
     "image": "attack-modifiers/base/player-mod/am-pm-17.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm17"
   },
   {
@@ -443,6 +540,7 @@
     "points": 67,
     "image": "attack-modifiers/base/player-mod/am-pm-18.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm18"
   },
   {
@@ -450,6 +548,7 @@
     "points": 68,
     "image": "attack-modifiers/base/player-mod/am-pm-19.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm19"
   },
   {
@@ -457,6 +556,7 @@
     "points": 69,
     "image": "attack-modifiers/base/player-mod/am-pm-20.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm20"
   },
   {
@@ -464,6 +564,7 @@
     "points": 70,
     "image": "attack-modifiers/base/player-mod/am-pm-21.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm21"
   },
   {
@@ -471,6 +572,7 @@
     "points": 71,
     "image": "attack-modifiers/base/player-mod/am-pm-22.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm22"
   },
   {
@@ -478,6 +580,7 @@
     "points": 72,
     "image": "attack-modifiers/base/player-mod/am-pm-23.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm23"
   },
   {
@@ -485,6 +588,7 @@
     "points": 73,
     "image": "attack-modifiers/base/player-mod/am-pm-24.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm24"
   },
   {
@@ -492,6 +596,7 @@
     "points": 74,
     "image": "attack-modifiers/base/player-mod/am-pm-25.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm25"
   },
   {
@@ -499,6 +604,7 @@
     "points": 75,
     "image": "attack-modifiers/base/player-mod/am-pm-26.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm26"
   },
   {
@@ -506,6 +612,7 @@
     "points": 76,
     "image": "attack-modifiers/base/player-mod/am-pm-27.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm27"
   },
   {
@@ -513,6 +620,7 @@
     "points": 77,
     "image": "attack-modifiers/base/player-mod/am-pm-28.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm28"
   },
   {
@@ -520,6 +628,7 @@
     "points": 78,
     "image": "attack-modifiers/base/player-mod/am-pm-29.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm29"
   },
   {
@@ -527,6 +636,7 @@
     "points": 79,
     "image": "attack-modifiers/base/player-mod/am-pm-30.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm30"
   },
   {
@@ -534,6 +644,7 @@
     "points": 80,
     "image": "attack-modifiers/base/player-mod/am-pm-31.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm31"
   },
   {
@@ -541,6 +652,7 @@
     "points": 81,
     "image": "attack-modifiers/base/player-mod/am-pm-32.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm32"
   },
   {
@@ -548,6 +660,7 @@
     "points": 82,
     "image": "attack-modifiers/base/player-mod/am-pm-33.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm33"
   },
   {
@@ -555,6 +668,7 @@
     "points": 83,
     "image": "attack-modifiers/base/player-mod/am-pm-34.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm34"
   },
   {
@@ -562,2058 +676,2991 @@
     "points": 84,
     "image": "attack-modifiers/base/player-mod/am-pm-35.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm35"
   },
   {
     "name": "am-be-01",
     "points": 85,
     "image": "attack-modifiers/BE/am-be-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe01"
   },
   {
     "name": "am-be-02",
     "points": 86,
     "image": "attack-modifiers/BE/am-be-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe02"
   },
   {
     "name": "am-be-03",
     "points": 87,
     "image": "attack-modifiers/BE/am-be-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe03"
   },
   {
     "name": "am-be-04",
     "points": 88,
     "image": "attack-modifiers/BE/am-be-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe04"
   },
   {
     "name": "am-be-05",
     "points": 89,
     "image": "attack-modifiers/BE/am-be-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe05"
   },
   {
     "name": "am-be-06",
     "points": 90,
     "image": "attack-modifiers/BE/am-be-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe06"
   },
   {
     "name": "am-be-07",
     "points": 91,
     "image": "attack-modifiers/BE/am-be-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe07"
   },
   {
     "name": "am-be-08",
     "points": 92,
     "image": "attack-modifiers/BE/am-be-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe08"
   },
   {
     "name": "am-be-09",
     "points": 93,
     "image": "attack-modifiers/BE/am-be-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe09"
   },
   {
     "name": "am-be-10",
     "points": 94,
     "image": "attack-modifiers/BE/am-be-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe10"
   },
   {
     "name": "am-be-11",
     "points": 95,
     "image": "attack-modifiers/BE/am-be-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe11"
   },
   {
     "name": "am-be-12",
     "points": 96,
     "image": "attack-modifiers/BE/am-be-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe12"
   },
   {
     "name": "am-be-13",
     "points": 97,
     "image": "attack-modifiers/BE/am-be-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe13"
   },
   {
     "name": "am-be-14",
     "points": 98,
     "image": "attack-modifiers/BE/am-be-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe14"
   },
   {
     "name": "am-be-15",
     "points": 99,
     "image": "attack-modifiers/BE/am-be-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe15"
   },
   {
     "name": "am-br-01",
     "points": 100,
     "image": "attack-modifiers/BR/am-br-01.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr01"
   },
   {
     "name": "am-br-02",
     "points": 101,
     "image": "attack-modifiers/BR/am-br-02.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr02"
   },
   {
     "name": "am-br-03",
     "points": 102,
     "image": "attack-modifiers/BR/am-br-03.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr03"
   },
   {
     "name": "am-br-04",
     "points": 103,
     "image": "attack-modifiers/BR/am-br-04.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr04"
   },
   {
     "name": "am-br-05",
     "points": 104,
     "image": "attack-modifiers/BR/am-br-05.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr05"
   },
   {
     "name": "am-br-06",
     "points": 105,
     "image": "attack-modifiers/BR/am-br-06.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr06"
   },
   {
     "name": "am-br-07",
     "points": 106,
     "image": "attack-modifiers/BR/am-br-07.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr07"
   },
   {
     "name": "am-br-08",
     "points": 107,
     "image": "attack-modifiers/BR/am-br-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr08"
   },
   {
     "name": "am-br-09",
     "points": 108,
     "image": "attack-modifiers/BR/am-br-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr09"
   },
   {
     "name": "am-br-10",
     "points": 109,
     "image": "attack-modifiers/BR/am-br-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr10"
   },
   {
     "name": "am-br-11",
     "points": 110,
     "image": "attack-modifiers/BR/am-br-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr11"
   },
   {
     "name": "am-br-12",
     "points": 111,
     "image": "attack-modifiers/BR/am-br-12.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr12"
   },
   {
     "name": "am-br-13",
     "points": 112,
     "image": "attack-modifiers/BR/am-br-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambr13"
   },
   {
     "name": "am-br-14",
     "points": 113,
     "image": "attack-modifiers/BR/am-br-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr14"
   },
   {
     "name": "am-br-15",
     "points": 114,
     "image": "attack-modifiers/BR/am-br-15.png",
+    "value": 3,
+    "conditions": [],
     "xws": "ambr15"
   },
   {
     "name": "am-br-16",
     "points": 115,
     "image": "attack-modifiers/BR/am-br-16.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr16"
   },
   {
     "name": "am-br-17",
     "points": 116,
     "image": "attack-modifiers/BR/am-br-17.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr17"
   },
   {
     "name": "am-br-18",
     "points": 117,
     "image": "attack-modifiers/BR/am-br-18.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr18"
   },
   {
     "name": "am-br-19",
     "points": 118,
     "image": "attack-modifiers/BR/am-br-19.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr19"
   },
   {
     "name": "am-br-20",
     "points": 119,
     "image": "attack-modifiers/BR/am-br-20.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr20"
   },
   {
     "name": "am-br-21",
     "points": 120,
     "image": "attack-modifiers/BR/am-br-21.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr21"
   },
   {
     "name": "am-br-22",
     "points": 121,
     "image": "attack-modifiers/BR/am-br-22.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr22"
   },
   {
     "name": "am-bs-01",
     "points": 122,
     "image": "attack-modifiers/BS/am-bs-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs01"
   },
   {
     "name": "am-bs-02",
     "points": 123,
     "image": "attack-modifiers/BS/am-bs-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs02"
   },
   {
     "name": "am-bs-03",
     "points": 124,
     "image": "attack-modifiers/BS/am-bs-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs03"
   },
   {
     "name": "am-bs-04",
     "points": 125,
     "image": "attack-modifiers/BS/am-bs-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs04"
   },
   {
     "name": "am-bs-05",
     "points": 126,
     "image": "attack-modifiers/BS/am-bs-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs05"
   },
   {
     "name": "am-bs-06",
     "points": 127,
     "image": "attack-modifiers/BS/am-bs-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs06"
   },
   {
     "name": "am-bs-07",
     "points": 128,
     "image": "attack-modifiers/BS/am-bs-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs07"
   },
   {
     "name": "am-bs-08",
     "points": 129,
     "image": "attack-modifiers/BS/am-bs-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs08"
   },
   {
     "name": "am-bs-09",
     "points": 130,
     "image": "attack-modifiers/BS/am-bs-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs09"
   },
   {
     "name": "am-bs-10",
     "points": 131,
     "image": "attack-modifiers/BS/am-bs-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs10"
   },
   {
     "name": "am-bs-11",
     "points": 132,
     "image": "attack-modifiers/BS/am-bs-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs11"
   },
   {
     "name": "am-bs-12",
     "points": 133,
     "image": "attack-modifiers/BS/am-bs-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs12"
   },
   {
     "name": "am-bs-13",
     "points": 134,
     "image": "attack-modifiers/BS/am-bs-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs13"
   },
   {
     "name": "am-bs-14",
     "points": 135,
     "image": "attack-modifiers/BS/am-bs-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs14"
   },
   {
     "name": "am-bs-15",
     "points": 136,
     "image": "attack-modifiers/BS/am-bs-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs15"
   },
   {
     "name": "am-bt-01",
     "points": 137,
     "image": "attack-modifiers/BT/am-bt-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt01"
   },
   {
     "name": "am-bt-02",
     "points": 138,
     "image": "attack-modifiers/BT/am-bt-02.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt02"
   },
   {
     "name": "am-bt-03",
     "points": 139,
     "image": "attack-modifiers/BT/am-bt-03.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt03"
   },
   {
     "name": "am-bt-04",
     "points": 140,
     "image": "attack-modifiers/BT/am-bt-04.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt04"
   },
   {
     "name": "am-bt-05",
     "points": 141,
     "image": "attack-modifiers/BT/am-bt-05.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt05"
   },
   {
     "name": "am-bt-06",
     "points": 142,
     "image": "attack-modifiers/BT/am-bt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt06"
   },
   {
     "name": "am-bt-07",
     "points": 143,
     "image": "attack-modifiers/BT/am-bt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt07"
   },
   {
     "name": "am-bt-08",
     "points": 144,
     "image": "attack-modifiers/BT/am-bt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt08"
   },
   {
     "name": "am-bt-09",
     "points": 145,
     "image": "attack-modifiers/BT/am-bt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt09"
   },
   {
     "name": "am-bt-10",
     "points": 146,
     "image": "attack-modifiers/BT/am-bt-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt10"
   },
   {
     "name": "am-bt-11",
     "points": 147,
     "image": "attack-modifiers/BT/am-bt-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt11"
   },
   {
     "name": "am-bt-12",
     "points": 148,
     "image": "attack-modifiers/BT/am-bt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt12"
   },
   {
     "name": "am-bt-13",
     "points": 149,
     "image": "attack-modifiers/BT/am-bt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt13"
   },
   {
     "name": "am-bt-14",
     "points": 150,
     "image": "attack-modifiers/BT/am-bt-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt14"
   },
   {
     "name": "am-bt-15",
     "points": 151,
     "image": "attack-modifiers/BT/am-bt-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt15"
   },
   {
     "name": "am-bt-16",
     "points": 152,
     "image": "attack-modifiers/BT/am-bt-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt16"
   },
   {
     "name": "am-bt-17",
     "points": 153,
     "image": "attack-modifiers/BT/am-bt-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt17"
   },
   {
     "name": "am-ch-01",
     "points": 154,
     "image": "attack-modifiers/CH/am-ch-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch01"
   },
   {
     "name": "am-ch-02",
     "points": 155,
     "image": "attack-modifiers/CH/am-ch-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch02"
   },
   {
     "name": "am-ch-03",
     "points": 156,
     "image": "attack-modifiers/CH/am-ch-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch03"
   },
   {
     "name": "am-ch-04",
     "points": 157,
     "image": "attack-modifiers/CH/am-ch-04.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amch04"
   },
   {
     "name": "am-ch-05",
     "points": 158,
     "image": "attack-modifiers/CH/am-ch-05.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch05"
   },
   {
     "name": "am-ch-06",
     "points": 159,
     "image": "attack-modifiers/CH/am-ch-06.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch06"
   },
   {
     "name": "am-ch-07",
     "points": 160,
     "image": "attack-modifiers/CH/am-ch-07.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch07"
   },
   {
     "name": "am-ch-08",
     "points": 161,
     "image": "attack-modifiers/CH/am-ch-08.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch08"
   },
   {
     "name": "am-ch-09",
     "points": 162,
     "image": "attack-modifiers/CH/am-ch-09.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch09"
   },
   {
     "name": "am-ch-10",
     "points": 163,
     "image": "attack-modifiers/CH/am-ch-10.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch10"
   },
   {
     "name": "am-ch-11",
     "points": 164,
     "image": "attack-modifiers/CH/am-ch-11.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch11"
   },
   {
     "name": "am-ch-12",
     "points": 165,
     "image": "attack-modifiers/CH/am-ch-12.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch12"
   },
   {
     "name": "am-ch-13",
     "points": 166,
     "image": "attack-modifiers/CH/am-ch-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch13"
   },
   {
     "name": "am-ch-14",
     "points": 167,
     "image": "attack-modifiers/CH/am-ch-14.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch14"
   },
   {
     "name": "am-ch-15",
     "points": 168,
     "image": "attack-modifiers/CH/am-ch-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch15"
   },
   {
     "name": "am-ch-16",
     "points": 169,
     "image": "attack-modifiers/CH/am-ch-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch16"
   },
   {
     "name": "am-ch-17",
     "points": 170,
     "image": "attack-modifiers/CH/am-ch-17.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch17"
   },
   {
     "name": "am-ch-18",
     "points": 171,
     "image": "attack-modifiers/CH/am-ch-18.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch18"
   },
   {
     "name": "am-ds-01",
     "points": 172,
     "image": "attack-modifiers/DS/am-ds-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds01"
   },
   {
     "name": "am-ds-02",
     "points": 173,
     "image": "attack-modifiers/DS/am-ds-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds02"
   },
   {
     "name": "am-ds-03",
     "points": 174,
     "image": "attack-modifiers/DS/am-ds-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds03"
   },
   {
     "name": "am-ds-04",
     "points": 175,
     "image": "attack-modifiers/DS/am-ds-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds04"
   },
   {
     "name": "am-ds-05",
     "points": 176,
     "image": "attack-modifiers/DS/am-ds-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds05"
   },
   {
     "name": "am-ds-06",
     "points": 177,
     "image": "attack-modifiers/DS/am-ds-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds06"
   },
   {
     "name": "am-ds-07",
     "points": 178,
     "image": "attack-modifiers/DS/am-ds-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds07"
   },
   {
     "name": "am-ds-08",
     "points": 179,
     "image": "attack-modifiers/DS/am-ds-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds08"
   },
   {
     "name": "am-ds-09",
     "points": 180,
     "image": "attack-modifiers/DS/am-ds-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds09"
   },
   {
     "name": "am-ds-10",
     "points": 181,
     "image": "attack-modifiers/DS/am-ds-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds10"
   },
   {
     "name": "am-ds-11",
     "points": 182,
     "image": "attack-modifiers/DS/am-ds-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds11"
   },
   {
     "name": "am-ds-12",
     "points": 183,
     "image": "attack-modifiers/DS/am-ds-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds12"
   },
   {
     "name": "am-ds-13",
     "points": 184,
     "image": "attack-modifiers/DS/am-ds-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds13"
   },
   {
     "name": "am-ds-14",
     "points": 185,
     "image": "attack-modifiers/DS/am-ds-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds14"
   },
   {
     "name": "am-ds-15",
     "points": 186,
     "image": "attack-modifiers/DS/am-ds-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds15"
   },
   {
     "name": "am-ds-16",
     "points": 187,
     "image": "attack-modifiers/DS/am-ds-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds16"
   },
   {
     "name": "am-ds-17",
     "points": 188,
     "image": "attack-modifiers/DS/am-ds-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds17"
   },
   {
     "name": "am-el-01",
     "points": 189,
     "image": "attack-modifiers/EL/am-el-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel01"
   },
   {
     "name": "am-el-02",
     "points": 190,
     "image": "attack-modifiers/EL/am-el-02.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel02"
   },
   {
     "name": "am-el-03",
     "points": 191,
     "image": "attack-modifiers/EL/am-el-03.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel03"
   },
   {
     "name": "am-el-04",
     "points": 192,
     "image": "attack-modifiers/EL/am-el-04.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel04"
   },
   {
     "name": "am-el-05",
     "points": 193,
     "image": "attack-modifiers/EL/am-el-05.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel05"
   },
   {
     "name": "am-el-06",
     "points": 194,
     "image": "attack-modifiers/EL/am-el-06.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel06"
   },
   {
     "name": "am-el-07",
     "points": 195,
     "image": "attack-modifiers/EL/am-el-07.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel07"
   },
   {
     "name": "am-el-08",
     "points": 196,
     "image": "attack-modifiers/EL/am-el-08.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel08"
   },
   {
     "name": "am-el-09",
     "points": 197,
     "image": "attack-modifiers/EL/am-el-09.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel09"
   },
   {
     "name": "am-el-10",
     "points": 198,
     "image": "attack-modifiers/EL/am-el-10.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel10"
   },
   {
     "name": "am-el-11",
     "points": 199,
     "image": "attack-modifiers/EL/am-el-11.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel11"
   },
   {
     "name": "am-el-12",
     "points": 200,
     "image": "attack-modifiers/EL/am-el-12.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel12"
   },
   {
     "name": "am-el-13",
     "points": 201,
     "image": "attack-modifiers/EL/am-el-13.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel13"
   },
   {
     "name": "am-el-14",
     "points": 202,
     "image": "attack-modifiers/EL/am-el-14.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel14"
   },
   {
     "name": "am-el-15",
     "points": 203,
     "image": "attack-modifiers/EL/am-el-15.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel15"
   },
   {
     "name": "am-el-16",
     "points": 204,
     "image": "attack-modifiers/EL/am-el-16.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel16"
   },
   {
     "name": "am-el-17",
     "points": 205,
     "image": "attack-modifiers/EL/am-el-17.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel17"
   },
   {
     "name": "am-el-18",
     "points": 206,
     "image": "attack-modifiers/EL/am-el-18.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel18"
   },
   {
     "name": "am-el-19",
     "points": 207,
     "image": "attack-modifiers/EL/am-el-19.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel19"
   },
   {
     "name": "am-el-20",
     "points": 208,
     "image": "attack-modifiers/EL/am-el-20.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amel20"
   },
   {
     "name": "am-el-21",
     "points": 209,
     "image": "attack-modifiers/EL/am-el-21.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amel21"
   },
   {
     "name": "am-el-22",
     "points": 210,
     "image": "attack-modifiers/EL/am-el-22.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amel22"
   },
   {
     "name": "am-el-23",
     "points": 211,
     "image": "attack-modifiers/EL/am-el-23.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel23"
   },
   {
     "name": "am-el-24",
     "points": 212,
     "image": "attack-modifiers/EL/am-el-24.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel24"
   },
   {
     "name": "am-mt-01",
     "points": 213,
     "image": "attack-modifiers/MT/am-mt-01.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ammt01"
   },
   {
     "name": "am-mt-02",
     "points": 214,
     "image": "attack-modifiers/MT/am-mt-02.png",
+    "value": 2,
+    "conditions": [],
     "xws": "ammt02"
   },
   {
     "name": "am-mt-03",
     "points": 215,
     "image": "attack-modifiers/MT/am-mt-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ammt03"
   },
   {
     "name": "am-mt-04",
     "points": 216,
     "image": "attack-modifiers/MT/am-mt-04.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt04"
   },
   {
     "name": "am-mt-05",
     "points": 217,
     "image": "attack-modifiers/MT/am-mt-05.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt05"
   },
   {
     "name": "am-mt-06",
     "points": 218,
     "image": "attack-modifiers/MT/am-mt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt06"
   },
   {
     "name": "am-mt-07",
     "points": 219,
     "image": "attack-modifiers/MT/am-mt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt07"
   },
   {
     "name": "am-mt-08",
     "points": 220,
     "image": "attack-modifiers/MT/am-mt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt08"
   },
   {
     "name": "am-mt-09",
     "points": 221,
     "image": "attack-modifiers/MT/am-mt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt09"
   },
   {
     "name": "am-mt-10",
     "points": 222,
     "image": "attack-modifiers/MT/am-mt-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt10"
   },
   {
     "name": "am-mt-11",
     "points": 223,
     "image": "attack-modifiers/MT/am-mt-11.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt11"
   },
   {
     "name": "am-mt-12",
     "points": 224,
     "image": "attack-modifiers/MT/am-mt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt12"
   },
   {
     "name": "am-mt-13",
     "points": 225,
     "image": "attack-modifiers/MT/am-mt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt13"
   },
   {
     "name": "am-mt-14",
     "points": 226,
     "image": "attack-modifiers/MT/am-mt-14.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt14"
   },
   {
     "name": "am-mt-15",
     "points": 227,
     "image": "attack-modifiers/MT/am-mt-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt15"
   },
   {
     "name": "am-mt-16",
     "points": 228,
     "image": "attack-modifiers/MT/am-mt-16.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt16"
   },
   {
     "name": "am-mt-17",
     "points": 229,
     "image": "attack-modifiers/MT/am-mt-17.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt17"
   },
   {
     "name": "am-mt-18",
     "points": 230,
     "image": "attack-modifiers/MT/am-mt-18.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt18"
   },
   {
     "name": "am-mt-19",
     "points": 231,
     "image": "attack-modifiers/MT/am-mt-19.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ammt19"
   },
   {
     "name": "am-mt-20",
     "points": 232,
     "image": "attack-modifiers/MT/am-mt-20.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt20"
   },
   {
     "name": "am-ns-01",
     "points": 233,
     "image": "attack-modifiers/NS/am-ns-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns01"
   },
   {
     "name": "am-ns-02",
     "points": 234,
     "image": "attack-modifiers/NS/am-ns-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns02"
   },
   {
     "name": "am-ns-03",
     "points": 235,
     "image": "attack-modifiers/NS/am-ns-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns03"
   },
   {
     "name": "am-ns-04",
     "points": 236,
     "image": "attack-modifiers/NS/am-ns-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns04"
   },
   {
     "name": "am-ns-05",
     "points": 237,
     "image": "attack-modifiers/NS/am-ns-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns05"
   },
   {
     "name": "am-ns-06",
     "points": 238,
     "image": "attack-modifiers/NS/am-ns-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns06"
   },
   {
     "name": "am-ns-07",
     "points": 239,
     "image": "attack-modifiers/NS/am-ns-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns07"
   },
   {
     "name": "am-ns-08",
     "points": 240,
     "image": "attack-modifiers/NS/am-ns-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns08"
   },
   {
     "name": "am-ns-09",
     "points": 241,
     "image": "attack-modifiers/NS/am-ns-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns09"
   },
   {
     "name": "am-ns-10",
     "points": 242,
     "image": "attack-modifiers/NS/am-ns-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns10"
   },
   {
     "name": "am-ns-11",
     "points": 243,
     "image": "attack-modifiers/NS/am-ns-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns11"
   },
   {
     "name": "am-ns-12",
     "points": 244,
     "image": "attack-modifiers/NS/am-ns-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns12"
   },
   {
     "name": "am-ns-13",
     "points": 245,
     "image": "attack-modifiers/NS/am-ns-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns13"
   },
   {
     "name": "am-ns-14",
     "points": 246,
     "image": "attack-modifiers/NS/am-ns-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns14"
   },
   {
     "name": "am-ns-15",
     "points": 247,
     "image": "attack-modifiers/NS/am-ns-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns15"
   },
   {
     "name": "am-ns-16",
     "points": 248,
     "image": "attack-modifiers/NS/am-ns-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns16"
   },
   {
     "name": "am-ns-17",
     "points": 249,
     "image": "attack-modifiers/NS/am-ns-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns17"
   },
   {
     "name": "am-ns-18",
     "points": 250,
     "image": "attack-modifiers/NS/am-ns-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns18"
   },
   {
     "name": "am-ns-19",
     "points": 251,
     "image": "attack-modifiers/NS/am-ns-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns19"
   },
   {
     "name": "am-ph-01",
     "points": 252,
     "image": "attack-modifiers/PH/am-ph-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph01"
   },
   {
     "name": "am-ph-02",
     "points": 253,
     "image": "attack-modifiers/PH/am-ph-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph02"
   },
   {
     "name": "am-ph-03",
     "points": 254,
     "image": "attack-modifiers/PH/am-ph-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph03"
   },
   {
     "name": "am-ph-04",
     "points": 255,
     "image": "attack-modifiers/PH/am-ph-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph04"
   },
   {
     "name": "am-ph-05",
     "points": 256,
     "image": "attack-modifiers/PH/am-ph-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph05"
   },
   {
     "name": "am-ph-06",
     "points": 257,
     "image": "attack-modifiers/PH/am-ph-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph06"
   },
   {
     "name": "am-ph-07",
     "points": 258,
     "image": "attack-modifiers/PH/am-ph-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph07"
   },
   {
     "name": "am-ph-08",
     "points": 259,
     "image": "attack-modifiers/PH/am-ph-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph08"
   },
   {
     "name": "am-ph-09",
     "points": 260,
     "image": "attack-modifiers/PH/am-ph-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph09"
   },
   {
     "name": "am-ph-10",
     "points": 261,
     "image": "attack-modifiers/PH/am-ph-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph10"
   },
   {
     "name": "am-ph-11",
     "points": 262,
     "image": "attack-modifiers/PH/am-ph-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph11"
   },
   {
     "name": "am-ph-12",
     "points": 263,
     "image": "attack-modifiers/PH/am-ph-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph12"
   },
   {
     "name": "am-ph-13",
     "points": 264,
     "image": "attack-modifiers/PH/am-ph-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph13"
   },
   {
     "name": "am-ph-14",
     "points": 265,
     "image": "attack-modifiers/PH/am-ph-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph14"
   },
   {
     "name": "am-ph-15",
     "points": 266,
     "image": "attack-modifiers/PH/am-ph-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph15"
   },
   {
     "name": "am-ph-16",
     "points": 267,
     "image": "attack-modifiers/PH/am-ph-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph16"
   },
   {
     "name": "am-ph-17",
     "points": 268,
     "image": "attack-modifiers/PH/am-ph-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph17"
   },
   {
     "name": "am-ph-18",
     "points": 269,
     "image": "attack-modifiers/PH/am-ph-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph18"
   },
   {
     "name": "am-ph-19",
     "points": 270,
     "image": "attack-modifiers/PH/am-ph-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph19"
   },
   {
     "name": "am-ph-20",
     "points": 271,
     "image": "attack-modifiers/PH/am-ph-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph20"
   },
   {
     "name": "am-qm-01",
     "points": 272,
     "image": "attack-modifiers/QM/am-qm-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm01"
   },
   {
     "name": "am-qm-02",
     "points": 273,
     "image": "attack-modifiers/QM/am-qm-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm02"
   },
   {
     "name": "am-qm-03",
     "points": 274,
     "image": "attack-modifiers/QM/am-qm-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm03"
   },
   {
     "name": "am-qm-04",
     "points": 275,
     "image": "attack-modifiers/QM/am-qm-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm04"
   },
   {
     "name": "am-qm-05",
     "points": 276,
     "image": "attack-modifiers/QM/am-qm-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm05"
   },
   {
     "name": "am-qm-06",
     "points": 277,
     "image": "attack-modifiers/QM/am-qm-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm06"
   },
   {
     "name": "am-qm-07",
     "points": 278,
     "image": "attack-modifiers/QM/am-qm-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm07"
   },
   {
     "name": "am-qm-08",
     "points": 279,
     "image": "attack-modifiers/QM/am-qm-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm08"
   },
   {
     "name": "am-qm-09",
     "points": 280,
     "image": "attack-modifiers/QM/am-qm-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm09"
   },
   {
     "name": "am-qm-10",
     "points": 281,
     "image": "attack-modifiers/QM/am-qm-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm10"
   },
   {
     "name": "am-qm-11",
     "points": 282,
     "image": "attack-modifiers/QM/am-qm-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm11"
   },
   {
     "name": "am-qm-12",
     "points": 283,
     "image": "attack-modifiers/QM/am-qm-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm12"
   },
   {
     "name": "am-qm-13",
     "points": 284,
     "image": "attack-modifiers/QM/am-qm-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm13"
   },
   {
     "name": "am-qm-14",
     "points": 285,
     "image": "attack-modifiers/QM/am-qm-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm14"
   },
   {
     "name": "am-qm-15",
     "points": 286,
     "image": "attack-modifiers/QM/am-qm-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm15"
   },
   {
     "name": "am-qm-16",
     "points": 287,
     "image": "attack-modifiers/QM/am-qm-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm16"
   },
   {
     "name": "am-qm-17",
     "points": 288,
     "image": "attack-modifiers/QM/am-qm-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm17"
   },
   {
     "name": "am-qm-18",
     "points": 289,
     "image": "attack-modifiers/QM/am-qm-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm18"
   },
   {
     "name": "am-sb-01",
     "points": 290,
     "image": "attack-modifiers/SB/am-sb-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb01"
   },
   {
     "name": "am-sb-02",
     "points": 291,
     "image": "attack-modifiers/SB/am-sb-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb02"
   },
   {
     "name": "am-sb-03",
     "points": 292,
     "image": "attack-modifiers/SB/am-sb-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb03"
   },
   {
     "name": "am-sb-04",
     "points": 293,
     "image": "attack-modifiers/SB/am-sb-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb04"
   },
   {
     "name": "am-sb-05",
     "points": 294,
     "image": "attack-modifiers/SB/am-sb-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb05"
   },
   {
     "name": "am-sb-06",
     "points": 295,
     "image": "attack-modifiers/SB/am-sb-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb06"
   },
   {
     "name": "am-sb-07",
     "points": 296,
     "image": "attack-modifiers/SB/am-sb-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb07"
   },
   {
     "name": "am-sb-08",
     "points": 297,
     "image": "attack-modifiers/SB/am-sb-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb08"
   },
   {
     "name": "am-sb-09",
     "points": 298,
     "image": "attack-modifiers/SB/am-sb-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb09"
   },
   {
     "name": "am-sb-10",
     "points": 299,
     "image": "attack-modifiers/SB/am-sb-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb10"
   },
   {
     "name": "am-sb-11",
     "points": 300,
     "image": "attack-modifiers/SB/am-sb-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb11"
   },
   {
     "name": "am-sb-12",
     "points": 301,
     "image": "attack-modifiers/SB/am-sb-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb12"
   },
   {
     "name": "am-sb-13",
     "points": 302,
     "image": "attack-modifiers/SB/am-sb-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb13"
   },
   {
     "name": "am-sb-14",
     "points": 303,
     "image": "attack-modifiers/SB/am-sb-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb14"
   },
   {
     "name": "am-sc-01",
     "points": 304,
     "image": "attack-modifiers/SC/am-sc-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc01"
   },
   {
     "name": "am-sc-02",
     "points": 305,
     "image": "attack-modifiers/SC/am-sc-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc02"
   },
   {
     "name": "am-sc-03",
     "points": 306,
     "image": "attack-modifiers/SC/am-sc-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc03"
   },
   {
     "name": "am-sc-04",
     "points": 307,
     "image": "attack-modifiers/SC/am-sc-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc04"
   },
   {
     "name": "am-sc-05",
     "points": 308,
     "image": "attack-modifiers/SC/am-sc-05.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc05"
   },
   {
     "name": "am-sc-06",
     "points": 309,
     "image": "attack-modifiers/SC/am-sc-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc06"
   },
   {
     "name": "am-sc-07",
     "points": 310,
     "image": "attack-modifiers/SC/am-sc-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc07"
   },
   {
     "name": "am-sc-08",
     "points": 311,
     "image": "attack-modifiers/SC/am-sc-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc08"
   },
   {
     "name": "am-sc-09",
     "points": 312,
     "image": "attack-modifiers/SC/am-sc-09.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc09"
   },
   {
     "name": "am-sc-10",
     "points": 313,
     "image": "attack-modifiers/SC/am-sc-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc10"
   },
   {
     "name": "am-sc-11",
     "points": 314,
     "image": "attack-modifiers/SC/am-sc-11.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc11"
   },
   {
     "name": "am-sc-12",
     "points": 315,
     "image": "attack-modifiers/SC/am-sc-12.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc12"
   },
   {
     "name": "am-sc-13",
     "points": 316,
     "image": "attack-modifiers/SC/am-sc-13.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc13"
   },
   {
     "name": "am-sc-14",
     "points": 317,
     "image": "attack-modifiers/SC/am-sc-14.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc14"
   },
   {
     "name": "am-sc-15",
     "points": 318,
     "image": "attack-modifiers/SC/am-sc-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc15"
   },
   {
     "name": "am-sc-16",
     "points": 319,
     "image": "attack-modifiers/SC/am-sc-16.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc16"
   },
   {
     "name": "am-sc-17",
     "points": 320,
     "image": "attack-modifiers/SC/am-sc-17.png",
+    "value": "rolling",
+    "conditions": [
+      "invisible"
+    ],
     "xws": "amsc17"
   },
   {
     "name": "am-sk-01",
     "points": 321,
     "image": "attack-modifiers/SK/am-sk-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk01"
   },
   {
     "name": "am-sk-02",
     "points": 322,
     "image": "attack-modifiers/SK/am-sk-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk02"
   },
   {
     "name": "am-sk-03",
     "points": 323,
     "image": "attack-modifiers/SK/am-sk-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk03"
   },
   {
     "name": "am-sk-04",
     "points": 324,
     "image": "attack-modifiers/SK/am-sk-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk04"
   },
   {
     "name": "am-sk-05",
     "points": 325,
     "image": "attack-modifiers/SK/am-sk-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk05"
   },
   {
     "name": "am-sk-06",
     "points": 326,
     "image": "attack-modifiers/SK/am-sk-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk06"
   },
   {
     "name": "am-sk-07",
     "points": 327,
     "image": "attack-modifiers/SK/am-sk-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk07"
   },
   {
     "name": "am-sk-08",
     "points": 328,
     "image": "attack-modifiers/SK/am-sk-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk08"
   },
   {
     "name": "am-sk-09",
     "points": 329,
     "image": "attack-modifiers/SK/am-sk-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk09"
   },
   {
     "name": "am-sk-10",
     "points": 330,
     "image": "attack-modifiers/SK/am-sk-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk10"
   },
   {
     "name": "am-sk-11",
     "points": 331,
     "image": "attack-modifiers/SK/am-sk-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk11"
   },
   {
     "name": "am-sk-12",
     "points": 332,
     "image": "attack-modifiers/SK/am-sk-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk12"
   },
   {
     "name": "am-sk-13",
     "points": 333,
     "image": "attack-modifiers/SK/am-sk-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk13"
   },
   {
     "name": "am-sk-14",
     "points": 334,
     "image": "attack-modifiers/SK/am-sk-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk14"
   },
   {
     "name": "am-sk-15",
     "points": 335,
     "image": "attack-modifiers/SK/am-sk-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk15"
   },
   {
     "name": "am-sk-16",
     "points": 336,
     "image": "attack-modifiers/SK/am-sk-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk16"
   },
   {
     "name": "am-sk-17",
     "points": 337,
     "image": "attack-modifiers/SK/am-sk-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk17"
   },
   {
     "name": "am-sk-18",
     "points": 338,
     "image": "attack-modifiers/SK/am-sk-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk18"
   },
   {
     "name": "am-sk-19",
     "points": 339,
     "image": "attack-modifiers/SK/am-sk-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk19"
   },
   {
     "name": "am-ss-01",
     "points": 340,
     "image": "attack-modifiers/SS/am-ss-01.png",
+    "value": 0,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amss01"
   },
   {
     "name": "am-ss-02",
     "points": 341,
     "image": "attack-modifiers/SS/am-ss-02.png",
+    "value": 0,
+    "conditions": [
+      "disarm"
+    ],
     "xws": "amss02"
   },
   {
     "name": "am-ss-03",
     "points": 342,
     "image": "attack-modifiers/SS/am-ss-03.png",
+    "value": 0,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amss03"
   },
   {
     "name": "am-ss-04",
     "points": 343,
     "image": "attack-modifiers/SS/am-ss-04.png",
+    "value": 0,
+    "conditions": [
+      "poison"
+    ],
     "xws": "amss04"
   },
   {
     "name": "am-ss-05",
     "points": 344,
     "image": "attack-modifiers/SS/am-ss-05.png",
+    "value": 0,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss05"
   },
   {
     "name": "am-ss-06",
     "points": 345,
     "image": "attack-modifiers/SS/am-ss-06.png",
+    "value": 0,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amss06"
   },
   {
     "name": "am-ss-07",
     "points": 346,
     "image": "attack-modifiers/SS/am-ss-07.png",
+    "value": -1,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amss07"
   },
   {
     "name": "am-ss-08",
     "points": 347,
     "image": "attack-modifiers/SS/am-ss-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss08"
   },
   {
     "name": "am-ss-09",
     "points": 348,
     "image": "attack-modifiers/SS/am-ss-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss09"
   },
   {
     "name": "am-ss-10",
     "points": 349,
     "image": "attack-modifiers/SS/am-ss-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss10"
   },
   {
     "name": "am-ss-11",
     "points": 350,
     "image": "attack-modifiers/SS/am-ss-11.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss11"
   },
   {
     "name": "am-ss-12",
     "points": 351,
     "image": "attack-modifiers/SS/am-ss-12.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss12"
   },
   {
     "name": "am-ss-13",
     "points": 352,
     "image": "attack-modifiers/SS/am-ss-13.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss13"
   },
   {
     "name": "am-ss-14",
     "points": 353,
     "image": "attack-modifiers/SS/am-ss-14.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss14"
   },
   {
     "name": "am-ss-15",
     "points": 354,
     "image": "attack-modifiers/SS/am-ss-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss15"
   },
   {
     "name": "am-ss-16",
     "points": 355,
     "image": "attack-modifiers/SS/am-ss-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss16"
   },
   {
     "name": "am-su-01",
     "points": 356,
     "image": "attack-modifiers/SU/am-su-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu01"
   },
   {
     "name": "am-su-02",
     "points": 357,
     "image": "attack-modifiers/SU/am-su-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu02"
   },
   {
     "name": "am-su-03",
     "points": 358,
     "image": "attack-modifiers/SU/am-su-03.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu03"
   },
   {
     "name": "am-su-04",
     "points": 359,
     "image": "attack-modifiers/SU/am-su-04.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu04"
   },
   {
     "name": "am-su-05",
     "points": 360,
     "image": "attack-modifiers/SU/am-su-05.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu05"
   },
   {
     "name": "am-su-06",
     "points": 361,
     "image": "attack-modifiers/SU/am-su-06.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu06"
   },
   {
     "name": "am-su-07",
     "points": 362,
     "image": "attack-modifiers/SU/am-su-07.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu07"
   },
   {
     "name": "am-su-08",
     "points": 363,
     "image": "attack-modifiers/SU/am-su-08.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu08"
   },
   {
     "name": "am-su-09",
     "points": 364,
     "image": "attack-modifiers/SU/am-su-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu09"
   },
   {
     "name": "am-su-10",
     "points": 365,
     "image": "attack-modifiers/SU/am-su-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu10"
   },
   {
     "name": "am-su-11",
     "points": 366,
     "image": "attack-modifiers/SU/am-su-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu11"
   },
   {
     "name": "am-su-12",
     "points": 367,
     "image": "attack-modifiers/SU/am-su-12.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu12"
   },
   {
     "name": "am-su-13",
     "points": 368,
     "image": "attack-modifiers/SU/am-su-13.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu13"
   },
   {
     "name": "am-su-14",
     "points": 369,
     "image": "attack-modifiers/SU/am-su-14.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu14"
   },
   {
     "name": "am-su-15",
     "points": 370,
     "image": "attack-modifiers/SU/am-su-15.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu15"
   },
   {
     "name": "am-su-16",
     "points": 371,
     "image": "attack-modifiers/SU/am-su-16.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu16"
   },
   {
     "name": "am-su-17",
     "points": 372,
     "image": "attack-modifiers/SU/am-su-17.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu17"
   },
   {
     "name": "am-su-18",
     "points": 373,
     "image": "attack-modifiers/SU/am-su-18.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu18"
   },
   {
     "name": "am-su-19",
     "points": 374,
     "image": "attack-modifiers/SU/am-su-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu19"
   },
   {
     "name": "am-su-20",
     "points": 375,
     "image": "attack-modifiers/SU/am-su-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu20"
   },
   {
     "name": "am-su-21",
     "points": 376,
     "image": "attack-modifiers/SU/am-su-21.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu21"
   },
   {
     "name": "am-su-22",
     "points": 377,
     "image": "attack-modifiers/SU/am-su-22.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu22"
   },
   {
     "name": "am-sw-01",
     "points": 378,
     "image": "attack-modifiers/SW/am-sw-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw01"
   },
   {
     "name": "am-sw-02",
     "points": 379,
     "image": "attack-modifiers/SW/am-sw-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw02"
   },
   {
     "name": "am-sw-03",
     "points": 380,
     "image": "attack-modifiers/SW/am-sw-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw03"
   },
   {
     "name": "am-sw-04",
     "points": 381,
     "image": "attack-modifiers/SW/am-sw-04.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw04"
   },
   {
     "name": "am-sw-05",
     "points": 382,
     "image": "attack-modifiers/SW/am-sw-05.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw05"
   },
   {
     "name": "am-sw-06",
     "points": 383,
     "image": "attack-modifiers/SW/am-sw-06.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw06"
   },
   {
     "name": "am-sw-07",
     "points": 384,
     "image": "attack-modifiers/SW/am-sw-07.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amsw07"
   },
   {
     "name": "am-sw-08",
     "points": 385,
     "image": "attack-modifiers/SW/am-sw-08.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsw08"
   },
   {
     "name": "am-sw-09",
     "points": 386,
     "image": "attack-modifiers/SW/am-sw-09.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amsw09"
   },
   {
     "name": "am-sw-10",
     "points": 387,
     "image": "attack-modifiers/SW/am-sw-10.png",
+    "value": 1,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amsw10"
   },
   {
     "name": "am-sw-11",
     "points": 388,
     "image": "attack-modifiers/SW/am-sw-11.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw11"
   },
   {
     "name": "am-sw-12",
     "points": 389,
     "image": "attack-modifiers/SW/am-sw-12.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw12"
   },
   {
     "name": "am-sw-13",
     "points": 390,
     "image": "attack-modifiers/SW/am-sw-13.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw13"
   },
   {
     "name": "am-sw-14",
     "points": 391,
     "image": "attack-modifiers/SW/am-sw-14.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw14"
   },
   {
     "name": "am-sw-15",
     "points": 392,
     "image": "attack-modifiers/SW/am-sw-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw15"
   },
   {
     "name": "am-sw-16",
     "points": 393,
     "image": "attack-modifiers/SW/am-sw-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw16"
   },
   {
     "name": "am-sw-17",
     "points": 394,
     "image": "attack-modifiers/SW/am-sw-17.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw17"
   },
   {
     "name": "am-sw-18",
     "points": 395,
     "image": "attack-modifiers/SW/am-sw-18.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw18"
   },
   {
     "name": "am-ti-01",
     "points": 396,
     "image": "attack-modifiers/TI/am-ti-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amti01"
   },
   {
     "name": "am-ti-02",
     "points": 397,
     "image": "attack-modifiers/TI/am-ti-02.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti02"
   },
   {
     "name": "am-ti-03",
     "points": 398,
     "image": "attack-modifiers/TI/am-ti-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti03"
   },
   {
     "name": "am-ti-04",
     "points": 399,
     "image": "attack-modifiers/TI/am-ti-04.png",
+    "value": 3,
+    "conditions": [],
     "xws": "amti04"
   },
   {
     "name": "am-ti-05",
     "points": 400,
     "image": "attack-modifiers/TI/am-ti-05.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti05"
   },
   {
     "name": "am-ti-06",
     "points": 401,
     "image": "attack-modifiers/TI/am-ti-06.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti06"
   },
   {
     "name": "am-ti-07",
     "points": 402,
     "image": "attack-modifiers/TI/am-ti-07.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti07"
   },
   {
     "name": "am-ti-08",
     "points": 403,
     "image": "attack-modifiers/TI/am-ti-08.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti08"
   },
   {
     "name": "am-ti-09",
     "points": 404,
     "image": "attack-modifiers/TI/am-ti-09.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti09"
   },
   {
     "name": "am-ti-10",
     "points": 405,
     "image": "attack-modifiers/TI/am-ti-10.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti10"
   },
   {
     "name": "am-ti-11",
     "points": 406,
     "image": "attack-modifiers/TI/am-ti-11.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti11"
   },
   {
     "name": "am-ti-12",
     "points": 407,
     "image": "attack-modifiers/TI/am-ti-12.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti12"
   },
   {
     "name": "am-ti-13",
     "points": 408,
     "image": "attack-modifiers/TI/am-ti-13.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti13"
   },
   {
     "name": "am-ti-14",
     "points": 409,
     "image": "attack-modifiers/TI/am-ti-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti14"
   },
   {
     "name": "am-ti-15",
     "points": 410,
     "image": "attack-modifiers/TI/am-ti-15.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti15"
   },
   {
     "name": "am-ti-16",
     "points": 411,
     "image": "attack-modifiers/TI/am-ti-16.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amti16"
   },
   {
     "name": "am-dr-01",
     "points": 412,
     "image": "attack-modifiers/DR/am-dr-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr01"
   },
   {
     "name": "am-dr-02",
     "points": 413,
     "image": "attack-modifiers/DR/am-dr-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr02"
   },
   {
     "name": "am-dr-03",
     "points": 414,
     "image": "attack-modifiers/DR/am-dr-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr03"
   },
   {
     "name": "am-dr-04",
     "points": 415,
     "image": "attack-modifiers/DR/am-dr-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr04"
   },
   {
     "name": "am-dr-05",
     "points": 416,
     "image": "attack-modifiers/DR/am-dr-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr05"
   },
   {
     "name": "am-dr-06",
     "points": 417,
     "image": "attack-modifiers/DR/am-dr-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr06"
   },
   {
     "name": "am-dr-07",
     "points": 418,
     "image": "attack-modifiers/DR/am-dr-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr07"
   },
   {
     "name": "am-dr-08",
     "points": 419,
     "image": "attack-modifiers/DR/am-dr-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr08"
   },
   {
     "name": "am-dr-09",
     "points": 420,
     "image": "attack-modifiers/DR/am-dr-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr09"
   },
   {
     "name": "am-dr-10",
     "points": 421,
     "image": "attack-modifiers/DR/am-dr-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr10"
   },
   {
     "name": "am-dr-11",
     "points": 422,
     "image": "attack-modifiers/DR/am-dr-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr11"
   },
   {
     "name": "am-dr-12",
     "points": 423,
     "image": "attack-modifiers/DR/am-dr-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr12"
   },
   {
     "name": "am-dr-13",
     "points": 424,
     "image": "attack-modifiers/DR/am-dr-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr13"
   },
   {
     "name": "am-dr-14",
     "points": 425,
     "image": "attack-modifiers/DR/am-dr-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr14"
   },
   {
     "name": "am-dr-15",
     "points": 426,
     "image": "attack-modifiers/DR/am-dr-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr15"
   }
 ]

--- a/data/attack-modifiers.json
+++ b/data/attack-modifiers.json
@@ -3,180 +3,240 @@
     "name": "am-m-01",
     "points": 0,
     "image": "attack-modifiers/base/monster/am-m-01.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm01"
   },
   {
     "name": "am-m-02",
     "points": 1,
     "image": "attack-modifiers/base/monster/am-m-02.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm02"
   },
   {
     "name": "am-m-03",
     "points": 2,
     "image": "attack-modifiers/base/monster/am-m-03.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm03"
   },
   {
     "name": "am-m-04",
     "points": 3,
     "image": "attack-modifiers/base/monster/am-m-04.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm04"
   },
   {
     "name": "am-m-05",
     "points": 4,
     "image": "attack-modifiers/base/monster/am-m-05.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm05"
   },
   {
     "name": "am-m-06",
     "points": 5,
     "image": "attack-modifiers/base/monster/am-m-06.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm06"
   },
   {
     "name": "am-m-07",
     "points": 6,
     "image": "attack-modifiers/base/monster/am-m-07.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm07"
   },
   {
     "name": "am-m-08",
     "points": 7,
     "image": "attack-modifiers/base/monster/am-m-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm08"
   },
   {
     "name": "am-m-09",
     "points": 8,
     "image": "attack-modifiers/base/monster/am-m-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm09"
   },
   {
     "name": "am-m-10",
     "points": 9,
     "image": "attack-modifiers/base/monster/am-m-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm10"
   },
   {
     "name": "am-m-11",
     "points": 10,
     "image": "attack-modifiers/base/monster/am-m-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm11"
   },
   {
     "name": "am-m-12",
     "points": 11,
     "image": "attack-modifiers/base/monster/am-m-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm12"
   },
   {
     "name": "am-m-13",
     "points": 12,
     "image": "attack-modifiers/base/monster/am-m-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm13"
   },
   {
     "name": "am-m-14",
     "points": 13,
     "image": "attack-modifiers/base/monster/am-m-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm14"
   },
   {
     "name": "am-m-15",
     "points": 14,
     "image": "attack-modifiers/base/monster/am-m-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm15"
   },
   {
     "name": "am-m-16",
     "points": 15,
     "image": "attack-modifiers/base/monster/am-m-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm16"
   },
   {
     "name": "am-m-17",
     "points": 16,
     "image": "attack-modifiers/base/monster/am-m-17.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amm17"
   },
   {
     "name": "am-m-18",
     "points": 17,
     "image": "attack-modifiers/base/monster/am-m-18.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amm18"
   },
   {
     "name": "am-m-19",
     "points": 18,
     "image": "attack-modifiers/base/monster/am-m-19.png",
+    "value": "miss",
+    "conditions": [],
     "xws": "amm19"
   },
   {
     "name": "am-m-20",
     "points": 19,
     "image": "attack-modifiers/base/monster/am-m-20.png",
+    "value": "x2",
+    "conditions": [],
     "xws": "amm20"
   },
   {
     "name": "am-mm-01",
     "points": 20,
     "image": "attack-modifiers/base/monster-mod/am-mm-01.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm01"
   },
   {
     "name": "am-mm-02",
     "points": 21,
     "image": "attack-modifiers/base/monster-mod/am-mm-02.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm02"
   },
   {
     "name": "am-mm-03",
     "points": 22,
     "image": "attack-modifiers/base/monster-mod/am-mm-03.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm03"
   },
   {
     "name": "am-mm-04",
     "points": 23,
     "image": "attack-modifiers/base/monster-mod/am-mm-04.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm04"
   },
   {
     "name": "am-mm-05",
     "points": 24,
     "image": "attack-modifiers/base/monster-mod/am-mm-05.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm05"
   },
   {
     "name": "am-mm-06",
     "points": 25,
     "image": "attack-modifiers/base/monster-mod/am-mm-06.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm06"
   },
   {
     "name": "am-mm-07",
     "points": 26,
     "image": "attack-modifiers/base/monster-mod/am-mm-07.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm07"
   },
   {
     "name": "am-mm-08",
     "points": 27,
     "image": "attack-modifiers/base/monster-mod/am-mm-08.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm08"
   },
   {
     "name": "am-mm-09",
     "points": 28,
     "image": "attack-modifiers/base/monster-mod/am-mm-09.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm09"
   },
   {
     "name": "am-mm-10",
     "points": 29,
     "image": "attack-modifiers/base/monster-mod/am-mm-10.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm10"
   },
   {
@@ -184,6 +244,7 @@
     "points": 30,
     "image": "attack-modifiers/base/player/am-p-01.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp01"
   },
   {
@@ -191,6 +252,7 @@
     "points": 31,
     "image": "attack-modifiers/base/player/am-p-02.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp02"
   },
   {
@@ -198,6 +260,7 @@
     "points": 32,
     "image": "attack-modifiers/base/player/am-p-03.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp03"
   },
   {
@@ -205,6 +268,7 @@
     "points": 33,
     "image": "attack-modifiers/base/player/am-p-04.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp04"
   },
   {
@@ -212,6 +276,7 @@
     "points": 34,
     "image": "attack-modifiers/base/player/am-p-05.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp05"
   },
   {
@@ -219,6 +284,7 @@
     "points": 35,
     "image": "attack-modifiers/base/player/am-p-06.png",
     "value": 0,
+    "conditions": [],
     "xws": "amp06"
   },
   {
@@ -226,6 +292,7 @@
     "points": 36,
     "image": "attack-modifiers/base/player/am-p-07.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp07"
   },
   {
@@ -233,6 +300,7 @@
     "points": 37,
     "image": "attack-modifiers/base/player/am-p-08.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp08"
   },
   {
@@ -240,6 +308,7 @@
     "points": 38,
     "image": "attack-modifiers/base/player/am-p-09.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp09"
   },
   {
@@ -247,6 +316,7 @@
     "points": 39,
     "image": "attack-modifiers/base/player/am-p-10.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp10"
   },
   {
@@ -254,6 +324,7 @@
     "points": 40,
     "image": "attack-modifiers/base/player/am-p-11.png",
     "value": 1,
+    "conditions": [],
     "xws": "amp11"
   },
   {
@@ -261,6 +332,7 @@
     "points": 41,
     "image": "attack-modifiers/base/player/am-p-12.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp12"
   },
   {
@@ -268,6 +340,7 @@
     "points": 42,
     "image": "attack-modifiers/base/player/am-p-13.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp13"
   },
   {
@@ -275,6 +348,7 @@
     "points": 43,
     "image": "attack-modifiers/base/player/am-p-14.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp14"
   },
   {
@@ -282,6 +356,7 @@
     "points": 44,
     "image": "attack-modifiers/base/player/am-p-15.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp15"
   },
   {
@@ -289,13 +364,15 @@
     "points": 45,
     "image": "attack-modifiers/base/player/am-p-16.png",
     "value": -1,
+    "conditions": [],
     "xws": "amp16"
   },
   {
     "name": "am-p-17",
     "points": 46,
     "image": "attack-modifiers/base/player/am-p-17.png",
-    "value": -1,
+    "value": -2,
+    "conditions": [],
     "xws": "amp17"
   },
   {
@@ -303,6 +380,7 @@
     "points": 47,
     "image": "attack-modifiers/base/player/am-p-18.png",
     "value": 2,
+    "conditions": [],
     "xws": "amp18"
   },
   {
@@ -310,6 +388,7 @@
     "points": 48,
     "image": "attack-modifiers/base/player/am-p-19.png",
     "value": "miss",
+    "conditions": [],
     "xws": "amp19"
   },
   {
@@ -317,6 +396,7 @@
     "points": 49,
     "image": "attack-modifiers/base/player/am-p-20.png",
     "value": "x2",
+    "conditions": [],
     "xws": "amp20"
   },
   {
@@ -324,6 +404,7 @@
     "points": 50,
     "image": "attack-modifiers/base/player-mod/am-pm-01.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm01"
   },
   {
@@ -331,6 +412,7 @@
     "points": 51,
     "image": "attack-modifiers/base/player-mod/am-pm-02.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm02"
   },
   {
@@ -338,6 +420,7 @@
     "points": 52,
     "image": "attack-modifiers/base/player-mod/am-pm-03.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm03"
   },
   {
@@ -345,6 +428,7 @@
     "points": 53,
     "image": "attack-modifiers/base/player-mod/am-pm-04.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm04"
   },
   {
@@ -352,6 +436,7 @@
     "points": 54,
     "image": "attack-modifiers/base/player-mod/am-pm-05.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm05"
   },
   {
@@ -359,6 +444,7 @@
     "points": 55,
     "image": "attack-modifiers/base/player-mod/am-pm-06.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm06"
   },
   {
@@ -366,6 +452,7 @@
     "points": 56,
     "image": "attack-modifiers/base/player-mod/am-pm-07.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm07"
   },
   {
@@ -373,6 +460,7 @@
     "points": 57,
     "image": "attack-modifiers/base/player-mod/am-pm-08.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm08"
   },
   {
@@ -380,6 +468,7 @@
     "points": 58,
     "image": "attack-modifiers/base/player-mod/am-pm-09.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm09"
   },
   {
@@ -387,6 +476,7 @@
     "points": 59,
     "image": "attack-modifiers/base/player-mod/am-pm-10.png",
     "value": "bless",
+    "conditions": [],
     "xws": "ampm10"
   },
   {
@@ -394,6 +484,7 @@
     "points": 60,
     "image": "attack-modifiers/base/player-mod/am-pm-11.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm11"
   },
   {
@@ -401,6 +492,7 @@
     "points": 61,
     "image": "attack-modifiers/base/player-mod/am-pm-12.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm12"
   },
   {
@@ -408,6 +500,7 @@
     "points": 62,
     "image": "attack-modifiers/base/player-mod/am-pm-13.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm13"
   },
   {
@@ -415,6 +508,7 @@
     "points": 63,
     "image": "attack-modifiers/base/player-mod/am-pm-14.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm14"
   },
   {
@@ -422,6 +516,7 @@
     "points": 64,
     "image": "attack-modifiers/base/player-mod/am-pm-15.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm15"
   },
   {
@@ -429,6 +524,7 @@
     "points": 65,
     "image": "attack-modifiers/base/player-mod/am-pm-16.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm16"
   },
   {
@@ -436,6 +532,7 @@
     "points": 66,
     "image": "attack-modifiers/base/player-mod/am-pm-17.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm17"
   },
   {
@@ -443,6 +540,7 @@
     "points": 67,
     "image": "attack-modifiers/base/player-mod/am-pm-18.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm18"
   },
   {
@@ -450,6 +548,7 @@
     "points": 68,
     "image": "attack-modifiers/base/player-mod/am-pm-19.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm19"
   },
   {
@@ -457,6 +556,7 @@
     "points": 69,
     "image": "attack-modifiers/base/player-mod/am-pm-20.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm20"
   },
   {
@@ -464,6 +564,7 @@
     "points": 70,
     "image": "attack-modifiers/base/player-mod/am-pm-21.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm21"
   },
   {
@@ -471,6 +572,7 @@
     "points": 71,
     "image": "attack-modifiers/base/player-mod/am-pm-22.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm22"
   },
   {
@@ -478,6 +580,7 @@
     "points": 72,
     "image": "attack-modifiers/base/player-mod/am-pm-23.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm23"
   },
   {
@@ -485,6 +588,7 @@
     "points": 73,
     "image": "attack-modifiers/base/player-mod/am-pm-24.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm24"
   },
   {
@@ -492,6 +596,7 @@
     "points": 74,
     "image": "attack-modifiers/base/player-mod/am-pm-25.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm25"
   },
   {
@@ -499,6 +604,7 @@
     "points": 75,
     "image": "attack-modifiers/base/player-mod/am-pm-26.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm26"
   },
   {
@@ -506,6 +612,7 @@
     "points": 76,
     "image": "attack-modifiers/base/player-mod/am-pm-27.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm27"
   },
   {
@@ -513,6 +620,7 @@
     "points": 77,
     "image": "attack-modifiers/base/player-mod/am-pm-28.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm28"
   },
   {
@@ -520,6 +628,7 @@
     "points": 78,
     "image": "attack-modifiers/base/player-mod/am-pm-29.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm29"
   },
   {
@@ -527,6 +636,7 @@
     "points": 79,
     "image": "attack-modifiers/base/player-mod/am-pm-30.png",
     "value": "curse",
+    "conditions": [],
     "xws": "ampm30"
   },
   {
@@ -534,6 +644,7 @@
     "points": 80,
     "image": "attack-modifiers/base/player-mod/am-pm-31.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm31"
   },
   {
@@ -541,6 +652,7 @@
     "points": 81,
     "image": "attack-modifiers/base/player-mod/am-pm-32.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm32"
   },
   {
@@ -548,6 +660,7 @@
     "points": 82,
     "image": "attack-modifiers/base/player-mod/am-pm-33.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm33"
   },
   {
@@ -555,6 +668,7 @@
     "points": 83,
     "image": "attack-modifiers/base/player-mod/am-pm-34.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm34"
   },
   {
@@ -562,2058 +676,2991 @@
     "points": 84,
     "image": "attack-modifiers/base/player-mod/am-pm-35.png",
     "value": -1,
+    "conditions": [],
     "xws": "ampm35"
   },
   {
     "name": "am-be-01",
     "points": 85,
     "image": "attack-modifiers/BE/am-be-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe01"
   },
   {
     "name": "am-be-02",
     "points": 86,
     "image": "attack-modifiers/BE/am-be-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe02"
   },
   {
     "name": "am-be-03",
     "points": 87,
     "image": "attack-modifiers/BE/am-be-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe03"
   },
   {
     "name": "am-be-04",
     "points": 88,
     "image": "attack-modifiers/BE/am-be-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe04"
   },
   {
     "name": "am-be-05",
     "points": 89,
     "image": "attack-modifiers/BE/am-be-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe05"
   },
   {
     "name": "am-be-06",
     "points": 90,
     "image": "attack-modifiers/BE/am-be-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe06"
   },
   {
     "name": "am-be-07",
     "points": 91,
     "image": "attack-modifiers/BE/am-be-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe07"
   },
   {
     "name": "am-be-08",
     "points": 92,
     "image": "attack-modifiers/BE/am-be-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe08"
   },
   {
     "name": "am-be-09",
     "points": 93,
     "image": "attack-modifiers/BE/am-be-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe09"
   },
   {
     "name": "am-be-10",
     "points": 94,
     "image": "attack-modifiers/BE/am-be-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe10"
   },
   {
     "name": "am-be-11",
     "points": 95,
     "image": "attack-modifiers/BE/am-be-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe11"
   },
   {
     "name": "am-be-12",
     "points": 96,
     "image": "attack-modifiers/BE/am-be-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe12"
   },
   {
     "name": "am-be-13",
     "points": 97,
     "image": "attack-modifiers/BE/am-be-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe13"
   },
   {
     "name": "am-be-14",
     "points": 98,
     "image": "attack-modifiers/BE/am-be-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe14"
   },
   {
     "name": "am-be-15",
     "points": 99,
     "image": "attack-modifiers/BE/am-be-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe15"
   },
   {
     "name": "am-br-01",
     "points": 100,
     "image": "attack-modifiers/BR/am-br-01.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr01"
   },
   {
     "name": "am-br-02",
     "points": 101,
     "image": "attack-modifiers/BR/am-br-02.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr02"
   },
   {
     "name": "am-br-03",
     "points": 102,
     "image": "attack-modifiers/BR/am-br-03.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr03"
   },
   {
     "name": "am-br-04",
     "points": 103,
     "image": "attack-modifiers/BR/am-br-04.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr04"
   },
   {
     "name": "am-br-05",
     "points": 104,
     "image": "attack-modifiers/BR/am-br-05.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr05"
   },
   {
     "name": "am-br-06",
     "points": 105,
     "image": "attack-modifiers/BR/am-br-06.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr06"
   },
   {
     "name": "am-br-07",
     "points": 106,
     "image": "attack-modifiers/BR/am-br-07.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr07"
   },
   {
     "name": "am-br-08",
     "points": 107,
     "image": "attack-modifiers/BR/am-br-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr08"
   },
   {
     "name": "am-br-09",
     "points": 108,
     "image": "attack-modifiers/BR/am-br-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr09"
   },
   {
     "name": "am-br-10",
     "points": 109,
     "image": "attack-modifiers/BR/am-br-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr10"
   },
   {
     "name": "am-br-11",
     "points": 110,
     "image": "attack-modifiers/BR/am-br-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr11"
   },
   {
     "name": "am-br-12",
     "points": 111,
     "image": "attack-modifiers/BR/am-br-12.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr12"
   },
   {
     "name": "am-br-13",
     "points": 112,
     "image": "attack-modifiers/BR/am-br-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambr13"
   },
   {
     "name": "am-br-14",
     "points": 113,
     "image": "attack-modifiers/BR/am-br-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr14"
   },
   {
     "name": "am-br-15",
     "points": 114,
     "image": "attack-modifiers/BR/am-br-15.png",
+    "value": 3,
+    "conditions": [],
     "xws": "ambr15"
   },
   {
     "name": "am-br-16",
     "points": 115,
     "image": "attack-modifiers/BR/am-br-16.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr16"
   },
   {
     "name": "am-br-17",
     "points": 116,
     "image": "attack-modifiers/BR/am-br-17.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr17"
   },
   {
     "name": "am-br-18",
     "points": 117,
     "image": "attack-modifiers/BR/am-br-18.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr18"
   },
   {
     "name": "am-br-19",
     "points": 118,
     "image": "attack-modifiers/BR/am-br-19.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr19"
   },
   {
     "name": "am-br-20",
     "points": 119,
     "image": "attack-modifiers/BR/am-br-20.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr20"
   },
   {
     "name": "am-br-21",
     "points": 120,
     "image": "attack-modifiers/BR/am-br-21.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr21"
   },
   {
     "name": "am-br-22",
     "points": 121,
     "image": "attack-modifiers/BR/am-br-22.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr22"
   },
   {
     "name": "am-bs-01",
     "points": 122,
     "image": "attack-modifiers/BS/am-bs-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs01"
   },
   {
     "name": "am-bs-02",
     "points": 123,
     "image": "attack-modifiers/BS/am-bs-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs02"
   },
   {
     "name": "am-bs-03",
     "points": 124,
     "image": "attack-modifiers/BS/am-bs-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs03"
   },
   {
     "name": "am-bs-04",
     "points": 125,
     "image": "attack-modifiers/BS/am-bs-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs04"
   },
   {
     "name": "am-bs-05",
     "points": 126,
     "image": "attack-modifiers/BS/am-bs-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs05"
   },
   {
     "name": "am-bs-06",
     "points": 127,
     "image": "attack-modifiers/BS/am-bs-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs06"
   },
   {
     "name": "am-bs-07",
     "points": 128,
     "image": "attack-modifiers/BS/am-bs-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs07"
   },
   {
     "name": "am-bs-08",
     "points": 129,
     "image": "attack-modifiers/BS/am-bs-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs08"
   },
   {
     "name": "am-bs-09",
     "points": 130,
     "image": "attack-modifiers/BS/am-bs-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs09"
   },
   {
     "name": "am-bs-10",
     "points": 131,
     "image": "attack-modifiers/BS/am-bs-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs10"
   },
   {
     "name": "am-bs-11",
     "points": 132,
     "image": "attack-modifiers/BS/am-bs-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs11"
   },
   {
     "name": "am-bs-12",
     "points": 133,
     "image": "attack-modifiers/BS/am-bs-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs12"
   },
   {
     "name": "am-bs-13",
     "points": 134,
     "image": "attack-modifiers/BS/am-bs-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs13"
   },
   {
     "name": "am-bs-14",
     "points": 135,
     "image": "attack-modifiers/BS/am-bs-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs14"
   },
   {
     "name": "am-bs-15",
     "points": 136,
     "image": "attack-modifiers/BS/am-bs-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs15"
   },
   {
     "name": "am-bt-01",
     "points": 137,
     "image": "attack-modifiers/BT/am-bt-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt01"
   },
   {
     "name": "am-bt-02",
     "points": 138,
     "image": "attack-modifiers/BT/am-bt-02.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt02"
   },
   {
     "name": "am-bt-03",
     "points": 139,
     "image": "attack-modifiers/BT/am-bt-03.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt03"
   },
   {
     "name": "am-bt-04",
     "points": 140,
     "image": "attack-modifiers/BT/am-bt-04.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt04"
   },
   {
     "name": "am-bt-05",
     "points": 141,
     "image": "attack-modifiers/BT/am-bt-05.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt05"
   },
   {
     "name": "am-bt-06",
     "points": 142,
     "image": "attack-modifiers/BT/am-bt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt06"
   },
   {
     "name": "am-bt-07",
     "points": 143,
     "image": "attack-modifiers/BT/am-bt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt07"
   },
   {
     "name": "am-bt-08",
     "points": 144,
     "image": "attack-modifiers/BT/am-bt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt08"
   },
   {
     "name": "am-bt-09",
     "points": 145,
     "image": "attack-modifiers/BT/am-bt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt09"
   },
   {
     "name": "am-bt-10",
     "points": 146,
     "image": "attack-modifiers/BT/am-bt-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt10"
   },
   {
     "name": "am-bt-11",
     "points": 147,
     "image": "attack-modifiers/BT/am-bt-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt11"
   },
   {
     "name": "am-bt-12",
     "points": 148,
     "image": "attack-modifiers/BT/am-bt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt12"
   },
   {
     "name": "am-bt-13",
     "points": 149,
     "image": "attack-modifiers/BT/am-bt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt13"
   },
   {
     "name": "am-bt-14",
     "points": 150,
     "image": "attack-modifiers/BT/am-bt-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt14"
   },
   {
     "name": "am-bt-15",
     "points": 151,
     "image": "attack-modifiers/BT/am-bt-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt15"
   },
   {
     "name": "am-bt-16",
     "points": 152,
     "image": "attack-modifiers/BT/am-bt-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt16"
   },
   {
     "name": "am-bt-17",
     "points": 153,
     "image": "attack-modifiers/BT/am-bt-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt17"
   },
   {
     "name": "am-ch-01",
     "points": 154,
     "image": "attack-modifiers/CH/am-ch-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch01"
   },
   {
     "name": "am-ch-02",
     "points": 155,
     "image": "attack-modifiers/CH/am-ch-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch02"
   },
   {
     "name": "am-ch-03",
     "points": 156,
     "image": "attack-modifiers/CH/am-ch-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch03"
   },
   {
     "name": "am-ch-04",
     "points": 157,
     "image": "attack-modifiers/CH/am-ch-04.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amch04"
   },
   {
     "name": "am-ch-05",
     "points": 158,
     "image": "attack-modifiers/CH/am-ch-05.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch05"
   },
   {
     "name": "am-ch-06",
     "points": 159,
     "image": "attack-modifiers/CH/am-ch-06.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch06"
   },
   {
     "name": "am-ch-07",
     "points": 160,
     "image": "attack-modifiers/CH/am-ch-07.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch07"
   },
   {
     "name": "am-ch-08",
     "points": 161,
     "image": "attack-modifiers/CH/am-ch-08.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch08"
   },
   {
     "name": "am-ch-09",
     "points": 162,
     "image": "attack-modifiers/CH/am-ch-09.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch09"
   },
   {
     "name": "am-ch-10",
     "points": 163,
     "image": "attack-modifiers/CH/am-ch-10.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch10"
   },
   {
     "name": "am-ch-11",
     "points": 164,
     "image": "attack-modifiers/CH/am-ch-11.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch11"
   },
   {
     "name": "am-ch-12",
     "points": 165,
     "image": "attack-modifiers/CH/am-ch-12.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch12"
   },
   {
     "name": "am-ch-13",
     "points": 166,
     "image": "attack-modifiers/CH/am-ch-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch13"
   },
   {
     "name": "am-ch-14",
     "points": 167,
     "image": "attack-modifiers/CH/am-ch-14.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch14"
   },
   {
     "name": "am-ch-15",
     "points": 168,
     "image": "attack-modifiers/CH/am-ch-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch15"
   },
   {
     "name": "am-ch-16",
     "points": 169,
     "image": "attack-modifiers/CH/am-ch-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch16"
   },
   {
     "name": "am-ch-17",
     "points": 170,
     "image": "attack-modifiers/CH/am-ch-17.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch17"
   },
   {
     "name": "am-ch-18",
     "points": 171,
     "image": "attack-modifiers/CH/am-ch-18.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch18"
   },
   {
     "name": "am-ds-01",
     "points": 172,
     "image": "attack-modifiers/DS/am-ds-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds01"
   },
   {
     "name": "am-ds-02",
     "points": 173,
     "image": "attack-modifiers/DS/am-ds-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds02"
   },
   {
     "name": "am-ds-03",
     "points": 174,
     "image": "attack-modifiers/DS/am-ds-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds03"
   },
   {
     "name": "am-ds-04",
     "points": 175,
     "image": "attack-modifiers/DS/am-ds-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds04"
   },
   {
     "name": "am-ds-05",
     "points": 176,
     "image": "attack-modifiers/DS/am-ds-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds05"
   },
   {
     "name": "am-ds-06",
     "points": 177,
     "image": "attack-modifiers/DS/am-ds-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds06"
   },
   {
     "name": "am-ds-07",
     "points": 178,
     "image": "attack-modifiers/DS/am-ds-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds07"
   },
   {
     "name": "am-ds-08",
     "points": 179,
     "image": "attack-modifiers/DS/am-ds-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds08"
   },
   {
     "name": "am-ds-09",
     "points": 180,
     "image": "attack-modifiers/DS/am-ds-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds09"
   },
   {
     "name": "am-ds-10",
     "points": 181,
     "image": "attack-modifiers/DS/am-ds-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds10"
   },
   {
     "name": "am-ds-11",
     "points": 182,
     "image": "attack-modifiers/DS/am-ds-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds11"
   },
   {
     "name": "am-ds-12",
     "points": 183,
     "image": "attack-modifiers/DS/am-ds-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds12"
   },
   {
     "name": "am-ds-13",
     "points": 184,
     "image": "attack-modifiers/DS/am-ds-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds13"
   },
   {
     "name": "am-ds-14",
     "points": 185,
     "image": "attack-modifiers/DS/am-ds-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds14"
   },
   {
     "name": "am-ds-15",
     "points": 186,
     "image": "attack-modifiers/DS/am-ds-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds15"
   },
   {
     "name": "am-ds-16",
     "points": 187,
     "image": "attack-modifiers/DS/am-ds-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds16"
   },
   {
     "name": "am-ds-17",
     "points": 188,
     "image": "attack-modifiers/DS/am-ds-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds17"
   },
   {
     "name": "am-el-01",
     "points": 189,
     "image": "attack-modifiers/EL/am-el-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel01"
   },
   {
     "name": "am-el-02",
     "points": 190,
     "image": "attack-modifiers/EL/am-el-02.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel02"
   },
   {
     "name": "am-el-03",
     "points": 191,
     "image": "attack-modifiers/EL/am-el-03.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel03"
   },
   {
     "name": "am-el-04",
     "points": 192,
     "image": "attack-modifiers/EL/am-el-04.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel04"
   },
   {
     "name": "am-el-05",
     "points": 193,
     "image": "attack-modifiers/EL/am-el-05.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel05"
   },
   {
     "name": "am-el-06",
     "points": 194,
     "image": "attack-modifiers/EL/am-el-06.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel06"
   },
   {
     "name": "am-el-07",
     "points": 195,
     "image": "attack-modifiers/EL/am-el-07.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel07"
   },
   {
     "name": "am-el-08",
     "points": 196,
     "image": "attack-modifiers/EL/am-el-08.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel08"
   },
   {
     "name": "am-el-09",
     "points": 197,
     "image": "attack-modifiers/EL/am-el-09.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel09"
   },
   {
     "name": "am-el-10",
     "points": 198,
     "image": "attack-modifiers/EL/am-el-10.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel10"
   },
   {
     "name": "am-el-11",
     "points": 199,
     "image": "attack-modifiers/EL/am-el-11.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel11"
   },
   {
     "name": "am-el-12",
     "points": 200,
     "image": "attack-modifiers/EL/am-el-12.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel12"
   },
   {
     "name": "am-el-13",
     "points": 201,
     "image": "attack-modifiers/EL/am-el-13.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel13"
   },
   {
     "name": "am-el-14",
     "points": 202,
     "image": "attack-modifiers/EL/am-el-14.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel14"
   },
   {
     "name": "am-el-15",
     "points": 203,
     "image": "attack-modifiers/EL/am-el-15.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel15"
   },
   {
     "name": "am-el-16",
     "points": 204,
     "image": "attack-modifiers/EL/am-el-16.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel16"
   },
   {
     "name": "am-el-17",
     "points": 205,
     "image": "attack-modifiers/EL/am-el-17.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel17"
   },
   {
     "name": "am-el-18",
     "points": 206,
     "image": "attack-modifiers/EL/am-el-18.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel18"
   },
   {
     "name": "am-el-19",
     "points": 207,
     "image": "attack-modifiers/EL/am-el-19.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel19"
   },
   {
     "name": "am-el-20",
     "points": 208,
     "image": "attack-modifiers/EL/am-el-20.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amel20"
   },
   {
     "name": "am-el-21",
     "points": 209,
     "image": "attack-modifiers/EL/am-el-21.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amel21"
   },
   {
     "name": "am-el-22",
     "points": 210,
     "image": "attack-modifiers/EL/am-el-22.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amel22"
   },
   {
     "name": "am-el-23",
     "points": 211,
     "image": "attack-modifiers/EL/am-el-23.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel23"
   },
   {
     "name": "am-el-24",
     "points": 212,
     "image": "attack-modifiers/EL/am-el-24.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel24"
   },
   {
     "name": "am-mt-01",
     "points": 213,
     "image": "attack-modifiers/MT/am-mt-01.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ammt01"
   },
   {
     "name": "am-mt-02",
     "points": 214,
     "image": "attack-modifiers/MT/am-mt-02.png",
+    "value": 2,
+    "conditions": [],
     "xws": "ammt02"
   },
   {
     "name": "am-mt-03",
     "points": 215,
     "image": "attack-modifiers/MT/am-mt-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ammt03"
   },
   {
     "name": "am-mt-04",
     "points": 216,
     "image": "attack-modifiers/MT/am-mt-04.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt04"
   },
   {
     "name": "am-mt-05",
     "points": 217,
     "image": "attack-modifiers/MT/am-mt-05.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt05"
   },
   {
     "name": "am-mt-06",
     "points": 218,
     "image": "attack-modifiers/MT/am-mt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt06"
   },
   {
     "name": "am-mt-07",
     "points": 219,
     "image": "attack-modifiers/MT/am-mt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt07"
   },
   {
     "name": "am-mt-08",
     "points": 220,
     "image": "attack-modifiers/MT/am-mt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt08"
   },
   {
     "name": "am-mt-09",
     "points": 221,
     "image": "attack-modifiers/MT/am-mt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt09"
   },
   {
     "name": "am-mt-10",
     "points": 222,
     "image": "attack-modifiers/MT/am-mt-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt10"
   },
   {
     "name": "am-mt-11",
     "points": 223,
     "image": "attack-modifiers/MT/am-mt-11.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt11"
   },
   {
     "name": "am-mt-12",
     "points": 224,
     "image": "attack-modifiers/MT/am-mt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt12"
   },
   {
     "name": "am-mt-13",
     "points": 225,
     "image": "attack-modifiers/MT/am-mt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt13"
   },
   {
     "name": "am-mt-14",
     "points": 226,
     "image": "attack-modifiers/MT/am-mt-14.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt14"
   },
   {
     "name": "am-mt-15",
     "points": 227,
     "image": "attack-modifiers/MT/am-mt-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt15"
   },
   {
     "name": "am-mt-16",
     "points": 228,
     "image": "attack-modifiers/MT/am-mt-16.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt16"
   },
   {
     "name": "am-mt-17",
     "points": 229,
     "image": "attack-modifiers/MT/am-mt-17.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt17"
   },
   {
     "name": "am-mt-18",
     "points": 230,
     "image": "attack-modifiers/MT/am-mt-18.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt18"
   },
   {
     "name": "am-mt-19",
     "points": 231,
     "image": "attack-modifiers/MT/am-mt-19.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ammt19"
   },
   {
     "name": "am-mt-20",
     "points": 232,
     "image": "attack-modifiers/MT/am-mt-20.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt20"
   },
   {
     "name": "am-ns-01",
     "points": 233,
     "image": "attack-modifiers/NS/am-ns-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns01"
   },
   {
     "name": "am-ns-02",
     "points": 234,
     "image": "attack-modifiers/NS/am-ns-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns02"
   },
   {
     "name": "am-ns-03",
     "points": 235,
     "image": "attack-modifiers/NS/am-ns-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns03"
   },
   {
     "name": "am-ns-04",
     "points": 236,
     "image": "attack-modifiers/NS/am-ns-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns04"
   },
   {
     "name": "am-ns-05",
     "points": 237,
     "image": "attack-modifiers/NS/am-ns-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns05"
   },
   {
     "name": "am-ns-06",
     "points": 238,
     "image": "attack-modifiers/NS/am-ns-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns06"
   },
   {
     "name": "am-ns-07",
     "points": 239,
     "image": "attack-modifiers/NS/am-ns-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns07"
   },
   {
     "name": "am-ns-08",
     "points": 240,
     "image": "attack-modifiers/NS/am-ns-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns08"
   },
   {
     "name": "am-ns-09",
     "points": 241,
     "image": "attack-modifiers/NS/am-ns-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns09"
   },
   {
     "name": "am-ns-10",
     "points": 242,
     "image": "attack-modifiers/NS/am-ns-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns10"
   },
   {
     "name": "am-ns-11",
     "points": 243,
     "image": "attack-modifiers/NS/am-ns-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns11"
   },
   {
     "name": "am-ns-12",
     "points": 244,
     "image": "attack-modifiers/NS/am-ns-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns12"
   },
   {
     "name": "am-ns-13",
     "points": 245,
     "image": "attack-modifiers/NS/am-ns-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns13"
   },
   {
     "name": "am-ns-14",
     "points": 246,
     "image": "attack-modifiers/NS/am-ns-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns14"
   },
   {
     "name": "am-ns-15",
     "points": 247,
     "image": "attack-modifiers/NS/am-ns-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns15"
   },
   {
     "name": "am-ns-16",
     "points": 248,
     "image": "attack-modifiers/NS/am-ns-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns16"
   },
   {
     "name": "am-ns-17",
     "points": 249,
     "image": "attack-modifiers/NS/am-ns-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns17"
   },
   {
     "name": "am-ns-18",
     "points": 250,
     "image": "attack-modifiers/NS/am-ns-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns18"
   },
   {
     "name": "am-ns-19",
     "points": 251,
     "image": "attack-modifiers/NS/am-ns-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns19"
   },
   {
     "name": "am-ph-01",
     "points": 252,
     "image": "attack-modifiers/PH/am-ph-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph01"
   },
   {
     "name": "am-ph-02",
     "points": 253,
     "image": "attack-modifiers/PH/am-ph-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph02"
   },
   {
     "name": "am-ph-03",
     "points": 254,
     "image": "attack-modifiers/PH/am-ph-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph03"
   },
   {
     "name": "am-ph-04",
     "points": 255,
     "image": "attack-modifiers/PH/am-ph-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph04"
   },
   {
     "name": "am-ph-05",
     "points": 256,
     "image": "attack-modifiers/PH/am-ph-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph05"
   },
   {
     "name": "am-ph-06",
     "points": 257,
     "image": "attack-modifiers/PH/am-ph-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph06"
   },
   {
     "name": "am-ph-07",
     "points": 258,
     "image": "attack-modifiers/PH/am-ph-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph07"
   },
   {
     "name": "am-ph-08",
     "points": 259,
     "image": "attack-modifiers/PH/am-ph-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph08"
   },
   {
     "name": "am-ph-09",
     "points": 260,
     "image": "attack-modifiers/PH/am-ph-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph09"
   },
   {
     "name": "am-ph-10",
     "points": 261,
     "image": "attack-modifiers/PH/am-ph-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph10"
   },
   {
     "name": "am-ph-11",
     "points": 262,
     "image": "attack-modifiers/PH/am-ph-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph11"
   },
   {
     "name": "am-ph-12",
     "points": 263,
     "image": "attack-modifiers/PH/am-ph-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph12"
   },
   {
     "name": "am-ph-13",
     "points": 264,
     "image": "attack-modifiers/PH/am-ph-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph13"
   },
   {
     "name": "am-ph-14",
     "points": 265,
     "image": "attack-modifiers/PH/am-ph-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph14"
   },
   {
     "name": "am-ph-15",
     "points": 266,
     "image": "attack-modifiers/PH/am-ph-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph15"
   },
   {
     "name": "am-ph-16",
     "points": 267,
     "image": "attack-modifiers/PH/am-ph-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph16"
   },
   {
     "name": "am-ph-17",
     "points": 268,
     "image": "attack-modifiers/PH/am-ph-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph17"
   },
   {
     "name": "am-ph-18",
     "points": 269,
     "image": "attack-modifiers/PH/am-ph-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph18"
   },
   {
     "name": "am-ph-19",
     "points": 270,
     "image": "attack-modifiers/PH/am-ph-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph19"
   },
   {
     "name": "am-ph-20",
     "points": 271,
     "image": "attack-modifiers/PH/am-ph-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph20"
   },
   {
     "name": "am-qm-01",
     "points": 272,
     "image": "attack-modifiers/QM/am-qm-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm01"
   },
   {
     "name": "am-qm-02",
     "points": 273,
     "image": "attack-modifiers/QM/am-qm-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm02"
   },
   {
     "name": "am-qm-03",
     "points": 274,
     "image": "attack-modifiers/QM/am-qm-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm03"
   },
   {
     "name": "am-qm-04",
     "points": 275,
     "image": "attack-modifiers/QM/am-qm-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm04"
   },
   {
     "name": "am-qm-05",
     "points": 276,
     "image": "attack-modifiers/QM/am-qm-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm05"
   },
   {
     "name": "am-qm-06",
     "points": 277,
     "image": "attack-modifiers/QM/am-qm-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm06"
   },
   {
     "name": "am-qm-07",
     "points": 278,
     "image": "attack-modifiers/QM/am-qm-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm07"
   },
   {
     "name": "am-qm-08",
     "points": 279,
     "image": "attack-modifiers/QM/am-qm-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm08"
   },
   {
     "name": "am-qm-09",
     "points": 280,
     "image": "attack-modifiers/QM/am-qm-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm09"
   },
   {
     "name": "am-qm-10",
     "points": 281,
     "image": "attack-modifiers/QM/am-qm-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm10"
   },
   {
     "name": "am-qm-11",
     "points": 282,
     "image": "attack-modifiers/QM/am-qm-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm11"
   },
   {
     "name": "am-qm-12",
     "points": 283,
     "image": "attack-modifiers/QM/am-qm-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm12"
   },
   {
     "name": "am-qm-13",
     "points": 284,
     "image": "attack-modifiers/QM/am-qm-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm13"
   },
   {
     "name": "am-qm-14",
     "points": 285,
     "image": "attack-modifiers/QM/am-qm-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm14"
   },
   {
     "name": "am-qm-15",
     "points": 286,
     "image": "attack-modifiers/QM/am-qm-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm15"
   },
   {
     "name": "am-qm-16",
     "points": 287,
     "image": "attack-modifiers/QM/am-qm-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm16"
   },
   {
     "name": "am-qm-17",
     "points": 288,
     "image": "attack-modifiers/QM/am-qm-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm17"
   },
   {
     "name": "am-qm-18",
     "points": 289,
     "image": "attack-modifiers/QM/am-qm-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm18"
   },
   {
     "name": "am-sb-01",
     "points": 290,
     "image": "attack-modifiers/SB/am-sb-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb01"
   },
   {
     "name": "am-sb-02",
     "points": 291,
     "image": "attack-modifiers/SB/am-sb-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb02"
   },
   {
     "name": "am-sb-03",
     "points": 292,
     "image": "attack-modifiers/SB/am-sb-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb03"
   },
   {
     "name": "am-sb-04",
     "points": 293,
     "image": "attack-modifiers/SB/am-sb-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb04"
   },
   {
     "name": "am-sb-05",
     "points": 294,
     "image": "attack-modifiers/SB/am-sb-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb05"
   },
   {
     "name": "am-sb-06",
     "points": 295,
     "image": "attack-modifiers/SB/am-sb-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb06"
   },
   {
     "name": "am-sb-07",
     "points": 296,
     "image": "attack-modifiers/SB/am-sb-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb07"
   },
   {
     "name": "am-sb-08",
     "points": 297,
     "image": "attack-modifiers/SB/am-sb-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb08"
   },
   {
     "name": "am-sb-09",
     "points": 298,
     "image": "attack-modifiers/SB/am-sb-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb09"
   },
   {
     "name": "am-sb-10",
     "points": 299,
     "image": "attack-modifiers/SB/am-sb-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb10"
   },
   {
     "name": "am-sb-11",
     "points": 300,
     "image": "attack-modifiers/SB/am-sb-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb11"
   },
   {
     "name": "am-sb-12",
     "points": 301,
     "image": "attack-modifiers/SB/am-sb-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb12"
   },
   {
     "name": "am-sb-13",
     "points": 302,
     "image": "attack-modifiers/SB/am-sb-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb13"
   },
   {
     "name": "am-sb-14",
     "points": 303,
     "image": "attack-modifiers/SB/am-sb-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb14"
   },
   {
     "name": "am-sc-01",
     "points": 304,
     "image": "attack-modifiers/SC/am-sc-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc01"
   },
   {
     "name": "am-sc-02",
     "points": 305,
     "image": "attack-modifiers/SC/am-sc-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc02"
   },
   {
     "name": "am-sc-03",
     "points": 306,
     "image": "attack-modifiers/SC/am-sc-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc03"
   },
   {
     "name": "am-sc-04",
     "points": 307,
     "image": "attack-modifiers/SC/am-sc-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc04"
   },
   {
     "name": "am-sc-05",
     "points": 308,
     "image": "attack-modifiers/SC/am-sc-05.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc05"
   },
   {
     "name": "am-sc-06",
     "points": 309,
     "image": "attack-modifiers/SC/am-sc-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc06"
   },
   {
     "name": "am-sc-07",
     "points": 310,
     "image": "attack-modifiers/SC/am-sc-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc07"
   },
   {
     "name": "am-sc-08",
     "points": 311,
     "image": "attack-modifiers/SC/am-sc-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc08"
   },
   {
     "name": "am-sc-09",
     "points": 312,
     "image": "attack-modifiers/SC/am-sc-09.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc09"
   },
   {
     "name": "am-sc-10",
     "points": 313,
     "image": "attack-modifiers/SC/am-sc-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc10"
   },
   {
     "name": "am-sc-11",
     "points": 314,
     "image": "attack-modifiers/SC/am-sc-11.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc11"
   },
   {
     "name": "am-sc-12",
     "points": 315,
     "image": "attack-modifiers/SC/am-sc-12.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc12"
   },
   {
     "name": "am-sc-13",
     "points": 316,
     "image": "attack-modifiers/SC/am-sc-13.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc13"
   },
   {
     "name": "am-sc-14",
     "points": 317,
     "image": "attack-modifiers/SC/am-sc-14.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc14"
   },
   {
     "name": "am-sc-15",
     "points": 318,
     "image": "attack-modifiers/SC/am-sc-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc15"
   },
   {
     "name": "am-sc-16",
     "points": 319,
     "image": "attack-modifiers/SC/am-sc-16.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc16"
   },
   {
     "name": "am-sc-17",
     "points": 320,
     "image": "attack-modifiers/SC/am-sc-17.png",
+    "value": "rolling",
+    "conditions": [
+      "invisible"
+    ],
     "xws": "amsc17"
   },
   {
     "name": "am-sk-01",
     "points": 321,
     "image": "attack-modifiers/SK/am-sk-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk01"
   },
   {
     "name": "am-sk-02",
     "points": 322,
     "image": "attack-modifiers/SK/am-sk-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk02"
   },
   {
     "name": "am-sk-03",
     "points": 323,
     "image": "attack-modifiers/SK/am-sk-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk03"
   },
   {
     "name": "am-sk-04",
     "points": 324,
     "image": "attack-modifiers/SK/am-sk-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk04"
   },
   {
     "name": "am-sk-05",
     "points": 325,
     "image": "attack-modifiers/SK/am-sk-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk05"
   },
   {
     "name": "am-sk-06",
     "points": 326,
     "image": "attack-modifiers/SK/am-sk-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk06"
   },
   {
     "name": "am-sk-07",
     "points": 327,
     "image": "attack-modifiers/SK/am-sk-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk07"
   },
   {
     "name": "am-sk-08",
     "points": 328,
     "image": "attack-modifiers/SK/am-sk-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk08"
   },
   {
     "name": "am-sk-09",
     "points": 329,
     "image": "attack-modifiers/SK/am-sk-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk09"
   },
   {
     "name": "am-sk-10",
     "points": 330,
     "image": "attack-modifiers/SK/am-sk-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk10"
   },
   {
     "name": "am-sk-11",
     "points": 331,
     "image": "attack-modifiers/SK/am-sk-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk11"
   },
   {
     "name": "am-sk-12",
     "points": 332,
     "image": "attack-modifiers/SK/am-sk-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk12"
   },
   {
     "name": "am-sk-13",
     "points": 333,
     "image": "attack-modifiers/SK/am-sk-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk13"
   },
   {
     "name": "am-sk-14",
     "points": 334,
     "image": "attack-modifiers/SK/am-sk-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk14"
   },
   {
     "name": "am-sk-15",
     "points": 335,
     "image": "attack-modifiers/SK/am-sk-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk15"
   },
   {
     "name": "am-sk-16",
     "points": 336,
     "image": "attack-modifiers/SK/am-sk-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk16"
   },
   {
     "name": "am-sk-17",
     "points": 337,
     "image": "attack-modifiers/SK/am-sk-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk17"
   },
   {
     "name": "am-sk-18",
     "points": 338,
     "image": "attack-modifiers/SK/am-sk-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk18"
   },
   {
     "name": "am-sk-19",
     "points": 339,
     "image": "attack-modifiers/SK/am-sk-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk19"
   },
   {
     "name": "am-ss-01",
     "points": 340,
     "image": "attack-modifiers/SS/am-ss-01.png",
+    "value": 0,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amss01"
   },
   {
     "name": "am-ss-02",
     "points": 341,
     "image": "attack-modifiers/SS/am-ss-02.png",
+    "value": 0,
+    "conditions": [
+      "disarm"
+    ],
     "xws": "amss02"
   },
   {
     "name": "am-ss-03",
     "points": 342,
     "image": "attack-modifiers/SS/am-ss-03.png",
+    "value": 0,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amss03"
   },
   {
     "name": "am-ss-04",
     "points": 343,
     "image": "attack-modifiers/SS/am-ss-04.png",
+    "value": 0,
+    "conditions": [
+      "poison"
+    ],
     "xws": "amss04"
   },
   {
     "name": "am-ss-05",
     "points": 344,
     "image": "attack-modifiers/SS/am-ss-05.png",
+    "value": 0,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss05"
   },
   {
     "name": "am-ss-06",
     "points": 345,
     "image": "attack-modifiers/SS/am-ss-06.png",
+    "value": 0,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amss06"
   },
   {
     "name": "am-ss-07",
     "points": 346,
     "image": "attack-modifiers/SS/am-ss-07.png",
+    "value": -1,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amss07"
   },
   {
     "name": "am-ss-08",
     "points": 347,
     "image": "attack-modifiers/SS/am-ss-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss08"
   },
   {
     "name": "am-ss-09",
     "points": 348,
     "image": "attack-modifiers/SS/am-ss-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss09"
   },
   {
     "name": "am-ss-10",
     "points": 349,
     "image": "attack-modifiers/SS/am-ss-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss10"
   },
   {
     "name": "am-ss-11",
     "points": 350,
     "image": "attack-modifiers/SS/am-ss-11.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss11"
   },
   {
     "name": "am-ss-12",
     "points": 351,
     "image": "attack-modifiers/SS/am-ss-12.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss12"
   },
   {
     "name": "am-ss-13",
     "points": 352,
     "image": "attack-modifiers/SS/am-ss-13.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss13"
   },
   {
     "name": "am-ss-14",
     "points": 353,
     "image": "attack-modifiers/SS/am-ss-14.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss14"
   },
   {
     "name": "am-ss-15",
     "points": 354,
     "image": "attack-modifiers/SS/am-ss-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss15"
   },
   {
     "name": "am-ss-16",
     "points": 355,
     "image": "attack-modifiers/SS/am-ss-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss16"
   },
   {
     "name": "am-su-01",
     "points": 356,
     "image": "attack-modifiers/SU/am-su-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu01"
   },
   {
     "name": "am-su-02",
     "points": 357,
     "image": "attack-modifiers/SU/am-su-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu02"
   },
   {
     "name": "am-su-03",
     "points": 358,
     "image": "attack-modifiers/SU/am-su-03.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu03"
   },
   {
     "name": "am-su-04",
     "points": 359,
     "image": "attack-modifiers/SU/am-su-04.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu04"
   },
   {
     "name": "am-su-05",
     "points": 360,
     "image": "attack-modifiers/SU/am-su-05.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu05"
   },
   {
     "name": "am-su-06",
     "points": 361,
     "image": "attack-modifiers/SU/am-su-06.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu06"
   },
   {
     "name": "am-su-07",
     "points": 362,
     "image": "attack-modifiers/SU/am-su-07.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu07"
   },
   {
     "name": "am-su-08",
     "points": 363,
     "image": "attack-modifiers/SU/am-su-08.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu08"
   },
   {
     "name": "am-su-09",
     "points": 364,
     "image": "attack-modifiers/SU/am-su-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu09"
   },
   {
     "name": "am-su-10",
     "points": 365,
     "image": "attack-modifiers/SU/am-su-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu10"
   },
   {
     "name": "am-su-11",
     "points": 366,
     "image": "attack-modifiers/SU/am-su-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu11"
   },
   {
     "name": "am-su-12",
     "points": 367,
     "image": "attack-modifiers/SU/am-su-12.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu12"
   },
   {
     "name": "am-su-13",
     "points": 368,
     "image": "attack-modifiers/SU/am-su-13.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu13"
   },
   {
     "name": "am-su-14",
     "points": 369,
     "image": "attack-modifiers/SU/am-su-14.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu14"
   },
   {
     "name": "am-su-15",
     "points": 370,
     "image": "attack-modifiers/SU/am-su-15.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu15"
   },
   {
     "name": "am-su-16",
     "points": 371,
     "image": "attack-modifiers/SU/am-su-16.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu16"
   },
   {
     "name": "am-su-17",
     "points": 372,
     "image": "attack-modifiers/SU/am-su-17.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu17"
   },
   {
     "name": "am-su-18",
     "points": 373,
     "image": "attack-modifiers/SU/am-su-18.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu18"
   },
   {
     "name": "am-su-19",
     "points": 374,
     "image": "attack-modifiers/SU/am-su-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu19"
   },
   {
     "name": "am-su-20",
     "points": 375,
     "image": "attack-modifiers/SU/am-su-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu20"
   },
   {
     "name": "am-su-21",
     "points": 376,
     "image": "attack-modifiers/SU/am-su-21.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu21"
   },
   {
     "name": "am-su-22",
     "points": 377,
     "image": "attack-modifiers/SU/am-su-22.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu22"
   },
   {
     "name": "am-sw-01",
     "points": 378,
     "image": "attack-modifiers/SW/am-sw-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw01"
   },
   {
     "name": "am-sw-02",
     "points": 379,
     "image": "attack-modifiers/SW/am-sw-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw02"
   },
   {
     "name": "am-sw-03",
     "points": 380,
     "image": "attack-modifiers/SW/am-sw-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw03"
   },
   {
     "name": "am-sw-04",
     "points": 381,
     "image": "attack-modifiers/SW/am-sw-04.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw04"
   },
   {
     "name": "am-sw-05",
     "points": 382,
     "image": "attack-modifiers/SW/am-sw-05.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw05"
   },
   {
     "name": "am-sw-06",
     "points": 383,
     "image": "attack-modifiers/SW/am-sw-06.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw06"
   },
   {
     "name": "am-sw-07",
     "points": 384,
     "image": "attack-modifiers/SW/am-sw-07.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amsw07"
   },
   {
     "name": "am-sw-08",
     "points": 385,
     "image": "attack-modifiers/SW/am-sw-08.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsw08"
   },
   {
     "name": "am-sw-09",
     "points": 386,
     "image": "attack-modifiers/SW/am-sw-09.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amsw09"
   },
   {
     "name": "am-sw-10",
     "points": 387,
     "image": "attack-modifiers/SW/am-sw-10.png",
+    "value": 1,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amsw10"
   },
   {
     "name": "am-sw-11",
     "points": 388,
     "image": "attack-modifiers/SW/am-sw-11.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw11"
   },
   {
     "name": "am-sw-12",
     "points": 389,
     "image": "attack-modifiers/SW/am-sw-12.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw12"
   },
   {
     "name": "am-sw-13",
     "points": 390,
     "image": "attack-modifiers/SW/am-sw-13.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw13"
   },
   {
     "name": "am-sw-14",
     "points": 391,
     "image": "attack-modifiers/SW/am-sw-14.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw14"
   },
   {
     "name": "am-sw-15",
     "points": 392,
     "image": "attack-modifiers/SW/am-sw-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw15"
   },
   {
     "name": "am-sw-16",
     "points": 393,
     "image": "attack-modifiers/SW/am-sw-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw16"
   },
   {
     "name": "am-sw-17",
     "points": 394,
     "image": "attack-modifiers/SW/am-sw-17.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw17"
   },
   {
     "name": "am-sw-18",
     "points": 395,
     "image": "attack-modifiers/SW/am-sw-18.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw18"
   },
   {
     "name": "am-ti-01",
     "points": 396,
     "image": "attack-modifiers/TI/am-ti-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amti01"
   },
   {
     "name": "am-ti-02",
     "points": 397,
     "image": "attack-modifiers/TI/am-ti-02.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti02"
   },
   {
     "name": "am-ti-03",
     "points": 398,
     "image": "attack-modifiers/TI/am-ti-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti03"
   },
   {
     "name": "am-ti-04",
     "points": 399,
     "image": "attack-modifiers/TI/am-ti-04.png",
+    "value": 3,
+    "conditions": [],
     "xws": "amti04"
   },
   {
     "name": "am-ti-05",
     "points": 400,
     "image": "attack-modifiers/TI/am-ti-05.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti05"
   },
   {
     "name": "am-ti-06",
     "points": 401,
     "image": "attack-modifiers/TI/am-ti-06.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti06"
   },
   {
     "name": "am-ti-07",
     "points": 402,
     "image": "attack-modifiers/TI/am-ti-07.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti07"
   },
   {
     "name": "am-ti-08",
     "points": 403,
     "image": "attack-modifiers/TI/am-ti-08.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti08"
   },
   {
     "name": "am-ti-09",
     "points": 404,
     "image": "attack-modifiers/TI/am-ti-09.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti09"
   },
   {
     "name": "am-ti-10",
     "points": 405,
     "image": "attack-modifiers/TI/am-ti-10.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti10"
   },
   {
     "name": "am-ti-11",
     "points": 406,
     "image": "attack-modifiers/TI/am-ti-11.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti11"
   },
   {
     "name": "am-ti-12",
     "points": 407,
     "image": "attack-modifiers/TI/am-ti-12.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti12"
   },
   {
     "name": "am-ti-13",
     "points": 408,
     "image": "attack-modifiers/TI/am-ti-13.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti13"
   },
   {
     "name": "am-ti-14",
     "points": 409,
     "image": "attack-modifiers/TI/am-ti-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti14"
   },
   {
     "name": "am-ti-15",
     "points": 410,
     "image": "attack-modifiers/TI/am-ti-15.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti15"
   },
   {
     "name": "am-ti-16",
     "points": 411,
     "image": "attack-modifiers/TI/am-ti-16.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amti16"
   },
   {
     "name": "am-dr-01",
     "points": 412,
     "image": "attack-modifiers/DR/am-dr-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr01"
   },
   {
     "name": "am-dr-02",
     "points": 413,
     "image": "attack-modifiers/DR/am-dr-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr02"
   },
   {
     "name": "am-dr-03",
     "points": 414,
     "image": "attack-modifiers/DR/am-dr-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr03"
   },
   {
     "name": "am-dr-04",
     "points": 415,
     "image": "attack-modifiers/DR/am-dr-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr04"
   },
   {
     "name": "am-dr-05",
     "points": 416,
     "image": "attack-modifiers/DR/am-dr-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr05"
   },
   {
     "name": "am-dr-06",
     "points": 417,
     "image": "attack-modifiers/DR/am-dr-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr06"
   },
   {
     "name": "am-dr-07",
     "points": 418,
     "image": "attack-modifiers/DR/am-dr-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr07"
   },
   {
     "name": "am-dr-08",
     "points": 419,
     "image": "attack-modifiers/DR/am-dr-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr08"
   },
   {
     "name": "am-dr-09",
     "points": 420,
     "image": "attack-modifiers/DR/am-dr-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr09"
   },
   {
     "name": "am-dr-10",
     "points": 421,
     "image": "attack-modifiers/DR/am-dr-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr10"
   },
   {
     "name": "am-dr-11",
     "points": 422,
     "image": "attack-modifiers/DR/am-dr-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr11"
   },
   {
     "name": "am-dr-12",
     "points": 423,
     "image": "attack-modifiers/DR/am-dr-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr12"
   },
   {
     "name": "am-dr-13",
     "points": 424,
     "image": "attack-modifiers/DR/am-dr-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr13"
   },
   {
     "name": "am-dr-14",
     "points": 425,
     "image": "attack-modifiers/DR/am-dr-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr14"
   },
   {
     "name": "am-dr-15",
     "points": 426,
     "image": "attack-modifiers/DR/am-dr-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr15"
   }
 ]

--- a/data/attackmodifiers.js
+++ b/data/attackmodifiers.js
@@ -3,2562 +3,3664 @@
     "name": "am-m-01",
     "points": 0,
     "image": "attack-modifiers/base/monster/am-m-01.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm01"
   },
   {
     "name": "am-m-02",
     "points": 1,
     "image": "attack-modifiers/base/monster/am-m-02.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm02"
   },
   {
     "name": "am-m-03",
     "points": 2,
     "image": "attack-modifiers/base/monster/am-m-03.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm03"
   },
   {
     "name": "am-m-04",
     "points": 3,
     "image": "attack-modifiers/base/monster/am-m-04.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm04"
   },
   {
     "name": "am-m-05",
     "points": 4,
     "image": "attack-modifiers/base/monster/am-m-05.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm05"
   },
   {
     "name": "am-m-06",
     "points": 5,
     "image": "attack-modifiers/base/monster/am-m-06.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm06"
   },
   {
     "name": "am-m-07",
     "points": 6,
     "image": "attack-modifiers/base/monster/am-m-07.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm07"
   },
   {
     "name": "am-m-08",
     "points": 7,
     "image": "attack-modifiers/base/monster/am-m-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm08"
   },
   {
     "name": "am-m-09",
     "points": 8,
     "image": "attack-modifiers/base/monster/am-m-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm09"
   },
   {
     "name": "am-m-10",
     "points": 9,
     "image": "attack-modifiers/base/monster/am-m-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm10"
   },
   {
     "name": "am-m-11",
     "points": 10,
     "image": "attack-modifiers/base/monster/am-m-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm11"
   },
   {
     "name": "am-m-12",
     "points": 11,
     "image": "attack-modifiers/base/monster/am-m-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm12"
   },
   {
     "name": "am-m-13",
     "points": 12,
     "image": "attack-modifiers/base/monster/am-m-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm13"
   },
   {
     "name": "am-m-14",
     "points": 13,
     "image": "attack-modifiers/base/monster/am-m-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm14"
   },
   {
     "name": "am-m-15",
     "points": 14,
     "image": "attack-modifiers/base/monster/am-m-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm15"
   },
   {
     "name": "am-m-16",
     "points": 15,
     "image": "attack-modifiers/base/monster/am-m-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm16"
   },
   {
     "name": "am-m-17",
     "points": 16,
     "image": "attack-modifiers/base/monster/am-m-17.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amm17"
   },
   {
     "name": "am-m-18",
     "points": 17,
     "image": "attack-modifiers/base/monster/am-m-18.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amm18"
   },
   {
     "name": "am-m-19",
     "points": 18,
     "image": "attack-modifiers/base/monster/am-m-19.png",
+    "value": "miss",
+    "conditions": [],
     "xws": "amm19"
   },
   {
     "name": "am-m-20",
     "points": 19,
     "image": "attack-modifiers/base/monster/am-m-20.png",
+    "value": "x2",
+    "conditions": [],
     "xws": "amm20"
   },
   {
     "name": "am-mm-01",
     "points": 20,
     "image": "attack-modifiers/base/monster-mod/am-mm-01.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm01"
   },
   {
     "name": "am-mm-02",
     "points": 21,
     "image": "attack-modifiers/base/monster-mod/am-mm-02.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm02"
   },
   {
     "name": "am-mm-03",
     "points": 22,
     "image": "attack-modifiers/base/monster-mod/am-mm-03.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm03"
   },
   {
     "name": "am-mm-04",
     "points": 23,
     "image": "attack-modifiers/base/monster-mod/am-mm-04.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm04"
   },
   {
     "name": "am-mm-05",
     "points": 24,
     "image": "attack-modifiers/base/monster-mod/am-mm-05.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm05"
   },
   {
     "name": "am-mm-06",
     "points": 25,
     "image": "attack-modifiers/base/monster-mod/am-mm-06.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm06"
   },
   {
     "name": "am-mm-07",
     "points": 26,
     "image": "attack-modifiers/base/monster-mod/am-mm-07.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm07"
   },
   {
     "name": "am-mm-08",
     "points": 27,
     "image": "attack-modifiers/base/monster-mod/am-mm-08.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm08"
   },
   {
     "name": "am-mm-09",
     "points": 28,
     "image": "attack-modifiers/base/monster-mod/am-mm-09.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm09"
   },
   {
     "name": "am-mm-10",
     "points": 29,
     "image": "attack-modifiers/base/monster-mod/am-mm-10.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm10"
   },
   {
     "name": "am-p-01",
     "points": 30,
     "image": "attack-modifiers/base/player/am-p-01.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp01"
   },
   {
     "name": "am-p-02",
     "points": 31,
     "image": "attack-modifiers/base/player/am-p-02.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp02"
   },
   {
     "name": "am-p-03",
     "points": 32,
     "image": "attack-modifiers/base/player/am-p-03.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp03"
   },
   {
     "name": "am-p-04",
     "points": 33,
     "image": "attack-modifiers/base/player/am-p-04.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp04"
   },
   {
     "name": "am-p-05",
     "points": 34,
     "image": "attack-modifiers/base/player/am-p-05.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp05"
   },
   {
     "name": "am-p-06",
     "points": 35,
     "image": "attack-modifiers/base/player/am-p-06.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp06"
   },
   {
     "name": "am-p-07",
     "points": 36,
     "image": "attack-modifiers/base/player/am-p-07.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp07"
   },
   {
     "name": "am-p-08",
     "points": 37,
     "image": "attack-modifiers/base/player/am-p-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp08"
   },
   {
     "name": "am-p-09",
     "points": 38,
     "image": "attack-modifiers/base/player/am-p-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp09"
   },
   {
     "name": "am-p-10",
     "points": 39,
     "image": "attack-modifiers/base/player/am-p-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp10"
   },
   {
     "name": "am-p-11",
     "points": 40,
     "image": "attack-modifiers/base/player/am-p-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp11"
   },
   {
     "name": "am-p-12",
     "points": 41,
     "image": "attack-modifiers/base/player/am-p-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp12"
   },
   {
     "name": "am-p-13",
     "points": 42,
     "image": "attack-modifiers/base/player/am-p-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp13"
   },
   {
     "name": "am-p-14",
     "points": 43,
     "image": "attack-modifiers/base/player/am-p-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp14"
   },
   {
     "name": "am-p-15",
     "points": 44,
     "image": "attack-modifiers/base/player/am-p-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp15"
   },
   {
     "name": "am-p-16",
     "points": 45,
     "image": "attack-modifiers/base/player/am-p-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp16"
   },
   {
     "name": "am-p-17",
     "points": 46,
     "image": "attack-modifiers/base/player/am-p-17.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amp17"
   },
   {
     "name": "am-p-18",
     "points": 47,
     "image": "attack-modifiers/base/player/am-p-18.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amp18"
   },
   {
     "name": "am-p-19",
     "points": 48,
     "image": "attack-modifiers/base/player/am-p-19.png",
+    "value": "miss",
+    "conditions": [],
     "xws": "amp19"
   },
   {
     "name": "am-p-20",
     "points": 49,
     "image": "attack-modifiers/base/player/am-p-20.png",
+    "value": "x2",
+    "conditions": [],
     "xws": "amp20"
   },
   {
     "name": "am-pm-01",
     "points": 50,
     "image": "attack-modifiers/base/player-mod/am-pm-01.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm01"
   },
   {
     "name": "am-pm-02",
     "points": 51,
     "image": "attack-modifiers/base/player-mod/am-pm-02.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm02"
   },
   {
     "name": "am-pm-03",
     "points": 52,
     "image": "attack-modifiers/base/player-mod/am-pm-03.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm03"
   },
   {
     "name": "am-pm-04",
     "points": 53,
     "image": "attack-modifiers/base/player-mod/am-pm-04.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm04"
   },
   {
     "name": "am-pm-05",
     "points": 54,
     "image": "attack-modifiers/base/player-mod/am-pm-05.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm05"
   },
   {
     "name": "am-pm-06",
     "points": 55,
     "image": "attack-modifiers/base/player-mod/am-pm-06.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm06"
   },
   {
     "name": "am-pm-07",
     "points": 56,
     "image": "attack-modifiers/base/player-mod/am-pm-07.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm07"
   },
   {
     "name": "am-pm-08",
     "points": 57,
     "image": "attack-modifiers/base/player-mod/am-pm-08.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm08"
   },
   {
     "name": "am-pm-09",
     "points": 58,
     "image": "attack-modifiers/base/player-mod/am-pm-09.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm09"
   },
   {
     "name": "am-pm-10",
     "points": 59,
     "image": "attack-modifiers/base/player-mod/am-pm-10.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm10"
   },
   {
     "name": "am-pm-11",
     "points": 60,
     "image": "attack-modifiers/base/player-mod/am-pm-11.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm11"
   },
   {
     "name": "am-pm-12",
     "points": 61,
     "image": "attack-modifiers/base/player-mod/am-pm-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm12"
   },
   {
     "name": "am-pm-13",
     "points": 62,
     "image": "attack-modifiers/base/player-mod/am-pm-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm13"
   },
   {
     "name": "am-pm-14",
     "points": 63,
     "image": "attack-modifiers/base/player-mod/am-pm-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm14"
   },
   {
     "name": "am-pm-15",
     "points": 64,
     "image": "attack-modifiers/base/player-mod/am-pm-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm15"
   },
   {
     "name": "am-pm-16",
     "points": 65,
     "image": "attack-modifiers/base/player-mod/am-pm-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm16"
   },
   {
     "name": "am-pm-17",
     "points": 66,
     "image": "attack-modifiers/base/player-mod/am-pm-17.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm17"
   },
   {
     "name": "am-pm-18",
     "points": 67,
     "image": "attack-modifiers/base/player-mod/am-pm-18.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm18"
   },
   {
     "name": "am-pm-19",
     "points": 68,
     "image": "attack-modifiers/base/player-mod/am-pm-19.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm19"
   },
   {
     "name": "am-pm-20",
     "points": 69,
     "image": "attack-modifiers/base/player-mod/am-pm-20.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm20"
   },
   {
     "name": "am-pm-21",
     "points": 70,
     "image": "attack-modifiers/base/player-mod/am-pm-21.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm21"
   },
   {
     "name": "am-pm-22",
     "points": 71,
     "image": "attack-modifiers/base/player-mod/am-pm-22.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm22"
   },
   {
     "name": "am-pm-23",
     "points": 72,
     "image": "attack-modifiers/base/player-mod/am-pm-23.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm23"
   },
   {
     "name": "am-pm-24",
     "points": 73,
     "image": "attack-modifiers/base/player-mod/am-pm-24.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm24"
   },
   {
     "name": "am-pm-25",
     "points": 74,
     "image": "attack-modifiers/base/player-mod/am-pm-25.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm25"
   },
   {
     "name": "am-pm-26",
     "points": 75,
     "image": "attack-modifiers/base/player-mod/am-pm-26.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm26"
   },
   {
     "name": "am-pm-27",
     "points": 76,
     "image": "attack-modifiers/base/player-mod/am-pm-27.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm27"
   },
   {
     "name": "am-pm-28",
     "points": 77,
     "image": "attack-modifiers/base/player-mod/am-pm-28.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm28"
   },
   {
     "name": "am-pm-29",
     "points": 78,
     "image": "attack-modifiers/base/player-mod/am-pm-29.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm29"
   },
   {
     "name": "am-pm-30",
     "points": 79,
     "image": "attack-modifiers/base/player-mod/am-pm-30.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm30"
   },
   {
     "name": "am-pm-31",
     "points": 80,
     "image": "attack-modifiers/base/player-mod/am-pm-31.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm31"
   },
   {
     "name": "am-pm-32",
     "points": 81,
     "image": "attack-modifiers/base/player-mod/am-pm-32.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm32"
   },
   {
     "name": "am-pm-33",
     "points": 82,
     "image": "attack-modifiers/base/player-mod/am-pm-33.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm33"
   },
   {
     "name": "am-pm-34",
     "points": 83,
     "image": "attack-modifiers/base/player-mod/am-pm-34.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm34"
   },
   {
     "name": "am-pm-35",
     "points": 84,
     "image": "attack-modifiers/base/player-mod/am-pm-35.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm35"
   },
   {
     "name": "am-be-01",
     "points": 85,
     "image": "attack-modifiers/BE/am-be-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe01"
   },
   {
     "name": "am-be-02",
     "points": 86,
     "image": "attack-modifiers/BE/am-be-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe02"
   },
   {
     "name": "am-be-03",
     "points": 87,
     "image": "attack-modifiers/BE/am-be-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe03"
   },
   {
     "name": "am-be-04",
     "points": 88,
     "image": "attack-modifiers/BE/am-be-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe04"
   },
   {
     "name": "am-be-05",
     "points": 89,
     "image": "attack-modifiers/BE/am-be-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe05"
   },
   {
     "name": "am-be-06",
     "points": 90,
     "image": "attack-modifiers/BE/am-be-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe06"
   },
   {
     "name": "am-be-07",
     "points": 91,
     "image": "attack-modifiers/BE/am-be-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe07"
   },
   {
     "name": "am-be-08",
     "points": 92,
     "image": "attack-modifiers/BE/am-be-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe08"
   },
   {
     "name": "am-be-09",
     "points": 93,
     "image": "attack-modifiers/BE/am-be-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe09"
   },
   {
     "name": "am-be-10",
     "points": 94,
     "image": "attack-modifiers/BE/am-be-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe10"
   },
   {
     "name": "am-be-11",
     "points": 95,
     "image": "attack-modifiers/BE/am-be-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe11"
   },
   {
     "name": "am-be-12",
     "points": 96,
     "image": "attack-modifiers/BE/am-be-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe12"
   },
   {
     "name": "am-be-13",
     "points": 97,
     "image": "attack-modifiers/BE/am-be-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe13"
   },
   {
     "name": "am-be-14",
     "points": 98,
     "image": "attack-modifiers/BE/am-be-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe14"
   },
   {
     "name": "am-be-15",
     "points": 99,
     "image": "attack-modifiers/BE/am-be-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe15"
   },
   {
     "name": "am-br-01",
     "points": 100,
     "image": "attack-modifiers/BR/am-br-01.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr01"
   },
   {
     "name": "am-br-02",
     "points": 101,
     "image": "attack-modifiers/BR/am-br-02.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr02"
   },
   {
     "name": "am-br-03",
     "points": 102,
     "image": "attack-modifiers/BR/am-br-03.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr03"
   },
   {
     "name": "am-br-04",
     "points": 103,
     "image": "attack-modifiers/BR/am-br-04.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr04"
   },
   {
     "name": "am-br-05",
     "points": 104,
     "image": "attack-modifiers/BR/am-br-05.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr05"
   },
   {
     "name": "am-br-06",
     "points": 105,
     "image": "attack-modifiers/BR/am-br-06.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr06"
   },
   {
     "name": "am-br-07",
     "points": 106,
     "image": "attack-modifiers/BR/am-br-07.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr07"
   },
   {
     "name": "am-br-08",
     "points": 107,
     "image": "attack-modifiers/BR/am-br-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr08"
   },
   {
     "name": "am-br-09",
     "points": 108,
     "image": "attack-modifiers/BR/am-br-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr09"
   },
   {
     "name": "am-br-10",
     "points": 109,
     "image": "attack-modifiers/BR/am-br-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr10"
   },
   {
     "name": "am-br-11",
     "points": 110,
     "image": "attack-modifiers/BR/am-br-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr11"
   },
   {
     "name": "am-br-12",
     "points": 111,
     "image": "attack-modifiers/BR/am-br-12.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr12"
   },
   {
     "name": "am-br-13",
     "points": 112,
     "image": "attack-modifiers/BR/am-br-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambr13"
   },
   {
     "name": "am-br-14",
     "points": 113,
     "image": "attack-modifiers/BR/am-br-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr14"
   },
   {
     "name": "am-br-15",
     "points": 114,
     "image": "attack-modifiers/BR/am-br-15.png",
+    "value": 3,
+    "conditions": [],
     "xws": "ambr15"
   },
   {
     "name": "am-br-16",
     "points": 115,
     "image": "attack-modifiers/BR/am-br-16.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr16"
   },
   {
     "name": "am-br-17",
     "points": 116,
     "image": "attack-modifiers/BR/am-br-17.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr17"
   },
   {
     "name": "am-br-18",
     "points": 117,
     "image": "attack-modifiers/BR/am-br-18.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr18"
   },
   {
     "name": "am-br-19",
     "points": 118,
     "image": "attack-modifiers/BR/am-br-19.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr19"
   },
   {
     "name": "am-br-20",
     "points": 119,
     "image": "attack-modifiers/BR/am-br-20.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr20"
   },
   {
     "name": "am-br-21",
     "points": 120,
     "image": "attack-modifiers/BR/am-br-21.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr21"
   },
   {
     "name": "am-br-22",
     "points": 121,
     "image": "attack-modifiers/BR/am-br-22.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr22"
   },
   {
     "name": "am-bs-01",
     "points": 122,
     "image": "attack-modifiers/BS/am-bs-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs01"
   },
   {
     "name": "am-bs-02",
     "points": 123,
     "image": "attack-modifiers/BS/am-bs-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs02"
   },
   {
     "name": "am-bs-03",
     "points": 124,
     "image": "attack-modifiers/BS/am-bs-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs03"
   },
   {
     "name": "am-bs-04",
     "points": 125,
     "image": "attack-modifiers/BS/am-bs-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs04"
   },
   {
     "name": "am-bs-05",
     "points": 126,
     "image": "attack-modifiers/BS/am-bs-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs05"
   },
   {
     "name": "am-bs-06",
     "points": 127,
     "image": "attack-modifiers/BS/am-bs-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs06"
   },
   {
     "name": "am-bs-07",
     "points": 128,
     "image": "attack-modifiers/BS/am-bs-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs07"
   },
   {
     "name": "am-bs-08",
     "points": 129,
     "image": "attack-modifiers/BS/am-bs-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs08"
   },
   {
     "name": "am-bs-09",
     "points": 130,
     "image": "attack-modifiers/BS/am-bs-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs09"
   },
   {
     "name": "am-bs-10",
     "points": 131,
     "image": "attack-modifiers/BS/am-bs-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs10"
   },
   {
     "name": "am-bs-11",
     "points": 132,
     "image": "attack-modifiers/BS/am-bs-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs11"
   },
   {
     "name": "am-bs-12",
     "points": 133,
     "image": "attack-modifiers/BS/am-bs-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs12"
   },
   {
     "name": "am-bs-13",
     "points": 134,
     "image": "attack-modifiers/BS/am-bs-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs13"
   },
   {
     "name": "am-bs-14",
     "points": 135,
     "image": "attack-modifiers/BS/am-bs-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs14"
   },
   {
     "name": "am-bs-15",
     "points": 136,
     "image": "attack-modifiers/BS/am-bs-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs15"
   },
   {
     "name": "am-bt-01",
     "points": 137,
     "image": "attack-modifiers/BT/am-bt-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt01"
   },
   {
     "name": "am-bt-02",
     "points": 138,
     "image": "attack-modifiers/BT/am-bt-02.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt02"
   },
   {
     "name": "am-bt-03",
     "points": 139,
     "image": "attack-modifiers/BT/am-bt-03.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt03"
   },
   {
     "name": "am-bt-04",
     "points": 140,
     "image": "attack-modifiers/BT/am-bt-04.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt04"
   },
   {
     "name": "am-bt-05",
     "points": 141,
     "image": "attack-modifiers/BT/am-bt-05.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt05"
   },
   {
     "name": "am-bt-06",
     "points": 142,
     "image": "attack-modifiers/BT/am-bt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt06"
   },
   {
     "name": "am-bt-07",
     "points": 143,
     "image": "attack-modifiers/BT/am-bt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt07"
   },
   {
     "name": "am-bt-08",
     "points": 144,
     "image": "attack-modifiers/BT/am-bt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt08"
   },
   {
     "name": "am-bt-09",
     "points": 145,
     "image": "attack-modifiers/BT/am-bt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt09"
   },
   {
     "name": "am-bt-10",
     "points": 146,
     "image": "attack-modifiers/BT/am-bt-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt10"
   },
   {
     "name": "am-bt-11",
     "points": 147,
     "image": "attack-modifiers/BT/am-bt-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt11"
   },
   {
     "name": "am-bt-12",
     "points": 148,
     "image": "attack-modifiers/BT/am-bt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt12"
   },
   {
     "name": "am-bt-13",
     "points": 149,
     "image": "attack-modifiers/BT/am-bt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt13"
   },
   {
     "name": "am-bt-14",
     "points": 150,
     "image": "attack-modifiers/BT/am-bt-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt14"
   },
   {
     "name": "am-bt-15",
     "points": 151,
     "image": "attack-modifiers/BT/am-bt-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt15"
   },
   {
     "name": "am-bt-16",
     "points": 152,
     "image": "attack-modifiers/BT/am-bt-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt16"
   },
   {
     "name": "am-bt-17",
     "points": 153,
     "image": "attack-modifiers/BT/am-bt-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt17"
   },
   {
     "name": "am-ch-01",
     "points": 154,
     "image": "attack-modifiers/CH/am-ch-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch01"
   },
   {
     "name": "am-ch-02",
     "points": 155,
     "image": "attack-modifiers/CH/am-ch-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch02"
   },
   {
     "name": "am-ch-03",
     "points": 156,
     "image": "attack-modifiers/CH/am-ch-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch03"
   },
   {
     "name": "am-ch-04",
     "points": 157,
     "image": "attack-modifiers/CH/am-ch-04.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amch04"
   },
   {
     "name": "am-ch-05",
     "points": 158,
     "image": "attack-modifiers/CH/am-ch-05.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch05"
   },
   {
     "name": "am-ch-06",
     "points": 159,
     "image": "attack-modifiers/CH/am-ch-06.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch06"
   },
   {
     "name": "am-ch-07",
     "points": 160,
     "image": "attack-modifiers/CH/am-ch-07.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch07"
   },
   {
     "name": "am-ch-08",
     "points": 161,
     "image": "attack-modifiers/CH/am-ch-08.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch08"
   },
   {
     "name": "am-ch-09",
     "points": 162,
     "image": "attack-modifiers/CH/am-ch-09.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch09"
   },
   {
     "name": "am-ch-10",
     "points": 163,
     "image": "attack-modifiers/CH/am-ch-10.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch10"
   },
   {
     "name": "am-ch-11",
     "points": 164,
     "image": "attack-modifiers/CH/am-ch-11.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch11"
   },
   {
     "name": "am-ch-12",
     "points": 165,
     "image": "attack-modifiers/CH/am-ch-12.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch12"
   },
   {
     "name": "am-ch-13",
     "points": 166,
     "image": "attack-modifiers/CH/am-ch-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch13"
   },
   {
     "name": "am-ch-14",
     "points": 167,
     "image": "attack-modifiers/CH/am-ch-14.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch14"
   },
   {
     "name": "am-ch-15",
     "points": 168,
     "image": "attack-modifiers/CH/am-ch-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch15"
   },
   {
     "name": "am-ch-16",
     "points": 169,
     "image": "attack-modifiers/CH/am-ch-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch16"
   },
   {
     "name": "am-ch-17",
     "points": 170,
     "image": "attack-modifiers/CH/am-ch-17.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch17"
   },
   {
     "name": "am-ch-18",
     "points": 171,
     "image": "attack-modifiers/CH/am-ch-18.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch18"
   },
   {
     "name": "am-ds-01",
     "points": 172,
     "image": "attack-modifiers/DS/am-ds-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds01"
   },
   {
     "name": "am-ds-02",
     "points": 173,
     "image": "attack-modifiers/DS/am-ds-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds02"
   },
   {
     "name": "am-ds-03",
     "points": 174,
     "image": "attack-modifiers/DS/am-ds-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds03"
   },
   {
     "name": "am-ds-04",
     "points": 175,
     "image": "attack-modifiers/DS/am-ds-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds04"
   },
   {
     "name": "am-ds-05",
     "points": 176,
     "image": "attack-modifiers/DS/am-ds-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds05"
   },
   {
     "name": "am-ds-06",
     "points": 177,
     "image": "attack-modifiers/DS/am-ds-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds06"
   },
   {
     "name": "am-ds-07",
     "points": 178,
     "image": "attack-modifiers/DS/am-ds-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds07"
   },
   {
     "name": "am-ds-08",
     "points": 179,
     "image": "attack-modifiers/DS/am-ds-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds08"
   },
   {
     "name": "am-ds-09",
     "points": 180,
     "image": "attack-modifiers/DS/am-ds-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds09"
   },
   {
     "name": "am-ds-10",
     "points": 181,
     "image": "attack-modifiers/DS/am-ds-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds10"
   },
   {
     "name": "am-ds-11",
     "points": 182,
     "image": "attack-modifiers/DS/am-ds-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds11"
   },
   {
     "name": "am-ds-12",
     "points": 183,
     "image": "attack-modifiers/DS/am-ds-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds12"
   },
   {
     "name": "am-ds-13",
     "points": 184,
     "image": "attack-modifiers/DS/am-ds-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds13"
   },
   {
     "name": "am-ds-14",
     "points": 185,
     "image": "attack-modifiers/DS/am-ds-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds14"
   },
   {
     "name": "am-ds-15",
     "points": 186,
     "image": "attack-modifiers/DS/am-ds-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds15"
   },
   {
     "name": "am-ds-16",
     "points": 187,
     "image": "attack-modifiers/DS/am-ds-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds16"
   },
   {
     "name": "am-ds-17",
     "points": 188,
     "image": "attack-modifiers/DS/am-ds-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds17"
   },
   {
     "name": "am-el-01",
     "points": 189,
     "image": "attack-modifiers/EL/am-el-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel01"
   },
   {
     "name": "am-el-02",
     "points": 190,
     "image": "attack-modifiers/EL/am-el-02.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel02"
   },
   {
     "name": "am-el-03",
     "points": 191,
     "image": "attack-modifiers/EL/am-el-03.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel03"
   },
   {
     "name": "am-el-04",
     "points": 192,
     "image": "attack-modifiers/EL/am-el-04.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel04"
   },
   {
     "name": "am-el-05",
     "points": 193,
     "image": "attack-modifiers/EL/am-el-05.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel05"
   },
   {
     "name": "am-el-06",
     "points": 194,
     "image": "attack-modifiers/EL/am-el-06.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel06"
   },
   {
     "name": "am-el-07",
     "points": 195,
     "image": "attack-modifiers/EL/am-el-07.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel07"
   },
   {
     "name": "am-el-08",
     "points": 196,
     "image": "attack-modifiers/EL/am-el-08.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel08"
   },
   {
     "name": "am-el-09",
     "points": 197,
     "image": "attack-modifiers/EL/am-el-09.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel09"
   },
   {
     "name": "am-el-10",
     "points": 198,
     "image": "attack-modifiers/EL/am-el-10.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel10"
   },
   {
     "name": "am-el-11",
     "points": 199,
     "image": "attack-modifiers/EL/am-el-11.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel11"
   },
   {
     "name": "am-el-12",
     "points": 200,
     "image": "attack-modifiers/EL/am-el-12.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel12"
   },
   {
     "name": "am-el-13",
     "points": 201,
     "image": "attack-modifiers/EL/am-el-13.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel13"
   },
   {
     "name": "am-el-14",
     "points": 202,
     "image": "attack-modifiers/EL/am-el-14.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel14"
   },
   {
     "name": "am-el-15",
     "points": 203,
     "image": "attack-modifiers/EL/am-el-15.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel15"
   },
   {
     "name": "am-el-16",
     "points": 204,
     "image": "attack-modifiers/EL/am-el-16.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel16"
   },
   {
     "name": "am-el-17",
     "points": 205,
     "image": "attack-modifiers/EL/am-el-17.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel17"
   },
   {
     "name": "am-el-18",
     "points": 206,
     "image": "attack-modifiers/EL/am-el-18.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel18"
   },
   {
     "name": "am-el-19",
     "points": 207,
     "image": "attack-modifiers/EL/am-el-19.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel19"
   },
   {
     "name": "am-el-20",
     "points": 208,
     "image": "attack-modifiers/EL/am-el-20.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amel20"
   },
   {
     "name": "am-el-21",
     "points": 209,
     "image": "attack-modifiers/EL/am-el-21.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amel21"
   },
   {
     "name": "am-el-22",
     "points": 210,
     "image": "attack-modifiers/EL/am-el-22.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amel22"
   },
   {
     "name": "am-el-23",
     "points": 211,
     "image": "attack-modifiers/EL/am-el-23.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel23"
   },
   {
     "name": "am-el-24",
     "points": 212,
     "image": "attack-modifiers/EL/am-el-24.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel24"
   },
   {
     "name": "am-mt-01",
     "points": 213,
     "image": "attack-modifiers/MT/am-mt-01.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ammt01"
   },
   {
     "name": "am-mt-02",
     "points": 214,
     "image": "attack-modifiers/MT/am-mt-02.png",
+    "value": 2,
+    "conditions": [],
     "xws": "ammt02"
   },
   {
     "name": "am-mt-03",
     "points": 215,
     "image": "attack-modifiers/MT/am-mt-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ammt03"
   },
   {
     "name": "am-mt-04",
     "points": 216,
     "image": "attack-modifiers/MT/am-mt-04.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt04"
   },
   {
     "name": "am-mt-05",
     "points": 217,
     "image": "attack-modifiers/MT/am-mt-05.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt05"
   },
   {
     "name": "am-mt-06",
     "points": 218,
     "image": "attack-modifiers/MT/am-mt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt06"
   },
   {
     "name": "am-mt-07",
     "points": 219,
     "image": "attack-modifiers/MT/am-mt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt07"
   },
   {
     "name": "am-mt-08",
     "points": 220,
     "image": "attack-modifiers/MT/am-mt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt08"
   },
   {
     "name": "am-mt-09",
     "points": 221,
     "image": "attack-modifiers/MT/am-mt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt09"
   },
   {
     "name": "am-mt-10",
     "points": 222,
     "image": "attack-modifiers/MT/am-mt-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt10"
   },
   {
     "name": "am-mt-11",
     "points": 223,
     "image": "attack-modifiers/MT/am-mt-11.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt11"
   },
   {
     "name": "am-mt-12",
     "points": 224,
     "image": "attack-modifiers/MT/am-mt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt12"
   },
   {
     "name": "am-mt-13",
     "points": 225,
     "image": "attack-modifiers/MT/am-mt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt13"
   },
   {
     "name": "am-mt-14",
     "points": 226,
     "image": "attack-modifiers/MT/am-mt-14.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt14"
   },
   {
     "name": "am-mt-15",
     "points": 227,
     "image": "attack-modifiers/MT/am-mt-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt15"
   },
   {
     "name": "am-mt-16",
     "points": 228,
     "image": "attack-modifiers/MT/am-mt-16.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt16"
   },
   {
     "name": "am-mt-17",
     "points": 229,
     "image": "attack-modifiers/MT/am-mt-17.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt17"
   },
   {
     "name": "am-mt-18",
     "points": 230,
     "image": "attack-modifiers/MT/am-mt-18.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt18"
   },
   {
     "name": "am-mt-19",
     "points": 231,
     "image": "attack-modifiers/MT/am-mt-19.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ammt19"
   },
   {
     "name": "am-mt-20",
     "points": 232,
     "image": "attack-modifiers/MT/am-mt-20.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt20"
   },
   {
     "name": "am-ns-01",
     "points": 233,
     "image": "attack-modifiers/NS/am-ns-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns01"
   },
   {
     "name": "am-ns-02",
     "points": 234,
     "image": "attack-modifiers/NS/am-ns-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns02"
   },
   {
     "name": "am-ns-03",
     "points": 235,
     "image": "attack-modifiers/NS/am-ns-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns03"
   },
   {
     "name": "am-ns-04",
     "points": 236,
     "image": "attack-modifiers/NS/am-ns-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns04"
   },
   {
     "name": "am-ns-05",
     "points": 237,
     "image": "attack-modifiers/NS/am-ns-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns05"
   },
   {
     "name": "am-ns-06",
     "points": 238,
     "image": "attack-modifiers/NS/am-ns-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns06"
   },
   {
     "name": "am-ns-07",
     "points": 239,
     "image": "attack-modifiers/NS/am-ns-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns07"
   },
   {
     "name": "am-ns-08",
     "points": 240,
     "image": "attack-modifiers/NS/am-ns-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns08"
   },
   {
     "name": "am-ns-09",
     "points": 241,
     "image": "attack-modifiers/NS/am-ns-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns09"
   },
   {
     "name": "am-ns-10",
     "points": 242,
     "image": "attack-modifiers/NS/am-ns-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns10"
   },
   {
     "name": "am-ns-11",
     "points": 243,
     "image": "attack-modifiers/NS/am-ns-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns11"
   },
   {
     "name": "am-ns-12",
     "points": 244,
     "image": "attack-modifiers/NS/am-ns-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns12"
   },
   {
     "name": "am-ns-13",
     "points": 245,
     "image": "attack-modifiers/NS/am-ns-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns13"
   },
   {
     "name": "am-ns-14",
     "points": 246,
     "image": "attack-modifiers/NS/am-ns-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns14"
   },
   {
     "name": "am-ns-15",
     "points": 247,
     "image": "attack-modifiers/NS/am-ns-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns15"
   },
   {
     "name": "am-ns-16",
     "points": 248,
     "image": "attack-modifiers/NS/am-ns-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns16"
   },
   {
     "name": "am-ns-17",
     "points": 249,
     "image": "attack-modifiers/NS/am-ns-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns17"
   },
   {
     "name": "am-ns-18",
     "points": 250,
     "image": "attack-modifiers/NS/am-ns-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns18"
   },
   {
     "name": "am-ns-19",
     "points": 251,
     "image": "attack-modifiers/NS/am-ns-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns19"
   },
   {
     "name": "am-ph-01",
     "points": 252,
     "image": "attack-modifiers/PH/am-ph-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph01"
   },
   {
     "name": "am-ph-02",
     "points": 253,
     "image": "attack-modifiers/PH/am-ph-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph02"
   },
   {
     "name": "am-ph-03",
     "points": 254,
     "image": "attack-modifiers/PH/am-ph-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph03"
   },
   {
     "name": "am-ph-04",
     "points": 255,
     "image": "attack-modifiers/PH/am-ph-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph04"
   },
   {
     "name": "am-ph-05",
     "points": 256,
     "image": "attack-modifiers/PH/am-ph-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph05"
   },
   {
     "name": "am-ph-06",
     "points": 257,
     "image": "attack-modifiers/PH/am-ph-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph06"
   },
   {
     "name": "am-ph-07",
     "points": 258,
     "image": "attack-modifiers/PH/am-ph-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph07"
   },
   {
     "name": "am-ph-08",
     "points": 259,
     "image": "attack-modifiers/PH/am-ph-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph08"
   },
   {
     "name": "am-ph-09",
     "points": 260,
     "image": "attack-modifiers/PH/am-ph-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph09"
   },
   {
     "name": "am-ph-10",
     "points": 261,
     "image": "attack-modifiers/PH/am-ph-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph10"
   },
   {
     "name": "am-ph-11",
     "points": 262,
     "image": "attack-modifiers/PH/am-ph-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph11"
   },
   {
     "name": "am-ph-12",
     "points": 263,
     "image": "attack-modifiers/PH/am-ph-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph12"
   },
   {
     "name": "am-ph-13",
     "points": 264,
     "image": "attack-modifiers/PH/am-ph-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph13"
   },
   {
     "name": "am-ph-14",
     "points": 265,
     "image": "attack-modifiers/PH/am-ph-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph14"
   },
   {
     "name": "am-ph-15",
     "points": 266,
     "image": "attack-modifiers/PH/am-ph-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph15"
   },
   {
     "name": "am-ph-16",
     "points": 267,
     "image": "attack-modifiers/PH/am-ph-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph16"
   },
   {
     "name": "am-ph-17",
     "points": 268,
     "image": "attack-modifiers/PH/am-ph-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph17"
   },
   {
     "name": "am-ph-18",
     "points": 269,
     "image": "attack-modifiers/PH/am-ph-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph18"
   },
   {
     "name": "am-ph-19",
     "points": 270,
     "image": "attack-modifiers/PH/am-ph-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph19"
   },
   {
     "name": "am-ph-20",
     "points": 271,
     "image": "attack-modifiers/PH/am-ph-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph20"
   },
   {
     "name": "am-qm-01",
     "points": 272,
     "image": "attack-modifiers/QM/am-qm-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm01"
   },
   {
     "name": "am-qm-02",
     "points": 273,
     "image": "attack-modifiers/QM/am-qm-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm02"
   },
   {
     "name": "am-qm-03",
     "points": 274,
     "image": "attack-modifiers/QM/am-qm-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm03"
   },
   {
     "name": "am-qm-04",
     "points": 275,
     "image": "attack-modifiers/QM/am-qm-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm04"
   },
   {
     "name": "am-qm-05",
     "points": 276,
     "image": "attack-modifiers/QM/am-qm-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm05"
   },
   {
     "name": "am-qm-06",
     "points": 277,
     "image": "attack-modifiers/QM/am-qm-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm06"
   },
   {
     "name": "am-qm-07",
     "points": 278,
     "image": "attack-modifiers/QM/am-qm-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm07"
   },
   {
     "name": "am-qm-08",
     "points": 279,
     "image": "attack-modifiers/QM/am-qm-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm08"
   },
   {
     "name": "am-qm-09",
     "points": 280,
     "image": "attack-modifiers/QM/am-qm-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm09"
   },
   {
     "name": "am-qm-10",
     "points": 281,
     "image": "attack-modifiers/QM/am-qm-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm10"
   },
   {
     "name": "am-qm-11",
     "points": 282,
     "image": "attack-modifiers/QM/am-qm-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm11"
   },
   {
     "name": "am-qm-12",
     "points": 283,
     "image": "attack-modifiers/QM/am-qm-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm12"
   },
   {
     "name": "am-qm-13",
     "points": 284,
     "image": "attack-modifiers/QM/am-qm-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm13"
   },
   {
     "name": "am-qm-14",
     "points": 285,
     "image": "attack-modifiers/QM/am-qm-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm14"
   },
   {
     "name": "am-qm-15",
     "points": 286,
     "image": "attack-modifiers/QM/am-qm-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm15"
   },
   {
     "name": "am-qm-16",
     "points": 287,
     "image": "attack-modifiers/QM/am-qm-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm16"
   },
   {
     "name": "am-qm-17",
     "points": 288,
     "image": "attack-modifiers/QM/am-qm-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm17"
   },
   {
     "name": "am-qm-18",
     "points": 289,
     "image": "attack-modifiers/QM/am-qm-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm18"
   },
   {
     "name": "am-sb-01",
     "points": 290,
     "image": "attack-modifiers/SB/am-sb-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb01"
   },
   {
     "name": "am-sb-02",
     "points": 291,
     "image": "attack-modifiers/SB/am-sb-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb02"
   },
   {
     "name": "am-sb-03",
     "points": 292,
     "image": "attack-modifiers/SB/am-sb-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb03"
   },
   {
     "name": "am-sb-04",
     "points": 293,
     "image": "attack-modifiers/SB/am-sb-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb04"
   },
   {
     "name": "am-sb-05",
     "points": 294,
     "image": "attack-modifiers/SB/am-sb-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb05"
   },
   {
     "name": "am-sb-06",
     "points": 295,
     "image": "attack-modifiers/SB/am-sb-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb06"
   },
   {
     "name": "am-sb-07",
     "points": 296,
     "image": "attack-modifiers/SB/am-sb-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb07"
   },
   {
     "name": "am-sb-08",
     "points": 297,
     "image": "attack-modifiers/SB/am-sb-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb08"
   },
   {
     "name": "am-sb-09",
     "points": 298,
     "image": "attack-modifiers/SB/am-sb-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb09"
   },
   {
     "name": "am-sb-10",
     "points": 299,
     "image": "attack-modifiers/SB/am-sb-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb10"
   },
   {
     "name": "am-sb-11",
     "points": 300,
     "image": "attack-modifiers/SB/am-sb-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb11"
   },
   {
     "name": "am-sb-12",
     "points": 301,
     "image": "attack-modifiers/SB/am-sb-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb12"
   },
   {
     "name": "am-sb-13",
     "points": 302,
     "image": "attack-modifiers/SB/am-sb-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb13"
   },
   {
     "name": "am-sb-14",
     "points": 303,
     "image": "attack-modifiers/SB/am-sb-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb14"
   },
   {
     "name": "am-sc-01",
     "points": 304,
     "image": "attack-modifiers/SC/am-sc-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc01"
   },
   {
     "name": "am-sc-02",
     "points": 305,
     "image": "attack-modifiers/SC/am-sc-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc02"
   },
   {
     "name": "am-sc-03",
     "points": 306,
     "image": "attack-modifiers/SC/am-sc-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc03"
   },
   {
     "name": "am-sc-04",
     "points": 307,
     "image": "attack-modifiers/SC/am-sc-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc04"
   },
   {
     "name": "am-sc-05",
     "points": 308,
     "image": "attack-modifiers/SC/am-sc-05.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc05"
   },
   {
     "name": "am-sc-06",
     "points": 309,
     "image": "attack-modifiers/SC/am-sc-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc06"
   },
   {
     "name": "am-sc-07",
     "points": 310,
     "image": "attack-modifiers/SC/am-sc-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc07"
   },
   {
     "name": "am-sc-08",
     "points": 311,
     "image": "attack-modifiers/SC/am-sc-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc08"
   },
   {
     "name": "am-sc-09",
     "points": 312,
     "image": "attack-modifiers/SC/am-sc-09.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc09"
   },
   {
     "name": "am-sc-10",
     "points": 313,
     "image": "attack-modifiers/SC/am-sc-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc10"
   },
   {
     "name": "am-sc-11",
     "points": 314,
     "image": "attack-modifiers/SC/am-sc-11.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc11"
   },
   {
     "name": "am-sc-12",
     "points": 315,
     "image": "attack-modifiers/SC/am-sc-12.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc12"
   },
   {
     "name": "am-sc-13",
     "points": 316,
     "image": "attack-modifiers/SC/am-sc-13.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc13"
   },
   {
     "name": "am-sc-14",
     "points": 317,
     "image": "attack-modifiers/SC/am-sc-14.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc14"
   },
   {
     "name": "am-sc-15",
     "points": 318,
     "image": "attack-modifiers/SC/am-sc-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc15"
   },
   {
     "name": "am-sc-16",
     "points": 319,
     "image": "attack-modifiers/SC/am-sc-16.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc16"
   },
   {
     "name": "am-sc-17",
     "points": 320,
     "image": "attack-modifiers/SC/am-sc-17.png",
+    "value": "rolling",
+    "conditions": [
+      "invisible"
+    ],
     "xws": "amsc17"
   },
   {
     "name": "am-sk-01",
     "points": 321,
     "image": "attack-modifiers/SK/am-sk-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk01"
   },
   {
     "name": "am-sk-02",
     "points": 322,
     "image": "attack-modifiers/SK/am-sk-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk02"
   },
   {
     "name": "am-sk-03",
     "points": 323,
     "image": "attack-modifiers/SK/am-sk-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk03"
   },
   {
     "name": "am-sk-04",
     "points": 324,
     "image": "attack-modifiers/SK/am-sk-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk04"
   },
   {
     "name": "am-sk-05",
     "points": 325,
     "image": "attack-modifiers/SK/am-sk-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk05"
   },
   {
     "name": "am-sk-06",
     "points": 326,
     "image": "attack-modifiers/SK/am-sk-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk06"
   },
   {
     "name": "am-sk-07",
     "points": 327,
     "image": "attack-modifiers/SK/am-sk-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk07"
   },
   {
     "name": "am-sk-08",
     "points": 328,
     "image": "attack-modifiers/SK/am-sk-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk08"
   },
   {
     "name": "am-sk-09",
     "points": 329,
     "image": "attack-modifiers/SK/am-sk-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk09"
   },
   {
     "name": "am-sk-10",
     "points": 330,
     "image": "attack-modifiers/SK/am-sk-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk10"
   },
   {
     "name": "am-sk-11",
     "points": 331,
     "image": "attack-modifiers/SK/am-sk-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk11"
   },
   {
     "name": "am-sk-12",
     "points": 332,
     "image": "attack-modifiers/SK/am-sk-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk12"
   },
   {
     "name": "am-sk-13",
     "points": 333,
     "image": "attack-modifiers/SK/am-sk-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk13"
   },
   {
     "name": "am-sk-14",
     "points": 334,
     "image": "attack-modifiers/SK/am-sk-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk14"
   },
   {
     "name": "am-sk-15",
     "points": 335,
     "image": "attack-modifiers/SK/am-sk-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk15"
   },
   {
     "name": "am-sk-16",
     "points": 336,
     "image": "attack-modifiers/SK/am-sk-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk16"
   },
   {
     "name": "am-sk-17",
     "points": 337,
     "image": "attack-modifiers/SK/am-sk-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk17"
   },
   {
     "name": "am-sk-18",
     "points": 338,
     "image": "attack-modifiers/SK/am-sk-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk18"
   },
   {
     "name": "am-sk-19",
     "points": 339,
     "image": "attack-modifiers/SK/am-sk-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk19"
   },
   {
     "name": "am-ss-01",
     "points": 340,
     "image": "attack-modifiers/SS/am-ss-01.png",
+    "value": 0,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amss01"
   },
   {
     "name": "am-ss-02",
     "points": 341,
     "image": "attack-modifiers/SS/am-ss-02.png",
+    "value": 0,
+    "conditions": [
+      "disarm"
+    ],
     "xws": "amss02"
   },
   {
     "name": "am-ss-03",
     "points": 342,
     "image": "attack-modifiers/SS/am-ss-03.png",
+    "value": 0,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amss03"
   },
   {
     "name": "am-ss-04",
     "points": 343,
     "image": "attack-modifiers/SS/am-ss-04.png",
+    "value": 0,
+    "conditions": [
+      "poison"
+    ],
     "xws": "amss04"
   },
   {
     "name": "am-ss-05",
     "points": 344,
     "image": "attack-modifiers/SS/am-ss-05.png",
+    "value": 0,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss05"
   },
   {
     "name": "am-ss-06",
     "points": 345,
     "image": "attack-modifiers/SS/am-ss-06.png",
+    "value": 0,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amss06"
   },
   {
     "name": "am-ss-07",
     "points": 346,
     "image": "attack-modifiers/SS/am-ss-07.png",
+    "value": -1,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amss07"
   },
   {
     "name": "am-ss-08",
     "points": 347,
     "image": "attack-modifiers/SS/am-ss-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss08"
   },
   {
     "name": "am-ss-09",
     "points": 348,
     "image": "attack-modifiers/SS/am-ss-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss09"
   },
   {
     "name": "am-ss-10",
     "points": 349,
     "image": "attack-modifiers/SS/am-ss-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss10"
   },
   {
     "name": "am-ss-11",
     "points": 350,
     "image": "attack-modifiers/SS/am-ss-11.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss11"
   },
   {
     "name": "am-ss-12",
     "points": 351,
     "image": "attack-modifiers/SS/am-ss-12.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss12"
   },
   {
     "name": "am-ss-13",
     "points": 352,
     "image": "attack-modifiers/SS/am-ss-13.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss13"
   },
   {
     "name": "am-ss-14",
     "points": 353,
     "image": "attack-modifiers/SS/am-ss-14.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss14"
   },
   {
     "name": "am-ss-15",
     "points": 354,
     "image": "attack-modifiers/SS/am-ss-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss15"
   },
   {
     "name": "am-ss-16",
     "points": 355,
     "image": "attack-modifiers/SS/am-ss-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss16"
   },
   {
     "name": "am-su-01",
     "points": 356,
     "image": "attack-modifiers/SU/am-su-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu01"
   },
   {
     "name": "am-su-02",
     "points": 357,
     "image": "attack-modifiers/SU/am-su-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu02"
   },
   {
     "name": "am-su-03",
     "points": 358,
     "image": "attack-modifiers/SU/am-su-03.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu03"
   },
   {
     "name": "am-su-04",
     "points": 359,
     "image": "attack-modifiers/SU/am-su-04.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu04"
   },
   {
     "name": "am-su-05",
     "points": 360,
     "image": "attack-modifiers/SU/am-su-05.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu05"
   },
   {
     "name": "am-su-06",
     "points": 361,
     "image": "attack-modifiers/SU/am-su-06.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu06"
   },
   {
     "name": "am-su-07",
     "points": 362,
     "image": "attack-modifiers/SU/am-su-07.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu07"
   },
   {
     "name": "am-su-08",
     "points": 363,
     "image": "attack-modifiers/SU/am-su-08.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu08"
   },
   {
     "name": "am-su-09",
     "points": 364,
     "image": "attack-modifiers/SU/am-su-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu09"
   },
   {
     "name": "am-su-10",
     "points": 365,
     "image": "attack-modifiers/SU/am-su-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu10"
   },
   {
     "name": "am-su-11",
     "points": 366,
     "image": "attack-modifiers/SU/am-su-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu11"
   },
   {
     "name": "am-su-12",
     "points": 367,
     "image": "attack-modifiers/SU/am-su-12.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu12"
   },
   {
     "name": "am-su-13",
     "points": 368,
     "image": "attack-modifiers/SU/am-su-13.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu13"
   },
   {
     "name": "am-su-14",
     "points": 369,
     "image": "attack-modifiers/SU/am-su-14.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu14"
   },
   {
     "name": "am-su-15",
     "points": 370,
     "image": "attack-modifiers/SU/am-su-15.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu15"
   },
   {
     "name": "am-su-16",
     "points": 371,
     "image": "attack-modifiers/SU/am-su-16.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu16"
   },
   {
     "name": "am-su-17",
     "points": 372,
     "image": "attack-modifiers/SU/am-su-17.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu17"
   },
   {
     "name": "am-su-18",
     "points": 373,
     "image": "attack-modifiers/SU/am-su-18.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu18"
   },
   {
     "name": "am-su-19",
     "points": 374,
     "image": "attack-modifiers/SU/am-su-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu19"
   },
   {
     "name": "am-su-20",
     "points": 375,
     "image": "attack-modifiers/SU/am-su-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu20"
   },
   {
     "name": "am-su-21",
     "points": 376,
     "image": "attack-modifiers/SU/am-su-21.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu21"
   },
   {
     "name": "am-su-22",
     "points": 377,
     "image": "attack-modifiers/SU/am-su-22.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu22"
   },
   {
     "name": "am-sw-01",
     "points": 378,
     "image": "attack-modifiers/SW/am-sw-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw01"
   },
   {
     "name": "am-sw-02",
     "points": 379,
     "image": "attack-modifiers/SW/am-sw-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw02"
   },
   {
     "name": "am-sw-03",
     "points": 380,
     "image": "attack-modifiers/SW/am-sw-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw03"
   },
   {
     "name": "am-sw-04",
     "points": 381,
     "image": "attack-modifiers/SW/am-sw-04.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw04"
   },
   {
     "name": "am-sw-05",
     "points": 382,
     "image": "attack-modifiers/SW/am-sw-05.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw05"
   },
   {
     "name": "am-sw-06",
     "points": 383,
     "image": "attack-modifiers/SW/am-sw-06.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw06"
   },
   {
     "name": "am-sw-07",
     "points": 384,
     "image": "attack-modifiers/SW/am-sw-07.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amsw07"
   },
   {
     "name": "am-sw-08",
     "points": 385,
     "image": "attack-modifiers/SW/am-sw-08.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsw08"
   },
   {
     "name": "am-sw-09",
     "points": 386,
     "image": "attack-modifiers/SW/am-sw-09.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amsw09"
   },
   {
     "name": "am-sw-10",
     "points": 387,
     "image": "attack-modifiers/SW/am-sw-10.png",
+    "value": 1,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amsw10"
   },
   {
     "name": "am-sw-11",
     "points": 388,
     "image": "attack-modifiers/SW/am-sw-11.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw11"
   },
   {
     "name": "am-sw-12",
     "points": 389,
     "image": "attack-modifiers/SW/am-sw-12.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw12"
   },
   {
     "name": "am-sw-13",
     "points": 390,
     "image": "attack-modifiers/SW/am-sw-13.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw13"
   },
   {
     "name": "am-sw-14",
     "points": 391,
     "image": "attack-modifiers/SW/am-sw-14.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw14"
   },
   {
     "name": "am-sw-15",
     "points": 392,
     "image": "attack-modifiers/SW/am-sw-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw15"
   },
   {
     "name": "am-sw-16",
     "points": 393,
     "image": "attack-modifiers/SW/am-sw-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw16"
   },
   {
     "name": "am-sw-17",
     "points": 394,
     "image": "attack-modifiers/SW/am-sw-17.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw17"
   },
   {
     "name": "am-sw-18",
     "points": 395,
     "image": "attack-modifiers/SW/am-sw-18.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw18"
   },
   {
     "name": "am-ti-01",
     "points": 396,
     "image": "attack-modifiers/TI/am-ti-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amti01"
   },
   {
     "name": "am-ti-02",
     "points": 397,
     "image": "attack-modifiers/TI/am-ti-02.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti02"
   },
   {
     "name": "am-ti-03",
     "points": 398,
     "image": "attack-modifiers/TI/am-ti-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti03"
   },
   {
     "name": "am-ti-04",
     "points": 399,
     "image": "attack-modifiers/TI/am-ti-04.png",
+    "value": 3,
+    "conditions": [],
     "xws": "amti04"
   },
   {
     "name": "am-ti-05",
     "points": 400,
     "image": "attack-modifiers/TI/am-ti-05.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti05"
   },
   {
     "name": "am-ti-06",
     "points": 401,
     "image": "attack-modifiers/TI/am-ti-06.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti06"
   },
   {
     "name": "am-ti-07",
     "points": 402,
     "image": "attack-modifiers/TI/am-ti-07.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti07"
   },
   {
     "name": "am-ti-08",
     "points": 403,
     "image": "attack-modifiers/TI/am-ti-08.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti08"
   },
   {
     "name": "am-ti-09",
     "points": 404,
     "image": "attack-modifiers/TI/am-ti-09.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti09"
   },
   {
     "name": "am-ti-10",
     "points": 405,
     "image": "attack-modifiers/TI/am-ti-10.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti10"
   },
   {
     "name": "am-ti-11",
     "points": 406,
     "image": "attack-modifiers/TI/am-ti-11.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti11"
   },
   {
     "name": "am-ti-12",
     "points": 407,
     "image": "attack-modifiers/TI/am-ti-12.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti12"
   },
   {
     "name": "am-ti-13",
     "points": 408,
     "image": "attack-modifiers/TI/am-ti-13.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti13"
   },
   {
     "name": "am-ti-14",
     "points": 409,
     "image": "attack-modifiers/TI/am-ti-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti14"
   },
   {
     "name": "am-ti-15",
     "points": 410,
     "image": "attack-modifiers/TI/am-ti-15.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti15"
   },
   {
     "name": "am-ti-16",
     "points": 411,
     "image": "attack-modifiers/TI/am-ti-16.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amti16"
   },
   {
     "name": "am-dr-01",
     "points": 412,
     "image": "attack-modifiers/DR/am-dr-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr01"
   },
   {
     "name": "am-dr-02",
     "points": 413,
     "image": "attack-modifiers/DR/am-dr-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr02"
   },
   {
     "name": "am-dr-03",
     "points": 414,
     "image": "attack-modifiers/DR/am-dr-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr03"
   },
   {
     "name": "am-dr-04",
     "points": 415,
     "image": "attack-modifiers/DR/am-dr-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr04"
   },
   {
     "name": "am-dr-05",
     "points": 416,
     "image": "attack-modifiers/DR/am-dr-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr05"
   },
   {
     "name": "am-dr-06",
     "points": 417,
     "image": "attack-modifiers/DR/am-dr-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr06"
   },
   {
     "name": "am-dr-07",
     "points": 418,
     "image": "attack-modifiers/DR/am-dr-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr07"
   },
   {
     "name": "am-dr-08",
     "points": 419,
     "image": "attack-modifiers/DR/am-dr-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr08"
   },
   {
     "name": "am-dr-09",
     "points": 420,
     "image": "attack-modifiers/DR/am-dr-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr09"
   },
   {
     "name": "am-dr-10",
     "points": 421,
     "image": "attack-modifiers/DR/am-dr-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr10"
   },
   {
     "name": "am-dr-11",
     "points": 422,
     "image": "attack-modifiers/DR/am-dr-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr11"
   },
   {
     "name": "am-dr-12",
     "points": 423,
     "image": "attack-modifiers/DR/am-dr-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr12"
   },
   {
     "name": "am-dr-13",
     "points": 424,
     "image": "attack-modifiers/DR/am-dr-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr13"
   },
   {
     "name": "am-dr-14",
     "points": 425,
     "image": "attack-modifiers/DR/am-dr-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr14"
   },
   {
     "name": "am-dr-15",
     "points": 426,
     "image": "attack-modifiers/DR/am-dr-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr15"
   }
 ]

--- a/data/attackmodifiers.json
+++ b/data/attackmodifiers.json
@@ -3,2562 +3,3664 @@
     "name": "am-m-01",
     "points": 0,
     "image": "attack-modifiers/base/monster/am-m-01.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm01"
   },
   {
     "name": "am-m-02",
     "points": 1,
     "image": "attack-modifiers/base/monster/am-m-02.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm02"
   },
   {
     "name": "am-m-03",
     "points": 2,
     "image": "attack-modifiers/base/monster/am-m-03.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm03"
   },
   {
     "name": "am-m-04",
     "points": 3,
     "image": "attack-modifiers/base/monster/am-m-04.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm04"
   },
   {
     "name": "am-m-05",
     "points": 4,
     "image": "attack-modifiers/base/monster/am-m-05.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm05"
   },
   {
     "name": "am-m-06",
     "points": 5,
     "image": "attack-modifiers/base/monster/am-m-06.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amm06"
   },
   {
     "name": "am-m-07",
     "points": 6,
     "image": "attack-modifiers/base/monster/am-m-07.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm07"
   },
   {
     "name": "am-m-08",
     "points": 7,
     "image": "attack-modifiers/base/monster/am-m-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm08"
   },
   {
     "name": "am-m-09",
     "points": 8,
     "image": "attack-modifiers/base/monster/am-m-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm09"
   },
   {
     "name": "am-m-10",
     "points": 9,
     "image": "attack-modifiers/base/monster/am-m-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm10"
   },
   {
     "name": "am-m-11",
     "points": 10,
     "image": "attack-modifiers/base/monster/am-m-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amm11"
   },
   {
     "name": "am-m-12",
     "points": 11,
     "image": "attack-modifiers/base/monster/am-m-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm12"
   },
   {
     "name": "am-m-13",
     "points": 12,
     "image": "attack-modifiers/base/monster/am-m-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm13"
   },
   {
     "name": "am-m-14",
     "points": 13,
     "image": "attack-modifiers/base/monster/am-m-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm14"
   },
   {
     "name": "am-m-15",
     "points": 14,
     "image": "attack-modifiers/base/monster/am-m-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm15"
   },
   {
     "name": "am-m-16",
     "points": 15,
     "image": "attack-modifiers/base/monster/am-m-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amm16"
   },
   {
     "name": "am-m-17",
     "points": 16,
     "image": "attack-modifiers/base/monster/am-m-17.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amm17"
   },
   {
     "name": "am-m-18",
     "points": 17,
     "image": "attack-modifiers/base/monster/am-m-18.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amm18"
   },
   {
     "name": "am-m-19",
     "points": 18,
     "image": "attack-modifiers/base/monster/am-m-19.png",
+    "value": "miss",
+    "conditions": [],
     "xws": "amm19"
   },
   {
     "name": "am-m-20",
     "points": 19,
     "image": "attack-modifiers/base/monster/am-m-20.png",
+    "value": "x2",
+    "conditions": [],
     "xws": "amm20"
   },
   {
     "name": "am-mm-01",
     "points": 20,
     "image": "attack-modifiers/base/monster-mod/am-mm-01.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm01"
   },
   {
     "name": "am-mm-02",
     "points": 21,
     "image": "attack-modifiers/base/monster-mod/am-mm-02.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm02"
   },
   {
     "name": "am-mm-03",
     "points": 22,
     "image": "attack-modifiers/base/monster-mod/am-mm-03.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm03"
   },
   {
     "name": "am-mm-04",
     "points": 23,
     "image": "attack-modifiers/base/monster-mod/am-mm-04.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm04"
   },
   {
     "name": "am-mm-05",
     "points": 24,
     "image": "attack-modifiers/base/monster-mod/am-mm-05.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm05"
   },
   {
     "name": "am-mm-06",
     "points": 25,
     "image": "attack-modifiers/base/monster-mod/am-mm-06.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm06"
   },
   {
     "name": "am-mm-07",
     "points": 26,
     "image": "attack-modifiers/base/monster-mod/am-mm-07.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm07"
   },
   {
     "name": "am-mm-08",
     "points": 27,
     "image": "attack-modifiers/base/monster-mod/am-mm-08.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm08"
   },
   {
     "name": "am-mm-09",
     "points": 28,
     "image": "attack-modifiers/base/monster-mod/am-mm-09.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm09"
   },
   {
     "name": "am-mm-10",
     "points": 29,
     "image": "attack-modifiers/base/monster-mod/am-mm-10.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ammm10"
   },
   {
     "name": "am-p-01",
     "points": 30,
     "image": "attack-modifiers/base/player/am-p-01.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp01"
   },
   {
     "name": "am-p-02",
     "points": 31,
     "image": "attack-modifiers/base/player/am-p-02.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp02"
   },
   {
     "name": "am-p-03",
     "points": 32,
     "image": "attack-modifiers/base/player/am-p-03.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp03"
   },
   {
     "name": "am-p-04",
     "points": 33,
     "image": "attack-modifiers/base/player/am-p-04.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp04"
   },
   {
     "name": "am-p-05",
     "points": 34,
     "image": "attack-modifiers/base/player/am-p-05.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp05"
   },
   {
     "name": "am-p-06",
     "points": 35,
     "image": "attack-modifiers/base/player/am-p-06.png",
+    "value": 0,
+    "conditions": [],
     "xws": "amp06"
   },
   {
     "name": "am-p-07",
     "points": 36,
     "image": "attack-modifiers/base/player/am-p-07.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp07"
   },
   {
     "name": "am-p-08",
     "points": 37,
     "image": "attack-modifiers/base/player/am-p-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp08"
   },
   {
     "name": "am-p-09",
     "points": 38,
     "image": "attack-modifiers/base/player/am-p-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp09"
   },
   {
     "name": "am-p-10",
     "points": 39,
     "image": "attack-modifiers/base/player/am-p-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp10"
   },
   {
     "name": "am-p-11",
     "points": 40,
     "image": "attack-modifiers/base/player/am-p-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amp11"
   },
   {
     "name": "am-p-12",
     "points": 41,
     "image": "attack-modifiers/base/player/am-p-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp12"
   },
   {
     "name": "am-p-13",
     "points": 42,
     "image": "attack-modifiers/base/player/am-p-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp13"
   },
   {
     "name": "am-p-14",
     "points": 43,
     "image": "attack-modifiers/base/player/am-p-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp14"
   },
   {
     "name": "am-p-15",
     "points": 44,
     "image": "attack-modifiers/base/player/am-p-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp15"
   },
   {
     "name": "am-p-16",
     "points": 45,
     "image": "attack-modifiers/base/player/am-p-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "amp16"
   },
   {
     "name": "am-p-17",
     "points": 46,
     "image": "attack-modifiers/base/player/am-p-17.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amp17"
   },
   {
     "name": "am-p-18",
     "points": 47,
     "image": "attack-modifiers/base/player/am-p-18.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amp18"
   },
   {
     "name": "am-p-19",
     "points": 48,
     "image": "attack-modifiers/base/player/am-p-19.png",
+    "value": "miss",
+    "conditions": [],
     "xws": "amp19"
   },
   {
     "name": "am-p-20",
     "points": 49,
     "image": "attack-modifiers/base/player/am-p-20.png",
+    "value": "x2",
+    "conditions": [],
     "xws": "amp20"
   },
   {
     "name": "am-pm-01",
     "points": 50,
     "image": "attack-modifiers/base/player-mod/am-pm-01.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm01"
   },
   {
     "name": "am-pm-02",
     "points": 51,
     "image": "attack-modifiers/base/player-mod/am-pm-02.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm02"
   },
   {
     "name": "am-pm-03",
     "points": 52,
     "image": "attack-modifiers/base/player-mod/am-pm-03.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm03"
   },
   {
     "name": "am-pm-04",
     "points": 53,
     "image": "attack-modifiers/base/player-mod/am-pm-04.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm04"
   },
   {
     "name": "am-pm-05",
     "points": 54,
     "image": "attack-modifiers/base/player-mod/am-pm-05.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm05"
   },
   {
     "name": "am-pm-06",
     "points": 55,
     "image": "attack-modifiers/base/player-mod/am-pm-06.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm06"
   },
   {
     "name": "am-pm-07",
     "points": 56,
     "image": "attack-modifiers/base/player-mod/am-pm-07.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm07"
   },
   {
     "name": "am-pm-08",
     "points": 57,
     "image": "attack-modifiers/base/player-mod/am-pm-08.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm08"
   },
   {
     "name": "am-pm-09",
     "points": 58,
     "image": "attack-modifiers/base/player-mod/am-pm-09.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm09"
   },
   {
     "name": "am-pm-10",
     "points": 59,
     "image": "attack-modifiers/base/player-mod/am-pm-10.png",
+    "value": "bless",
+    "conditions": [],
     "xws": "ampm10"
   },
   {
     "name": "am-pm-11",
     "points": 60,
     "image": "attack-modifiers/base/player-mod/am-pm-11.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm11"
   },
   {
     "name": "am-pm-12",
     "points": 61,
     "image": "attack-modifiers/base/player-mod/am-pm-12.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm12"
   },
   {
     "name": "am-pm-13",
     "points": 62,
     "image": "attack-modifiers/base/player-mod/am-pm-13.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm13"
   },
   {
     "name": "am-pm-14",
     "points": 63,
     "image": "attack-modifiers/base/player-mod/am-pm-14.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm14"
   },
   {
     "name": "am-pm-15",
     "points": 64,
     "image": "attack-modifiers/base/player-mod/am-pm-15.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm15"
   },
   {
     "name": "am-pm-16",
     "points": 65,
     "image": "attack-modifiers/base/player-mod/am-pm-16.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm16"
   },
   {
     "name": "am-pm-17",
     "points": 66,
     "image": "attack-modifiers/base/player-mod/am-pm-17.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm17"
   },
   {
     "name": "am-pm-18",
     "points": 67,
     "image": "attack-modifiers/base/player-mod/am-pm-18.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm18"
   },
   {
     "name": "am-pm-19",
     "points": 68,
     "image": "attack-modifiers/base/player-mod/am-pm-19.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm19"
   },
   {
     "name": "am-pm-20",
     "points": 69,
     "image": "attack-modifiers/base/player-mod/am-pm-20.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm20"
   },
   {
     "name": "am-pm-21",
     "points": 70,
     "image": "attack-modifiers/base/player-mod/am-pm-21.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm21"
   },
   {
     "name": "am-pm-22",
     "points": 71,
     "image": "attack-modifiers/base/player-mod/am-pm-22.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm22"
   },
   {
     "name": "am-pm-23",
     "points": 72,
     "image": "attack-modifiers/base/player-mod/am-pm-23.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm23"
   },
   {
     "name": "am-pm-24",
     "points": 73,
     "image": "attack-modifiers/base/player-mod/am-pm-24.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm24"
   },
   {
     "name": "am-pm-25",
     "points": 74,
     "image": "attack-modifiers/base/player-mod/am-pm-25.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm25"
   },
   {
     "name": "am-pm-26",
     "points": 75,
     "image": "attack-modifiers/base/player-mod/am-pm-26.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm26"
   },
   {
     "name": "am-pm-27",
     "points": 76,
     "image": "attack-modifiers/base/player-mod/am-pm-27.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm27"
   },
   {
     "name": "am-pm-28",
     "points": 77,
     "image": "attack-modifiers/base/player-mod/am-pm-28.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm28"
   },
   {
     "name": "am-pm-29",
     "points": 78,
     "image": "attack-modifiers/base/player-mod/am-pm-29.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm29"
   },
   {
     "name": "am-pm-30",
     "points": 79,
     "image": "attack-modifiers/base/player-mod/am-pm-30.png",
+    "value": "curse",
+    "conditions": [],
     "xws": "ampm30"
   },
   {
     "name": "am-pm-31",
     "points": 80,
     "image": "attack-modifiers/base/player-mod/am-pm-31.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm31"
   },
   {
     "name": "am-pm-32",
     "points": 81,
     "image": "attack-modifiers/base/player-mod/am-pm-32.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm32"
   },
   {
     "name": "am-pm-33",
     "points": 82,
     "image": "attack-modifiers/base/player-mod/am-pm-33.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm33"
   },
   {
     "name": "am-pm-34",
     "points": 83,
     "image": "attack-modifiers/base/player-mod/am-pm-34.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm34"
   },
   {
     "name": "am-pm-35",
     "points": 84,
     "image": "attack-modifiers/base/player-mod/am-pm-35.png",
+    "value": -1,
+    "conditions": [],
     "xws": "ampm35"
   },
   {
     "name": "am-be-01",
     "points": 85,
     "image": "attack-modifiers/BE/am-be-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe01"
   },
   {
     "name": "am-be-02",
     "points": 86,
     "image": "attack-modifiers/BE/am-be-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe02"
   },
   {
     "name": "am-be-03",
     "points": 87,
     "image": "attack-modifiers/BE/am-be-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe03"
   },
   {
     "name": "am-be-04",
     "points": 88,
     "image": "attack-modifiers/BE/am-be-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe04"
   },
   {
     "name": "am-be-05",
     "points": 89,
     "image": "attack-modifiers/BE/am-be-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe05"
   },
   {
     "name": "am-be-06",
     "points": 90,
     "image": "attack-modifiers/BE/am-be-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe06"
   },
   {
     "name": "am-be-07",
     "points": 91,
     "image": "attack-modifiers/BE/am-be-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe07"
   },
   {
     "name": "am-be-08",
     "points": 92,
     "image": "attack-modifiers/BE/am-be-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe08"
   },
   {
     "name": "am-be-09",
     "points": 93,
     "image": "attack-modifiers/BE/am-be-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe09"
   },
   {
     "name": "am-be-10",
     "points": 94,
     "image": "attack-modifiers/BE/am-be-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe10"
   },
   {
     "name": "am-be-11",
     "points": 95,
     "image": "attack-modifiers/BE/am-be-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe11"
   },
   {
     "name": "am-be-12",
     "points": 96,
     "image": "attack-modifiers/BE/am-be-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe12"
   },
   {
     "name": "am-be-13",
     "points": 97,
     "image": "attack-modifiers/BE/am-be-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe13"
   },
   {
     "name": "am-be-14",
     "points": 98,
     "image": "attack-modifiers/BE/am-be-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe14"
   },
   {
     "name": "am-be-15",
     "points": 99,
     "image": "attack-modifiers/BE/am-be-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambe15"
   },
   {
     "name": "am-br-01",
     "points": 100,
     "image": "attack-modifiers/BR/am-br-01.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr01"
   },
   {
     "name": "am-br-02",
     "points": 101,
     "image": "attack-modifiers/BR/am-br-02.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr02"
   },
   {
     "name": "am-br-03",
     "points": 102,
     "image": "attack-modifiers/BR/am-br-03.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ambr03"
   },
   {
     "name": "am-br-04",
     "points": 103,
     "image": "attack-modifiers/BR/am-br-04.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr04"
   },
   {
     "name": "am-br-05",
     "points": 104,
     "image": "attack-modifiers/BR/am-br-05.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ambr05"
   },
   {
     "name": "am-br-06",
     "points": 105,
     "image": "attack-modifiers/BR/am-br-06.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr06"
   },
   {
     "name": "am-br-07",
     "points": 106,
     "image": "attack-modifiers/BR/am-br-07.png",
+    "value": "rolling",
+    "conditions": [
+      "add-target"
+    ],
     "xws": "ambr07"
   },
   {
     "name": "am-br-08",
     "points": 107,
     "image": "attack-modifiers/BR/am-br-08.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr08"
   },
   {
     "name": "am-br-09",
     "points": 108,
     "image": "attack-modifiers/BR/am-br-09.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr09"
   },
   {
     "name": "am-br-10",
     "points": 109,
     "image": "attack-modifiers/BR/am-br-10.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr10"
   },
   {
     "name": "am-br-11",
     "points": 110,
     "image": "attack-modifiers/BR/am-br-11.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr11"
   },
   {
     "name": "am-br-12",
     "points": 111,
     "image": "attack-modifiers/BR/am-br-12.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr12"
   },
   {
     "name": "am-br-13",
     "points": 112,
     "image": "attack-modifiers/BR/am-br-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambr13"
   },
   {
     "name": "am-br-14",
     "points": 113,
     "image": "attack-modifiers/BR/am-br-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ambr14"
   },
   {
     "name": "am-br-15",
     "points": 114,
     "image": "attack-modifiers/BR/am-br-15.png",
+    "value": 3,
+    "conditions": [],
     "xws": "ambr15"
   },
   {
     "name": "am-br-16",
     "points": 115,
     "image": "attack-modifiers/BR/am-br-16.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr16"
   },
   {
     "name": "am-br-17",
     "points": 116,
     "image": "attack-modifiers/BR/am-br-17.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr17"
   },
   {
     "name": "am-br-18",
     "points": 117,
     "image": "attack-modifiers/BR/am-br-18.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr18"
   },
   {
     "name": "am-br-19",
     "points": 118,
     "image": "attack-modifiers/BR/am-br-19.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr19"
   },
   {
     "name": "am-br-20",
     "points": 119,
     "image": "attack-modifiers/BR/am-br-20.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr20"
   },
   {
     "name": "am-br-21",
     "points": 120,
     "image": "attack-modifiers/BR/am-br-21.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "ambr21"
   },
   {
     "name": "am-br-22",
     "points": 121,
     "image": "attack-modifiers/BR/am-br-22.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "ambr22"
   },
   {
     "name": "am-bs-01",
     "points": 122,
     "image": "attack-modifiers/BS/am-bs-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs01"
   },
   {
     "name": "am-bs-02",
     "points": 123,
     "image": "attack-modifiers/BS/am-bs-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs02"
   },
   {
     "name": "am-bs-03",
     "points": 124,
     "image": "attack-modifiers/BS/am-bs-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs03"
   },
   {
     "name": "am-bs-04",
     "points": 125,
     "image": "attack-modifiers/BS/am-bs-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs04"
   },
   {
     "name": "am-bs-05",
     "points": 126,
     "image": "attack-modifiers/BS/am-bs-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs05"
   },
   {
     "name": "am-bs-06",
     "points": 127,
     "image": "attack-modifiers/BS/am-bs-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs06"
   },
   {
     "name": "am-bs-07",
     "points": 128,
     "image": "attack-modifiers/BS/am-bs-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs07"
   },
   {
     "name": "am-bs-08",
     "points": 129,
     "image": "attack-modifiers/BS/am-bs-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs08"
   },
   {
     "name": "am-bs-09",
     "points": 130,
     "image": "attack-modifiers/BS/am-bs-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs09"
   },
   {
     "name": "am-bs-10",
     "points": 131,
     "image": "attack-modifiers/BS/am-bs-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs10"
   },
   {
     "name": "am-bs-11",
     "points": 132,
     "image": "attack-modifiers/BS/am-bs-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs11"
   },
   {
     "name": "am-bs-12",
     "points": 133,
     "image": "attack-modifiers/BS/am-bs-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs12"
   },
   {
     "name": "am-bs-13",
     "points": 134,
     "image": "attack-modifiers/BS/am-bs-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs13"
   },
   {
     "name": "am-bs-14",
     "points": 135,
     "image": "attack-modifiers/BS/am-bs-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs14"
   },
   {
     "name": "am-bs-15",
     "points": 136,
     "image": "attack-modifiers/BS/am-bs-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambs15"
   },
   {
     "name": "am-bt-01",
     "points": 137,
     "image": "attack-modifiers/BT/am-bt-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt01"
   },
   {
     "name": "am-bt-02",
     "points": 138,
     "image": "attack-modifiers/BT/am-bt-02.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt02"
   },
   {
     "name": "am-bt-03",
     "points": 139,
     "image": "attack-modifiers/BT/am-bt-03.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "ambt03"
   },
   {
     "name": "am-bt-04",
     "points": 140,
     "image": "attack-modifiers/BT/am-bt-04.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt04"
   },
   {
     "name": "am-bt-05",
     "points": 141,
     "image": "attack-modifiers/BT/am-bt-05.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ambt05"
   },
   {
     "name": "am-bt-06",
     "points": 142,
     "image": "attack-modifiers/BT/am-bt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt06"
   },
   {
     "name": "am-bt-07",
     "points": 143,
     "image": "attack-modifiers/BT/am-bt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt07"
   },
   {
     "name": "am-bt-08",
     "points": 144,
     "image": "attack-modifiers/BT/am-bt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt08"
   },
   {
     "name": "am-bt-09",
     "points": 145,
     "image": "attack-modifiers/BT/am-bt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt09"
   },
   {
     "name": "am-bt-10",
     "points": 146,
     "image": "attack-modifiers/BT/am-bt-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt10"
   },
   {
     "name": "am-bt-11",
     "points": 147,
     "image": "attack-modifiers/BT/am-bt-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ambt11"
   },
   {
     "name": "am-bt-12",
     "points": 148,
     "image": "attack-modifiers/BT/am-bt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt12"
   },
   {
     "name": "am-bt-13",
     "points": 149,
     "image": "attack-modifiers/BT/am-bt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "ambt13"
   },
   {
     "name": "am-bt-14",
     "points": 150,
     "image": "attack-modifiers/BT/am-bt-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt14"
   },
   {
     "name": "am-bt-15",
     "points": 151,
     "image": "attack-modifiers/BT/am-bt-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt15"
   },
   {
     "name": "am-bt-16",
     "points": 152,
     "image": "attack-modifiers/BT/am-bt-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt16"
   },
   {
     "name": "am-bt-17",
     "points": 153,
     "image": "attack-modifiers/BT/am-bt-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ambt17"
   },
   {
     "name": "am-ch-01",
     "points": 154,
     "image": "attack-modifiers/CH/am-ch-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch01"
   },
   {
     "name": "am-ch-02",
     "points": 155,
     "image": "attack-modifiers/CH/am-ch-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch02"
   },
   {
     "name": "am-ch-03",
     "points": 156,
     "image": "attack-modifiers/CH/am-ch-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amch03"
   },
   {
     "name": "am-ch-04",
     "points": 157,
     "image": "attack-modifiers/CH/am-ch-04.png",
+    "value": -2,
+    "conditions": [],
     "xws": "amch04"
   },
   {
     "name": "am-ch-05",
     "points": 158,
     "image": "attack-modifiers/CH/am-ch-05.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch05"
   },
   {
     "name": "am-ch-06",
     "points": 159,
     "image": "attack-modifiers/CH/am-ch-06.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amch06"
   },
   {
     "name": "am-ch-07",
     "points": 160,
     "image": "attack-modifiers/CH/am-ch-07.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch07"
   },
   {
     "name": "am-ch-08",
     "points": 161,
     "image": "attack-modifiers/CH/am-ch-08.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amch08"
   },
   {
     "name": "am-ch-09",
     "points": 162,
     "image": "attack-modifiers/CH/am-ch-09.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch09"
   },
   {
     "name": "am-ch-10",
     "points": 163,
     "image": "attack-modifiers/CH/am-ch-10.png",
+    "value": 2,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amch10"
   },
   {
     "name": "am-ch-11",
     "points": 164,
     "image": "attack-modifiers/CH/am-ch-11.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch11"
   },
   {
     "name": "am-ch-12",
     "points": 165,
     "image": "attack-modifiers/CH/am-ch-12.png",
+    "value": "rolling",
+    "conditions": [
+      "push"
+    ],
     "xws": "amch12"
   },
   {
     "name": "am-ch-13",
     "points": 166,
     "image": "attack-modifiers/CH/am-ch-13.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch13"
   },
   {
     "name": "am-ch-14",
     "points": 167,
     "image": "attack-modifiers/CH/am-ch-14.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch14"
   },
   {
     "name": "am-ch-15",
     "points": 168,
     "image": "attack-modifiers/CH/am-ch-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch15"
   },
   {
     "name": "am-ch-16",
     "points": 169,
     "image": "attack-modifiers/CH/am-ch-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth"
+    ],
     "xws": "amch16"
   },
   {
     "name": "am-ch-17",
     "points": 170,
     "image": "attack-modifiers/CH/am-ch-17.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch17"
   },
   {
     "name": "am-ch-18",
     "points": 171,
     "image": "attack-modifiers/CH/am-ch-18.png",
+    "value": "rolling",
+    "conditions": [
+      "wind"
+    ],
     "xws": "amch18"
   },
   {
     "name": "am-ds-01",
     "points": 172,
     "image": "attack-modifiers/DS/am-ds-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds01"
   },
   {
     "name": "am-ds-02",
     "points": 173,
     "image": "attack-modifiers/DS/am-ds-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds02"
   },
   {
     "name": "am-ds-03",
     "points": 174,
     "image": "attack-modifiers/DS/am-ds-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds03"
   },
   {
     "name": "am-ds-04",
     "points": 175,
     "image": "attack-modifiers/DS/am-ds-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds04"
   },
   {
     "name": "am-ds-05",
     "points": 176,
     "image": "attack-modifiers/DS/am-ds-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds05"
   },
   {
     "name": "am-ds-06",
     "points": 177,
     "image": "attack-modifiers/DS/am-ds-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds06"
   },
   {
     "name": "am-ds-07",
     "points": 178,
     "image": "attack-modifiers/DS/am-ds-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds07"
   },
   {
     "name": "am-ds-08",
     "points": 179,
     "image": "attack-modifiers/DS/am-ds-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds08"
   },
   {
     "name": "am-ds-09",
     "points": 180,
     "image": "attack-modifiers/DS/am-ds-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds09"
   },
   {
     "name": "am-ds-10",
     "points": 181,
     "image": "attack-modifiers/DS/am-ds-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds10"
   },
   {
     "name": "am-ds-11",
     "points": 182,
     "image": "attack-modifiers/DS/am-ds-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds11"
   },
   {
     "name": "am-ds-12",
     "points": 183,
     "image": "attack-modifiers/DS/am-ds-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds12"
   },
   {
     "name": "am-ds-13",
     "points": 184,
     "image": "attack-modifiers/DS/am-ds-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds13"
   },
   {
     "name": "am-ds-14",
     "points": 185,
     "image": "attack-modifiers/DS/am-ds-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds14"
   },
   {
     "name": "am-ds-15",
     "points": 186,
     "image": "attack-modifiers/DS/am-ds-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds15"
   },
   {
     "name": "am-ds-16",
     "points": 187,
     "image": "attack-modifiers/DS/am-ds-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds16"
   },
   {
     "name": "am-ds-17",
     "points": 188,
     "image": "attack-modifiers/DS/am-ds-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amds17"
   },
   {
     "name": "am-el-01",
     "points": 189,
     "image": "attack-modifiers/EL/am-el-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel01"
   },
   {
     "name": "am-el-02",
     "points": 190,
     "image": "attack-modifiers/EL/am-el-02.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel02"
   },
   {
     "name": "am-el-03",
     "points": 191,
     "image": "attack-modifiers/EL/am-el-03.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel03"
   },
   {
     "name": "am-el-04",
     "points": 192,
     "image": "attack-modifiers/EL/am-el-04.png",
+    "value": 0,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amel04"
   },
   {
     "name": "am-el-05",
     "points": 193,
     "image": "attack-modifiers/EL/am-el-05.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel05"
   },
   {
     "name": "am-el-06",
     "points": 194,
     "image": "attack-modifiers/EL/am-el-06.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel06"
   },
   {
     "name": "am-el-07",
     "points": 195,
     "image": "attack-modifiers/EL/am-el-07.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel07"
   },
   {
     "name": "am-el-08",
     "points": 196,
     "image": "attack-modifiers/EL/am-el-08.png",
+    "value": 0,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amel08"
   },
   {
     "name": "am-el-09",
     "points": 197,
     "image": "attack-modifiers/EL/am-el-09.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel09"
   },
   {
     "name": "am-el-10",
     "points": 198,
     "image": "attack-modifiers/EL/am-el-10.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel10"
   },
   {
     "name": "am-el-11",
     "points": 199,
     "image": "attack-modifiers/EL/am-el-11.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel11"
   },
   {
     "name": "am-el-12",
     "points": 200,
     "image": "attack-modifiers/EL/am-el-12.png",
+    "value": 0,
+    "conditions": [
+      "wind"
+    ],
     "xws": "amel12"
   },
   {
     "name": "am-el-13",
     "points": 201,
     "image": "attack-modifiers/EL/am-el-13.png",
+    "value": 0,
+    "conditions": [
+      "ice",
+      "wind"
+    ],
     "xws": "amel13"
   },
   {
     "name": "am-el-14",
     "points": 202,
     "image": "attack-modifiers/EL/am-el-14.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel14"
   },
   {
     "name": "am-el-15",
     "points": 203,
     "image": "attack-modifiers/EL/am-el-15.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel15"
   },
   {
     "name": "am-el-16",
     "points": 204,
     "image": "attack-modifiers/EL/am-el-16.png",
+    "value": 0,
+    "conditions": [
+      "earth"
+    ],
     "xws": "amel16"
   },
   {
     "name": "am-el-17",
     "points": 205,
     "image": "attack-modifiers/EL/am-el-17.png",
+    "value": 0,
+    "conditions": [
+      "fire",
+      "earth"
+    ],
     "xws": "amel17"
   },
   {
     "name": "am-el-18",
     "points": 206,
     "image": "attack-modifiers/EL/am-el-18.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel18"
   },
   {
     "name": "am-el-19",
     "points": 207,
     "image": "attack-modifiers/EL/am-el-19.png",
+    "value": 1,
+    "conditions": [
+      "push"
+    ],
     "xws": "amel19"
   },
   {
     "name": "am-el-20",
     "points": 208,
     "image": "attack-modifiers/EL/am-el-20.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amel20"
   },
   {
     "name": "am-el-21",
     "points": 209,
     "image": "attack-modifiers/EL/am-el-21.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amel21"
   },
   {
     "name": "am-el-22",
     "points": 210,
     "image": "attack-modifiers/EL/am-el-22.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amel22"
   },
   {
     "name": "am-el-23",
     "points": 211,
     "image": "attack-modifiers/EL/am-el-23.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel23"
   },
   {
     "name": "am-el-24",
     "points": 212,
     "image": "attack-modifiers/EL/am-el-24.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amel24"
   },
   {
     "name": "am-mt-01",
     "points": 213,
     "image": "attack-modifiers/MT/am-mt-01.png",
+    "value": 1,
+    "conditions": [],
     "xws": "ammt01"
   },
   {
     "name": "am-mt-02",
     "points": 214,
     "image": "attack-modifiers/MT/am-mt-02.png",
+    "value": 2,
+    "conditions": [],
     "xws": "ammt02"
   },
   {
     "name": "am-mt-03",
     "points": 215,
     "image": "attack-modifiers/MT/am-mt-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "ammt03"
   },
   {
     "name": "am-mt-04",
     "points": 216,
     "image": "attack-modifiers/MT/am-mt-04.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt04"
   },
   {
     "name": "am-mt-05",
     "points": 217,
     "image": "attack-modifiers/MT/am-mt-05.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "ammt05"
   },
   {
     "name": "am-mt-06",
     "points": 218,
     "image": "attack-modifiers/MT/am-mt-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt06"
   },
   {
     "name": "am-mt-07",
     "points": 219,
     "image": "attack-modifiers/MT/am-mt-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt07"
   },
   {
     "name": "am-mt-08",
     "points": 220,
     "image": "attack-modifiers/MT/am-mt-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt08"
   },
   {
     "name": "am-mt-09",
     "points": 221,
     "image": "attack-modifiers/MT/am-mt-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "ammt09"
   },
   {
     "name": "am-mt-10",
     "points": 222,
     "image": "attack-modifiers/MT/am-mt-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt10"
   },
   {
     "name": "am-mt-11",
     "points": 223,
     "image": "attack-modifiers/MT/am-mt-11.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt11"
   },
   {
     "name": "am-mt-12",
     "points": 224,
     "image": "attack-modifiers/MT/am-mt-12.png",
+    "value": "rolling",
+    "conditions": [
+      "pull"
+    ],
     "xws": "ammt12"
   },
   {
     "name": "am-mt-13",
     "points": 225,
     "image": "attack-modifiers/MT/am-mt-13.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt13"
   },
   {
     "name": "am-mt-14",
     "points": 226,
     "image": "attack-modifiers/MT/am-mt-14.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt14"
   },
   {
     "name": "am-mt-15",
     "points": 227,
     "image": "attack-modifiers/MT/am-mt-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "ammt15"
   },
   {
     "name": "am-mt-16",
     "points": 228,
     "image": "attack-modifiers/MT/am-mt-16.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt16"
   },
   {
     "name": "am-mt-17",
     "points": 229,
     "image": "attack-modifiers/MT/am-mt-17.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt17"
   },
   {
     "name": "am-mt-18",
     "points": 230,
     "image": "attack-modifiers/MT/am-mt-18.png",
+    "value": "rolling",
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "ammt18"
   },
   {
     "name": "am-mt-19",
     "points": 231,
     "image": "attack-modifiers/MT/am-mt-19.png",
+    "value": "rolling",
+    "conditions": [
+      "stun"
+    ],
     "xws": "ammt19"
   },
   {
     "name": "am-mt-20",
     "points": 232,
     "image": "attack-modifiers/MT/am-mt-20.png",
+    "value": "rolling",
+    "conditions": [
+      "disarm",
+      "muddle"
+    ],
     "xws": "ammt20"
   },
   {
     "name": "am-ns-01",
     "points": 233,
     "image": "attack-modifiers/NS/am-ns-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns01"
   },
   {
     "name": "am-ns-02",
     "points": 234,
     "image": "attack-modifiers/NS/am-ns-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns02"
   },
   {
     "name": "am-ns-03",
     "points": 235,
     "image": "attack-modifiers/NS/am-ns-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns03"
   },
   {
     "name": "am-ns-04",
     "points": 236,
     "image": "attack-modifiers/NS/am-ns-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns04"
   },
   {
     "name": "am-ns-05",
     "points": 237,
     "image": "attack-modifiers/NS/am-ns-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns05"
   },
   {
     "name": "am-ns-06",
     "points": 238,
     "image": "attack-modifiers/NS/am-ns-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns06"
   },
   {
     "name": "am-ns-07",
     "points": 239,
     "image": "attack-modifiers/NS/am-ns-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns07"
   },
   {
     "name": "am-ns-08",
     "points": 240,
     "image": "attack-modifiers/NS/am-ns-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns08"
   },
   {
     "name": "am-ns-09",
     "points": 241,
     "image": "attack-modifiers/NS/am-ns-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns09"
   },
   {
     "name": "am-ns-10",
     "points": 242,
     "image": "attack-modifiers/NS/am-ns-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns10"
   },
   {
     "name": "am-ns-11",
     "points": 243,
     "image": "attack-modifiers/NS/am-ns-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns11"
   },
   {
     "name": "am-ns-12",
     "points": 244,
     "image": "attack-modifiers/NS/am-ns-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns12"
   },
   {
     "name": "am-ns-13",
     "points": 245,
     "image": "attack-modifiers/NS/am-ns-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns13"
   },
   {
     "name": "am-ns-14",
     "points": 246,
     "image": "attack-modifiers/NS/am-ns-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns14"
   },
   {
     "name": "am-ns-15",
     "points": 247,
     "image": "attack-modifiers/NS/am-ns-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns15"
   },
   {
     "name": "am-ns-16",
     "points": 248,
     "image": "attack-modifiers/NS/am-ns-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns16"
   },
   {
     "name": "am-ns-17",
     "points": 249,
     "image": "attack-modifiers/NS/am-ns-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns17"
   },
   {
     "name": "am-ns-18",
     "points": 250,
     "image": "attack-modifiers/NS/am-ns-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns18"
   },
   {
     "name": "am-ns-19",
     "points": 251,
     "image": "attack-modifiers/NS/am-ns-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amns19"
   },
   {
     "name": "am-ph-01",
     "points": 252,
     "image": "attack-modifiers/PH/am-ph-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph01"
   },
   {
     "name": "am-ph-02",
     "points": 253,
     "image": "attack-modifiers/PH/am-ph-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph02"
   },
   {
     "name": "am-ph-03",
     "points": 254,
     "image": "attack-modifiers/PH/am-ph-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph03"
   },
   {
     "name": "am-ph-04",
     "points": 255,
     "image": "attack-modifiers/PH/am-ph-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph04"
   },
   {
     "name": "am-ph-05",
     "points": 256,
     "image": "attack-modifiers/PH/am-ph-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph05"
   },
   {
     "name": "am-ph-06",
     "points": 257,
     "image": "attack-modifiers/PH/am-ph-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph06"
   },
   {
     "name": "am-ph-07",
     "points": 258,
     "image": "attack-modifiers/PH/am-ph-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph07"
   },
   {
     "name": "am-ph-08",
     "points": 259,
     "image": "attack-modifiers/PH/am-ph-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph08"
   },
   {
     "name": "am-ph-09",
     "points": 260,
     "image": "attack-modifiers/PH/am-ph-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph09"
   },
   {
     "name": "am-ph-10",
     "points": 261,
     "image": "attack-modifiers/PH/am-ph-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph10"
   },
   {
     "name": "am-ph-11",
     "points": 262,
     "image": "attack-modifiers/PH/am-ph-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph11"
   },
   {
     "name": "am-ph-12",
     "points": 263,
     "image": "attack-modifiers/PH/am-ph-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph12"
   },
   {
     "name": "am-ph-13",
     "points": 264,
     "image": "attack-modifiers/PH/am-ph-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph13"
   },
   {
     "name": "am-ph-14",
     "points": 265,
     "image": "attack-modifiers/PH/am-ph-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph14"
   },
   {
     "name": "am-ph-15",
     "points": 266,
     "image": "attack-modifiers/PH/am-ph-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph15"
   },
   {
     "name": "am-ph-16",
     "points": 267,
     "image": "attack-modifiers/PH/am-ph-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph16"
   },
   {
     "name": "am-ph-17",
     "points": 268,
     "image": "attack-modifiers/PH/am-ph-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph17"
   },
   {
     "name": "am-ph-18",
     "points": 269,
     "image": "attack-modifiers/PH/am-ph-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph18"
   },
   {
     "name": "am-ph-19",
     "points": 270,
     "image": "attack-modifiers/PH/am-ph-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph19"
   },
   {
     "name": "am-ph-20",
     "points": 271,
     "image": "attack-modifiers/PH/am-ph-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amph20"
   },
   {
     "name": "am-qm-01",
     "points": 272,
     "image": "attack-modifiers/QM/am-qm-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm01"
   },
   {
     "name": "am-qm-02",
     "points": 273,
     "image": "attack-modifiers/QM/am-qm-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm02"
   },
   {
     "name": "am-qm-03",
     "points": 274,
     "image": "attack-modifiers/QM/am-qm-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm03"
   },
   {
     "name": "am-qm-04",
     "points": 275,
     "image": "attack-modifiers/QM/am-qm-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm04"
   },
   {
     "name": "am-qm-05",
     "points": 276,
     "image": "attack-modifiers/QM/am-qm-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm05"
   },
   {
     "name": "am-qm-06",
     "points": 277,
     "image": "attack-modifiers/QM/am-qm-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm06"
   },
   {
     "name": "am-qm-07",
     "points": 278,
     "image": "attack-modifiers/QM/am-qm-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm07"
   },
   {
     "name": "am-qm-08",
     "points": 279,
     "image": "attack-modifiers/QM/am-qm-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm08"
   },
   {
     "name": "am-qm-09",
     "points": 280,
     "image": "attack-modifiers/QM/am-qm-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm09"
   },
   {
     "name": "am-qm-10",
     "points": 281,
     "image": "attack-modifiers/QM/am-qm-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm10"
   },
   {
     "name": "am-qm-11",
     "points": 282,
     "image": "attack-modifiers/QM/am-qm-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm11"
   },
   {
     "name": "am-qm-12",
     "points": 283,
     "image": "attack-modifiers/QM/am-qm-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm12"
   },
   {
     "name": "am-qm-13",
     "points": 284,
     "image": "attack-modifiers/QM/am-qm-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm13"
   },
   {
     "name": "am-qm-14",
     "points": 285,
     "image": "attack-modifiers/QM/am-qm-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm14"
   },
   {
     "name": "am-qm-15",
     "points": 286,
     "image": "attack-modifiers/QM/am-qm-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm15"
   },
   {
     "name": "am-qm-16",
     "points": 287,
     "image": "attack-modifiers/QM/am-qm-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm16"
   },
   {
     "name": "am-qm-17",
     "points": 288,
     "image": "attack-modifiers/QM/am-qm-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm17"
   },
   {
     "name": "am-qm-18",
     "points": 289,
     "image": "attack-modifiers/QM/am-qm-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amqm18"
   },
   {
     "name": "am-sb-01",
     "points": 290,
     "image": "attack-modifiers/SB/am-sb-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb01"
   },
   {
     "name": "am-sb-02",
     "points": 291,
     "image": "attack-modifiers/SB/am-sb-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb02"
   },
   {
     "name": "am-sb-03",
     "points": 292,
     "image": "attack-modifiers/SB/am-sb-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb03"
   },
   {
     "name": "am-sb-04",
     "points": 293,
     "image": "attack-modifiers/SB/am-sb-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb04"
   },
   {
     "name": "am-sb-05",
     "points": 294,
     "image": "attack-modifiers/SB/am-sb-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb05"
   },
   {
     "name": "am-sb-06",
     "points": 295,
     "image": "attack-modifiers/SB/am-sb-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb06"
   },
   {
     "name": "am-sb-07",
     "points": 296,
     "image": "attack-modifiers/SB/am-sb-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb07"
   },
   {
     "name": "am-sb-08",
     "points": 297,
     "image": "attack-modifiers/SB/am-sb-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb08"
   },
   {
     "name": "am-sb-09",
     "points": 298,
     "image": "attack-modifiers/SB/am-sb-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb09"
   },
   {
     "name": "am-sb-10",
     "points": 299,
     "image": "attack-modifiers/SB/am-sb-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb10"
   },
   {
     "name": "am-sb-11",
     "points": 300,
     "image": "attack-modifiers/SB/am-sb-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb11"
   },
   {
     "name": "am-sb-12",
     "points": 301,
     "image": "attack-modifiers/SB/am-sb-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb12"
   },
   {
     "name": "am-sb-13",
     "points": 302,
     "image": "attack-modifiers/SB/am-sb-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb13"
   },
   {
     "name": "am-sb-14",
     "points": 303,
     "image": "attack-modifiers/SB/am-sb-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsb14"
   },
   {
     "name": "am-sc-01",
     "points": 304,
     "image": "attack-modifiers/SC/am-sc-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc01"
   },
   {
     "name": "am-sc-02",
     "points": 305,
     "image": "attack-modifiers/SC/am-sc-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc02"
   },
   {
     "name": "am-sc-03",
     "points": 306,
     "image": "attack-modifiers/SC/am-sc-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc03"
   },
   {
     "name": "am-sc-04",
     "points": 307,
     "image": "attack-modifiers/SC/am-sc-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsc04"
   },
   {
     "name": "am-sc-05",
     "points": 308,
     "image": "attack-modifiers/SC/am-sc-05.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc05"
   },
   {
     "name": "am-sc-06",
     "points": 309,
     "image": "attack-modifiers/SC/am-sc-06.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc06"
   },
   {
     "name": "am-sc-07",
     "points": 310,
     "image": "attack-modifiers/SC/am-sc-07.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc07"
   },
   {
     "name": "am-sc-08",
     "points": 311,
     "image": "attack-modifiers/SC/am-sc-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsc08"
   },
   {
     "name": "am-sc-09",
     "points": 312,
     "image": "attack-modifiers/SC/am-sc-09.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc09"
   },
   {
     "name": "am-sc-10",
     "points": 313,
     "image": "attack-modifiers/SC/am-sc-10.png",
+    "value": "rolling",
+    "conditions": [
+      "pierce"
+    ],
     "xws": "amsc10"
   },
   {
     "name": "am-sc-11",
     "points": 314,
     "image": "attack-modifiers/SC/am-sc-11.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc11"
   },
   {
     "name": "am-sc-12",
     "points": 315,
     "image": "attack-modifiers/SC/am-sc-12.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc12"
   },
   {
     "name": "am-sc-13",
     "points": 316,
     "image": "attack-modifiers/SC/am-sc-13.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc13"
   },
   {
     "name": "am-sc-14",
     "points": 317,
     "image": "attack-modifiers/SC/am-sc-14.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsc14"
   },
   {
     "name": "am-sc-15",
     "points": 318,
     "image": "attack-modifiers/SC/am-sc-15.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc15"
   },
   {
     "name": "am-sc-16",
     "points": 319,
     "image": "attack-modifiers/SC/am-sc-16.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amsc16"
   },
   {
     "name": "am-sc-17",
     "points": 320,
     "image": "attack-modifiers/SC/am-sc-17.png",
+    "value": "rolling",
+    "conditions": [
+      "invisible"
+    ],
     "xws": "amsc17"
   },
   {
     "name": "am-sk-01",
     "points": 321,
     "image": "attack-modifiers/SK/am-sk-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk01"
   },
   {
     "name": "am-sk-02",
     "points": 322,
     "image": "attack-modifiers/SK/am-sk-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk02"
   },
   {
     "name": "am-sk-03",
     "points": 323,
     "image": "attack-modifiers/SK/am-sk-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk03"
   },
   {
     "name": "am-sk-04",
     "points": 324,
     "image": "attack-modifiers/SK/am-sk-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk04"
   },
   {
     "name": "am-sk-05",
     "points": 325,
     "image": "attack-modifiers/SK/am-sk-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk05"
   },
   {
     "name": "am-sk-06",
     "points": 326,
     "image": "attack-modifiers/SK/am-sk-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk06"
   },
   {
     "name": "am-sk-07",
     "points": 327,
     "image": "attack-modifiers/SK/am-sk-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk07"
   },
   {
     "name": "am-sk-08",
     "points": 328,
     "image": "attack-modifiers/SK/am-sk-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk08"
   },
   {
     "name": "am-sk-09",
     "points": 329,
     "image": "attack-modifiers/SK/am-sk-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk09"
   },
   {
     "name": "am-sk-10",
     "points": 330,
     "image": "attack-modifiers/SK/am-sk-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk10"
   },
   {
     "name": "am-sk-11",
     "points": 331,
     "image": "attack-modifiers/SK/am-sk-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk11"
   },
   {
     "name": "am-sk-12",
     "points": 332,
     "image": "attack-modifiers/SK/am-sk-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk12"
   },
   {
     "name": "am-sk-13",
     "points": 333,
     "image": "attack-modifiers/SK/am-sk-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk13"
   },
   {
     "name": "am-sk-14",
     "points": 334,
     "image": "attack-modifiers/SK/am-sk-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk14"
   },
   {
     "name": "am-sk-15",
     "points": 335,
     "image": "attack-modifiers/SK/am-sk-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk15"
   },
   {
     "name": "am-sk-16",
     "points": 336,
     "image": "attack-modifiers/SK/am-sk-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk16"
   },
   {
     "name": "am-sk-17",
     "points": 337,
     "image": "attack-modifiers/SK/am-sk-17.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk17"
   },
   {
     "name": "am-sk-18",
     "points": 338,
     "image": "attack-modifiers/SK/am-sk-18.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk18"
   },
   {
     "name": "am-sk-19",
     "points": 339,
     "image": "attack-modifiers/SK/am-sk-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsk19"
   },
   {
     "name": "am-ss-01",
     "points": 340,
     "image": "attack-modifiers/SS/am-ss-01.png",
+    "value": 0,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amss01"
   },
   {
     "name": "am-ss-02",
     "points": 341,
     "image": "attack-modifiers/SS/am-ss-02.png",
+    "value": 0,
+    "conditions": [
+      "disarm"
+    ],
     "xws": "amss02"
   },
   {
     "name": "am-ss-03",
     "points": 342,
     "image": "attack-modifiers/SS/am-ss-03.png",
+    "value": 0,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amss03"
   },
   {
     "name": "am-ss-04",
     "points": 343,
     "image": "attack-modifiers/SS/am-ss-04.png",
+    "value": 0,
+    "conditions": [
+      "poison"
+    ],
     "xws": "amss04"
   },
   {
     "name": "am-ss-05",
     "points": 344,
     "image": "attack-modifiers/SS/am-ss-05.png",
+    "value": 0,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss05"
   },
   {
     "name": "am-ss-06",
     "points": 345,
     "image": "attack-modifiers/SS/am-ss-06.png",
+    "value": 0,
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amss06"
   },
   {
     "name": "am-ss-07",
     "points": 346,
     "image": "attack-modifiers/SS/am-ss-07.png",
+    "value": -1,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amss07"
   },
   {
     "name": "am-ss-08",
     "points": 347,
     "image": "attack-modifiers/SS/am-ss-08.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss08"
   },
   {
     "name": "am-ss-09",
     "points": 348,
     "image": "attack-modifiers/SS/am-ss-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss09"
   },
   {
     "name": "am-ss-10",
     "points": 349,
     "image": "attack-modifiers/SS/am-ss-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amss10"
   },
   {
     "name": "am-ss-11",
     "points": 350,
     "image": "attack-modifiers/SS/am-ss-11.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss11"
   },
   {
     "name": "am-ss-12",
     "points": 351,
     "image": "attack-modifiers/SS/am-ss-12.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss12"
   },
   {
     "name": "am-ss-13",
     "points": 352,
     "image": "attack-modifiers/SS/am-ss-13.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss13"
   },
   {
     "name": "am-ss-14",
     "points": 353,
     "image": "attack-modifiers/SS/am-ss-14.png",
+    "value": "rolling",
+    "conditions": [
+      "curse"
+    ],
     "xws": "amss14"
   },
   {
     "name": "am-ss-15",
     "points": 354,
     "image": "attack-modifiers/SS/am-ss-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss15"
   },
   {
     "name": "am-ss-16",
     "points": 355,
     "image": "attack-modifiers/SS/am-ss-16.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amss16"
   },
   {
     "name": "am-su-01",
     "points": 356,
     "image": "attack-modifiers/SU/am-su-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu01"
   },
   {
     "name": "am-su-02",
     "points": 357,
     "image": "attack-modifiers/SU/am-su-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu02"
   },
   {
     "name": "am-su-03",
     "points": 358,
     "image": "attack-modifiers/SU/am-su-03.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu03"
   },
   {
     "name": "am-su-04",
     "points": 359,
     "image": "attack-modifiers/SU/am-su-04.png",
+    "value": 2,
+    "conditions": [],
     "xws": "amsu04"
   },
   {
     "name": "am-su-05",
     "points": 360,
     "image": "attack-modifiers/SU/am-su-05.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu05"
   },
   {
     "name": "am-su-06",
     "points": 361,
     "image": "attack-modifiers/SU/am-su-06.png",
+    "value": "rolling",
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsu06"
   },
   {
     "name": "am-su-07",
     "points": 362,
     "image": "attack-modifiers/SU/am-su-07.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu07"
   },
   {
     "name": "am-su-08",
     "points": 363,
     "image": "attack-modifiers/SU/am-su-08.png",
+    "value": "rolling",
+    "conditions": [
+      "poison"
+    ],
     "xws": "amsu08"
   },
   {
     "name": "am-su-09",
     "points": 364,
     "image": "attack-modifiers/SU/am-su-09.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu09"
   },
   {
     "name": "am-su-10",
     "points": 365,
     "image": "attack-modifiers/SU/am-su-10.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu10"
   },
   {
     "name": "am-su-11",
     "points": 366,
     "image": "attack-modifiers/SU/am-su-11.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu11"
   },
   {
     "name": "am-su-12",
     "points": 367,
     "image": "attack-modifiers/SU/am-su-12.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu12"
   },
   {
     "name": "am-su-13",
     "points": 368,
     "image": "attack-modifiers/SU/am-su-13.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu13"
   },
   {
     "name": "am-su-14",
     "points": 369,
     "image": "attack-modifiers/SU/am-su-14.png",
+    "value": "rolling",
+    "conditions": [],
     "xws": "amsu14"
   },
   {
     "name": "am-su-15",
     "points": 370,
     "image": "attack-modifiers/SU/am-su-15.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu15"
   },
   {
     "name": "am-su-16",
     "points": 371,
     "image": "attack-modifiers/SU/am-su-16.png",
+    "value": "rolling",
+    "conditions": [
+      "fire",
+      "wind"
+    ],
     "xws": "amsu16"
   },
   {
     "name": "am-su-17",
     "points": 372,
     "image": "attack-modifiers/SU/am-su-17.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu17"
   },
   {
     "name": "am-su-18",
     "points": 373,
     "image": "attack-modifiers/SU/am-su-18.png",
+    "value": "rolling",
+    "conditions": [
+      "night",
+      "earth"
+    ],
     "xws": "amsu18"
   },
   {
     "name": "am-su-19",
     "points": 374,
     "image": "attack-modifiers/SU/am-su-19.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu19"
   },
   {
     "name": "am-su-20",
     "points": 375,
     "image": "attack-modifiers/SU/am-su-20.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsu20"
   },
   {
     "name": "am-su-21",
     "points": 376,
     "image": "attack-modifiers/SU/am-su-21.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu21"
   },
   {
     "name": "am-su-22",
     "points": 377,
     "image": "attack-modifiers/SU/am-su-22.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsu22"
   },
   {
     "name": "am-sw-01",
     "points": 378,
     "image": "attack-modifiers/SW/am-sw-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw01"
   },
   {
     "name": "am-sw-02",
     "points": 379,
     "image": "attack-modifiers/SW/am-sw-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amsw02"
   },
   {
     "name": "am-sw-03",
     "points": 380,
     "image": "attack-modifiers/SW/am-sw-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw03"
   },
   {
     "name": "am-sw-04",
     "points": 381,
     "image": "attack-modifiers/SW/am-sw-04.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw04"
   },
   {
     "name": "am-sw-05",
     "points": 382,
     "image": "attack-modifiers/SW/am-sw-05.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw05"
   },
   {
     "name": "am-sw-06",
     "points": 383,
     "image": "attack-modifiers/SW/am-sw-06.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amsw06"
   },
   {
     "name": "am-sw-07",
     "points": 384,
     "image": "attack-modifiers/SW/am-sw-07.png",
+    "value": 0,
+    "conditions": [
+      "stun"
+    ],
     "xws": "amsw07"
   },
   {
     "name": "am-sw-08",
     "points": 385,
     "image": "attack-modifiers/SW/am-sw-08.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amsw08"
   },
   {
     "name": "am-sw-09",
     "points": 386,
     "image": "attack-modifiers/SW/am-sw-09.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amsw09"
   },
   {
     "name": "am-sw-10",
     "points": 387,
     "image": "attack-modifiers/SW/am-sw-10.png",
+    "value": 1,
+    "conditions": [
+      "curse"
+    ],
     "xws": "amsw10"
   },
   {
     "name": "am-sw-11",
     "points": 388,
     "image": "attack-modifiers/SW/am-sw-11.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw11"
   },
   {
     "name": "am-sw-12",
     "points": 389,
     "image": "attack-modifiers/SW/am-sw-12.png",
+    "value": 2,
+    "conditions": [
+      "fire"
+    ],
     "xws": "amsw12"
   },
   {
     "name": "am-sw-13",
     "points": 390,
     "image": "attack-modifiers/SW/am-sw-13.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw13"
   },
   {
     "name": "am-sw-14",
     "points": 391,
     "image": "attack-modifiers/SW/am-sw-14.png",
+    "value": 2,
+    "conditions": [
+      "ice"
+    ],
     "xws": "amsw14"
   },
   {
     "name": "am-sw-15",
     "points": 392,
     "image": "attack-modifiers/SW/am-sw-15.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw15"
   },
   {
     "name": "am-sw-16",
     "points": 393,
     "image": "attack-modifiers/SW/am-sw-16.png",
+    "value": "rolling",
+    "conditions": [
+      "earth",
+      "wind"
+    ],
     "xws": "amsw16"
   },
   {
     "name": "am-sw-17",
     "points": 394,
     "image": "attack-modifiers/SW/am-sw-17.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw17"
   },
   {
     "name": "am-sw-18",
     "points": 395,
     "image": "attack-modifiers/SW/am-sw-18.png",
+    "value": "rolling",
+    "conditions": [
+      "sun",
+      "night"
+    ],
     "xws": "amsw18"
   },
   {
     "name": "am-ti-01",
     "points": 396,
     "image": "attack-modifiers/TI/am-ti-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amti01"
   },
   {
     "name": "am-ti-02",
     "points": 397,
     "image": "attack-modifiers/TI/am-ti-02.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti02"
   },
   {
     "name": "am-ti-03",
     "points": 398,
     "image": "attack-modifiers/TI/am-ti-03.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti03"
   },
   {
     "name": "am-ti-04",
     "points": 399,
     "image": "attack-modifiers/TI/am-ti-04.png",
+    "value": 3,
+    "conditions": [],
     "xws": "amti04"
   },
   {
     "name": "am-ti-05",
     "points": 400,
     "image": "attack-modifiers/TI/am-ti-05.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti05"
   },
   {
     "name": "am-ti-06",
     "points": 401,
     "image": "attack-modifiers/TI/am-ti-06.png",
+    "value": "rolling",
+    "conditions": [
+      "fire"
+    ],
     "xws": "amti06"
   },
   {
     "name": "am-ti-07",
     "points": 402,
     "image": "attack-modifiers/TI/am-ti-07.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti07"
   },
   {
     "name": "am-ti-08",
     "points": 403,
     "image": "attack-modifiers/TI/am-ti-08.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti08"
   },
   {
     "name": "am-ti-09",
     "points": 404,
     "image": "attack-modifiers/TI/am-ti-09.png",
+    "value": "rolling",
+    "conditions": [
+      "muddle"
+    ],
     "xws": "amti09"
   },
   {
     "name": "am-ti-10",
     "points": 405,
     "image": "attack-modifiers/TI/am-ti-10.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti10"
   },
   {
     "name": "am-ti-11",
     "points": 406,
     "image": "attack-modifiers/TI/am-ti-11.png",
+    "value": 1,
+    "conditions": [
+      "wound"
+    ],
     "xws": "amti11"
   },
   {
     "name": "am-ti-12",
     "points": 407,
     "image": "attack-modifiers/TI/am-ti-12.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti12"
   },
   {
     "name": "am-ti-13",
     "points": 408,
     "image": "attack-modifiers/TI/am-ti-13.png",
+    "value": 1,
+    "conditions": [
+      "immobilize"
+    ],
     "xws": "amti13"
   },
   {
     "name": "am-ti-14",
     "points": 409,
     "image": "attack-modifiers/TI/am-ti-14.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti14"
   },
   {
     "name": "am-ti-15",
     "points": 410,
     "image": "attack-modifiers/TI/am-ti-15.png",
+    "value": 1,
+    "conditions": [],
     "xws": "amti15"
   },
   {
     "name": "am-ti-16",
     "points": 411,
     "image": "attack-modifiers/TI/am-ti-16.png",
+    "value": 0,
+    "conditions": [
+      "add-target"
+    ],
     "xws": "amti16"
   },
   {
     "name": "am-dr-01",
     "points": 412,
     "image": "attack-modifiers/DR/am-dr-01.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr01"
   },
   {
     "name": "am-dr-02",
     "points": 413,
     "image": "attack-modifiers/DR/am-dr-02.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr02"
   },
   {
     "name": "am-dr-03",
     "points": 414,
     "image": "attack-modifiers/DR/am-dr-03.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr03"
   },
   {
     "name": "am-dr-04",
     "points": 415,
     "image": "attack-modifiers/DR/am-dr-04.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr04"
   },
   {
     "name": "am-dr-05",
     "points": 416,
     "image": "attack-modifiers/DR/am-dr-05.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr05"
   },
   {
     "name": "am-dr-06",
     "points": 417,
     "image": "attack-modifiers/DR/am-dr-06.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr06"
   },
   {
     "name": "am-dr-07",
     "points": 418,
     "image": "attack-modifiers/DR/am-dr-07.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr07"
   },
   {
     "name": "am-dr-08",
     "points": 419,
     "image": "attack-modifiers/DR/am-dr-08.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr08"
   },
   {
     "name": "am-dr-09",
     "points": 420,
     "image": "attack-modifiers/DR/am-dr-09.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr09"
   },
   {
     "name": "am-dr-10",
     "points": 421,
     "image": "attack-modifiers/DR/am-dr-10.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr10"
   },
   {
     "name": "am-dr-11",
     "points": 422,
     "image": "attack-modifiers/DR/am-dr-11.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr11"
   },
   {
     "name": "am-dr-12",
     "points": 423,
     "image": "attack-modifiers/DR/am-dr-12.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr12"
   },
   {
     "name": "am-dr-13",
     "points": 424,
     "image": "attack-modifiers/DR/am-dr-13.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr13"
   },
   {
     "name": "am-dr-14",
     "points": 425,
     "image": "attack-modifiers/DR/am-dr-14.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr14"
   },
   {
     "name": "am-dr-15",
     "points": 426,
     "image": "attack-modifiers/DR/am-dr-15.png",
+    "value": "special",
+    "conditions": [],
     "xws": "amdr15"
   }
 ]

--- a/data/character-ability-cards-revised.json
+++ b/data/character-ability-cards-revised.json
@@ -1,0 +1,86 @@
+[
+  {
+    "name": "bt-back",
+    "points": 0,
+    "image": "character-ability-cards-revised/BT/bt-back.png",
+    "xws": "btback"
+  },
+  {
+    "name": "disorienting roar",
+    "points": 1,
+    "image": "character-ability-cards-revised/BT/disorienting-roar.png",
+    "xws": "disorientingroar"
+  },
+  {
+    "name": "primal blessing",
+    "points": 2,
+    "image": "character-ability-cards-revised/BT/primal-blessing.png",
+    "xws": "primalblessing"
+  },
+  {
+    "name": "spirit swap",
+    "points": 3,
+    "image": "character-ability-cards-revised/BT/spirit-swap.png",
+    "xws": "spiritswap"
+  },
+  {
+    "name": "ds-back",
+    "points": 4,
+    "image": "character-ability-cards-revised/DS/ds-back.png",
+    "xws": "dsback"
+  },
+  {
+    "name": "felling swoop",
+    "points": 5,
+    "image": "character-ability-cards-revised/DS/felling-swoop.png",
+    "xws": "fellingswoop"
+  },
+  {
+    "name": "concealed dominance",
+    "points": 6,
+    "image": "character-ability-cards-revised/NS/concealed-dominance.png",
+    "xws": "concealeddominance"
+  },
+  {
+    "name": "ns-back",
+    "points": 7,
+    "image": "character-ability-cards-revised/NS/ns-back.png",
+    "xws": "nsback"
+  },
+  {
+    "name": "otherworldly rage",
+    "points": 8,
+    "image": "character-ability-cards-revised/SU/otherworldly-rage.png",
+    "xws": "otherworldlyrage"
+  },
+  {
+    "name": "su-back",
+    "points": 9,
+    "image": "character-ability-cards-revised/SU/su-back.png",
+    "xws": "suback"
+  },
+  {
+    "name": "halt-bottom-back",
+    "points": 10,
+    "image": "character-ability-cards-revised/ZZ/halt-bottom-back.png",
+    "xws": "haltbottomback"
+  },
+  {
+    "name": "halt-bottom-front",
+    "points": 11,
+    "image": "character-ability-cards-revised/ZZ/halt-bottom-front.png",
+    "xws": "haltbottomfront"
+  },
+  {
+    "name": "halt-top-back",
+    "points": 12,
+    "image": "character-ability-cards-revised/ZZ/halt-top-back.png",
+    "xws": "halttopback"
+  },
+  {
+    "name": "halt-top-front",
+    "points": 13,
+    "image": "character-ability-cards-revised/ZZ/halt-top-front.png",
+    "xws": "halttopfront"
+  }
+]

--- a/data/character-ability-cards.json
+++ b/data/character-ability-cards.json
@@ -1,0 +1,3704 @@
+[
+  {
+    "name": "be-back",
+    "points": 0,
+    "image": "character-ability-cards/BE/be-back.png",
+    "xws": "beback"
+  },
+  {
+    "name": "blood pact",
+    "points": 1,
+    "image": "character-ability-cards/BE/blood-pact.png",
+    "xws": "bloodpact"
+  },
+  {
+    "name": "bone breaker",
+    "points": 2,
+    "image": "character-ability-cards/BE/bone-breaker.png",
+    "xws": "bonebreaker"
+  },
+  {
+    "name": "bounce back",
+    "points": 3,
+    "image": "character-ability-cards/BE/bounce-back.png",
+    "xws": "bounceback"
+  },
+  {
+    "name": "break the chains",
+    "points": 4,
+    "image": "character-ability-cards/BE/break-the-chains.png",
+    "xws": "breakthechains"
+  },
+  {
+    "name": "burning hatred",
+    "points": 5,
+    "image": "character-ability-cards/BE/burning-hatred.png",
+    "xws": "burninghatred"
+  },
+  {
+    "name": "careless charge",
+    "points": 6,
+    "image": "character-ability-cards/BE/careless-charge.png",
+    "xws": "carelesscharge"
+  },
+  {
+    "name": "cauterize",
+    "points": 7,
+    "image": "character-ability-cards/BE/cauterize.png",
+    "xws": "cauterize"
+  },
+  {
+    "name": "dazing wound",
+    "points": 8,
+    "image": "character-ability-cards/BE/dazing-wound.png",
+    "xws": "dazingwound"
+  },
+  {
+    "name": "defiance of death",
+    "points": 9,
+    "image": "character-ability-cards/BE/defiance-of-death.png",
+    "xws": "defianceofdeath"
+  },
+  {
+    "name": "devil horns",
+    "points": 10,
+    "image": "character-ability-cards/BE/devil-horns.png",
+    "xws": "devilhorns"
+  },
+  {
+    "name": "fatal fury",
+    "points": 11,
+    "image": "character-ability-cards/BE/fatal-fury.png",
+    "xws": "fatalfury"
+  },
+  {
+    "name": "final fight",
+    "points": 12,
+    "image": "character-ability-cards/BE/final-fight.png",
+    "xws": "finalfight"
+  },
+  {
+    "name": "flurry of axes",
+    "points": 13,
+    "image": "character-ability-cards/BE/flurry-of-axes.png",
+    "xws": "flurryofaxes"
+  },
+  {
+    "name": "from the brink",
+    "points": 14,
+    "image": "character-ability-cards/BE/from-the-brink.png",
+    "xws": "fromthebrink"
+  },
+  {
+    "name": "furious aid",
+    "points": 15,
+    "image": "character-ability-cards/BE/furious-aid.png",
+    "xws": "furiousaid"
+  },
+  {
+    "name": "glass hammer",
+    "points": 16,
+    "image": "character-ability-cards/BE/glass-hammer.png",
+    "xws": "glasshammer"
+  },
+  {
+    "name": "growing rage",
+    "points": 17,
+    "image": "character-ability-cards/BE/growing-rage.png",
+    "xws": "growingrage"
+  },
+  {
+    "name": "immortality",
+    "points": 18,
+    "image": "character-ability-cards/BE/immortality.png",
+    "xws": "immortality"
+  },
+  {
+    "name": "numb the pain",
+    "points": 19,
+    "image": "character-ability-cards/BE/numb-the-pain.png",
+    "xws": "numbthepain"
+  },
+  {
+    "name": "reckless offensive",
+    "points": 20,
+    "image": "character-ability-cards/BE/reckless-offensive.png",
+    "xws": "recklessoffensive"
+  },
+  {
+    "name": "resolute stand",
+    "points": 21,
+    "image": "character-ability-cards/BE/resolute-stand.png",
+    "xws": "resolutestand"
+  },
+  {
+    "name": "seeing red",
+    "points": 22,
+    "image": "character-ability-cards/BE/seeing-red.png",
+    "xws": "seeingred"
+  },
+  {
+    "name": "shiny distraction",
+    "points": 23,
+    "image": "character-ability-cards/BE/shiny-distraction.png",
+    "xws": "shinydistraction"
+  },
+  {
+    "name": "spiked armor",
+    "points": 24,
+    "image": "character-ability-cards/BE/spiked-armor.png",
+    "xws": "spikedarmor"
+  },
+  {
+    "name": "strength in agony",
+    "points": 25,
+    "image": "character-ability-cards/BE/strength-in-agony.png",
+    "xws": "strengthinagony"
+  },
+  {
+    "name": "the maw of madness",
+    "points": 26,
+    "image": "character-ability-cards/BE/the-maw-of-madness.png",
+    "xws": "themawofmadness"
+  },
+  {
+    "name": "unbridled power",
+    "points": 27,
+    "image": "character-ability-cards/BE/unbridled-power.png",
+    "xws": "unbridledpower"
+  },
+  {
+    "name": "unstoppable destruction",
+    "points": 28,
+    "image": "character-ability-cards/BE/unstoppable-destruction.png",
+    "xws": "unstoppabledestruction"
+  },
+  {
+    "name": "vengeful barrage",
+    "points": 29,
+    "image": "character-ability-cards/BE/vengeful-barrage.png",
+    "xws": "vengefulbarrage"
+  },
+  {
+    "name": "balanced measure",
+    "points": 30,
+    "image": "character-ability-cards/BR/balanced-measure.png",
+    "xws": "balancedmeasure"
+  },
+  {
+    "name": "br-back",
+    "points": 31,
+    "image": "character-ability-cards/BR/br-back.png",
+    "xws": "brback"
+  },
+  {
+    "name": "brute force",
+    "points": 32,
+    "image": "character-ability-cards/BR/brute-force.png",
+    "xws": "bruteforce"
+  },
+  {
+    "name": "crippling offensive",
+    "points": 33,
+    "image": "character-ability-cards/BR/crippling-offensive.png",
+    "xws": "cripplingoffensive"
+  },
+  {
+    "name": "defensive tactics",
+    "points": 34,
+    "image": "character-ability-cards/BR/defensive-tactics.png",
+    "xws": "defensivetactics"
+  },
+  {
+    "name": "devastating hack",
+    "points": 35,
+    "image": "character-ability-cards/BR/devastating-hack.png",
+    "xws": "devastatinghack"
+  },
+  {
+    "name": "eye for an eye",
+    "points": 36,
+    "image": "character-ability-cards/BR/eye-for-an-eye.png",
+    "xws": "eyeforaneye"
+  },
+  {
+    "name": "face your end",
+    "points": 37,
+    "image": "character-ability-cards/BR/face-your-end.png",
+    "xws": "faceyourend"
+  },
+  {
+    "name": "fatal advance",
+    "points": 38,
+    "image": "character-ability-cards/BR/fatal-advance.png",
+    "xws": "fataladvance"
+  },
+  {
+    "name": "frenzied onslaught",
+    "points": 39,
+    "image": "character-ability-cards/BR/frenzied-onslaught.png",
+    "xws": "frenziedonslaught"
+  },
+  {
+    "name": "grab and go",
+    "points": 40,
+    "image": "character-ability-cards/BR/grab-and-go.png",
+    "xws": "grabandgo"
+  },
+  {
+    "name": "hook and chain",
+    "points": 41,
+    "image": "character-ability-cards/BR/hook-and-chain.png",
+    "xws": "hookandchain"
+  },
+  {
+    "name": "immovable phalanx",
+    "points": 42,
+    "image": "character-ability-cards/BR/immovable-phalanx.png",
+    "xws": "immovablephalanx"
+  },
+  {
+    "name": "juggernaut",
+    "points": 43,
+    "image": "character-ability-cards/BR/juggernaut.png",
+    "xws": "juggernaut"
+  },
+  {
+    "name": "king of the hill",
+    "points": 44,
+    "image": "character-ability-cards/BR/king-of-the-hill.png",
+    "xws": "kingofthehill"
+  },
+  {
+    "name": "leaping cleave",
+    "points": 45,
+    "image": "character-ability-cards/BR/leaping-cleave.png",
+    "xws": "leapingcleave"
+  },
+  {
+    "name": "overwhelming assault",
+    "points": 46,
+    "image": "character-ability-cards/BR/overwhelming-assault.png",
+    "xws": "overwhelmingassault"
+  },
+  {
+    "name": "provoking roar",
+    "points": 47,
+    "image": "character-ability-cards/BR/provoking-roar.png",
+    "xws": "provokingroar"
+  },
+  {
+    "name": "quietus",
+    "points": 48,
+    "image": "character-ability-cards/BR/quietus.png",
+    "xws": "quietus"
+  },
+  {
+    "name": "selfish retribution",
+    "points": 49,
+    "image": "character-ability-cards/BR/selfish-retribution.png",
+    "xws": "selfishretribution"
+  },
+  {
+    "name": "shield bash",
+    "points": 50,
+    "image": "character-ability-cards/BR/shield-bash.png",
+    "xws": "shieldbash"
+  },
+  {
+    "name": "skewer",
+    "points": 51,
+    "image": "character-ability-cards/BR/skewer.png",
+    "xws": "skewer"
+  },
+  {
+    "name": "skirmishing maneuver",
+    "points": 52,
+    "image": "character-ability-cards/BR/skirmishing-maneuver.png",
+    "xws": "skirmishingmaneuver"
+  },
+  {
+    "name": "spare dagger",
+    "points": 53,
+    "image": "character-ability-cards/BR/spare-dagger.png",
+    "xws": "sparedagger"
+  },
+  {
+    "name": "sweeping blow",
+    "points": 54,
+    "image": "character-ability-cards/BR/sweeping-blow.png",
+    "xws": "sweepingblow"
+  },
+  {
+    "name": "trample",
+    "points": 55,
+    "image": "character-ability-cards/BR/trample.png",
+    "xws": "trample"
+  },
+  {
+    "name": "unstoppable charge",
+    "points": 56,
+    "image": "character-ability-cards/BR/unstoppable-charge.png",
+    "xws": "unstoppablecharge"
+  },
+  {
+    "name": "wall of doom",
+    "points": 57,
+    "image": "character-ability-cards/BR/wall-of-doom.png",
+    "xws": "wallofdoom"
+  },
+  {
+    "name": "warding strength",
+    "points": 58,
+    "image": "character-ability-cards/BR/warding-strength.png",
+    "xws": "wardingstrength"
+  },
+  {
+    "name": "whirlwind",
+    "points": 59,
+    "image": "character-ability-cards/BR/whirlwind.png",
+    "xws": "whirlwind"
+  },
+  {
+    "name": "bioluminescence",
+    "points": 60,
+    "image": "character-ability-cards/BS/bioluminescence.png",
+    "xws": "bioluminescence"
+  },
+  {
+    "name": "blood drain",
+    "points": 61,
+    "image": "character-ability-cards/BS/blood-drain.png",
+    "xws": "blooddrain"
+  },
+  {
+    "name": "bone daggers",
+    "points": 62,
+    "image": "character-ability-cards/BS/bone-daggers.png",
+    "xws": "bonedaggers"
+  },
+  {
+    "name": "bs-back",
+    "points": 63,
+    "image": "character-ability-cards/BS/bs-back.png",
+    "xws": "bsback"
+  },
+  {
+    "name": "call of the grave",
+    "points": 64,
+    "image": "character-ability-cards/BS/call-of-the-grave.png",
+    "xws": "callofthegrave"
+  },
+  {
+    "name": "corrupting parasites",
+    "points": 65,
+    "image": "character-ability-cards/BS/corrupting-parasites.png",
+    "xws": "corruptingparasites"
+  },
+  {
+    "name": "death march",
+    "points": 66,
+    "image": "character-ability-cards/BS/death-march.png",
+    "xws": "deathmarch"
+  },
+  {
+    "name": "deflecting blades",
+    "points": 67,
+    "image": "character-ability-cards/BS/deflecting-blades.png",
+    "xws": "deflectingblades"
+  },
+  {
+    "name": "engulfing stingers",
+    "points": 68,
+    "image": "character-ability-cards/BS/engulfing-stingers.png",
+    "xws": "engulfingstingers"
+  },
+  {
+    "name": "erosion",
+    "points": 69,
+    "image": "character-ability-cards/BS/erosion.png",
+    "xws": "erosion"
+  },
+  {
+    "name": "focused scourge",
+    "points": 70,
+    "image": "character-ability-cards/BS/focused-scourge.png",
+    "xws": "focusedscourge"
+  },
+  {
+    "name": "grasping advance",
+    "points": 71,
+    "image": "character-ability-cards/BS/grasping-advance.png",
+    "xws": "graspingadvance"
+  },
+  {
+    "name": "hive mind",
+    "points": 72,
+    "image": "character-ability-cards/BS/hive-mind.png",
+    "xws": "hivemind"
+  },
+  {
+    "name": "incubation",
+    "points": 73,
+    "image": "character-ability-cards/BS/incubation.png",
+    "xws": "incubation"
+  },
+  {
+    "name": "infest",
+    "points": 74,
+    "image": "character-ability-cards/BS/infest.png",
+    "xws": "infest"
+  },
+  {
+    "name": "oasis",
+    "points": 75,
+    "image": "character-ability-cards/BS/oasis.png",
+    "xws": "oasis"
+  },
+  {
+    "name": "omniscient assault",
+    "points": 76,
+    "image": "character-ability-cards/BS/omniscient-assault.png",
+    "xws": "omniscientassault"
+  },
+  {
+    "name": "prismatic cyclone",
+    "points": 77,
+    "image": "character-ability-cards/BS/prismatic-cyclone.png",
+    "xws": "prismaticcyclone"
+  },
+  {
+    "name": "putrid grubs",
+    "points": 78,
+    "image": "character-ability-cards/BS/putrid-grubs.png",
+    "xws": "putridgrubs"
+  },
+  {
+    "name": "sand scythe",
+    "points": 79,
+    "image": "character-ability-cards/BS/sand-scythe.png",
+    "xws": "sandscythe"
+  },
+  {
+    "name": "scattered defense",
+    "points": 80,
+    "image": "character-ability-cards/BS/scattered-defense.png",
+    "xws": "scattereddefense"
+  },
+  {
+    "name": "solitary horde",
+    "points": 81,
+    "image": "character-ability-cards/BS/solitary-horde.png",
+    "xws": "solitaryhorde"
+  },
+  {
+    "name": "sunstroke",
+    "points": 82,
+    "image": "character-ability-cards/BS/sunstroke.png",
+    "xws": "sunstroke"
+  },
+  {
+    "name": "swarming minions",
+    "points": 83,
+    "image": "character-ability-cards/BS/swarming-minions.png",
+    "xws": "swarmingminions"
+  },
+  {
+    "name": "sword of tenacity",
+    "points": 84,
+    "image": "character-ability-cards/BS/sword-of-tenacity.png",
+    "xws": "swordoftenacity"
+  },
+  {
+    "name": "the storm's edge",
+    "points": 85,
+    "image": "character-ability-cards/BS/the-storms-edge.png",
+    "xws": "thestormsedge"
+  },
+  {
+    "name": "tomb of the immortal",
+    "points": 86,
+    "image": "character-ability-cards/BS/tomb-of-the-immortal.png",
+    "xws": "tomboftheimmortal"
+  },
+  {
+    "name": "unstoppable army",
+    "points": 87,
+    "image": "character-ability-cards/BS/unstoppable-army.png",
+    "xws": "unstoppablearmy"
+  },
+  {
+    "name": "vampiric tempest",
+    "points": 88,
+    "image": "character-ability-cards/BS/vampiric-tempest.png",
+    "xws": "vampirictempest"
+  },
+  {
+    "name": "venomous barbs",
+    "points": 89,
+    "image": "character-ability-cards/BS/venomous-barbs.png",
+    "xws": "venomousbarbs"
+  },
+  {
+    "name": "wasteland",
+    "points": 90,
+    "image": "character-ability-cards/BS/wasteland.png",
+    "xws": "wasteland"
+  },
+  {
+    "name": "ancient ward",
+    "points": 91,
+    "image": "character-ability-cards/BT/ancient-ward.png",
+    "xws": "ancientward"
+  },
+  {
+    "name": "blood hunger",
+    "points": 92,
+    "image": "character-ability-cards/BT/blood-hunger.png",
+    "xws": "bloodhunger"
+  },
+  {
+    "name": "borrowed essence",
+    "points": 93,
+    "image": "character-ability-cards/BT/borrowed-essence.png",
+    "xws": "borrowedessence"
+  },
+  {
+    "name": "bt-back",
+    "points": 94,
+    "image": "character-ability-cards/BT/bt-back.png",
+    "xws": "btback"
+  },
+  {
+    "name": "concentrated rage",
+    "points": 95,
+    "image": "character-ability-cards/BT/concentrated-rage.png",
+    "xws": "concentratedrage"
+  },
+  {
+    "name": "disappearing wounds",
+    "points": 96,
+    "image": "character-ability-cards/BT/disappearing-wounds.png",
+    "xws": "disappearingwounds"
+  },
+  {
+    "name": "disorienting roar",
+    "points": 97,
+    "image": "character-ability-cards/BT/disorienting-roar.png",
+    "xws": "disorientingroar"
+  },
+  {
+    "name": "earthen spikes",
+    "points": 98,
+    "image": "character-ability-cards/BT/earthen-spikes.png",
+    "xws": "earthenspikes"
+  },
+  {
+    "name": "energizing strike",
+    "points": 99,
+    "image": "character-ability-cards/BT/energizing-strike.png",
+    "xws": "energizingstrike"
+  },
+  {
+    "name": "focused aggression",
+    "points": 100,
+    "image": "character-ability-cards/BT/focused-aggression.png",
+    "xws": "focusedaggression"
+  },
+  {
+    "name": "forceful swipe",
+    "points": 101,
+    "image": "character-ability-cards/BT/forceful-swipe.png",
+    "xws": "forcefulswipe"
+  },
+  {
+    "name": "howling bolts",
+    "points": 102,
+    "image": "character-ability-cards/BT/howling-bolts.png",
+    "xws": "howlingbolts"
+  },
+  {
+    "name": "jaws of death",
+    "points": 103,
+    "image": "character-ability-cards/BT/jaws-of-death.png",
+    "xws": "jawsofdeath"
+  },
+  {
+    "name": "lash out",
+    "points": 104,
+    "image": "character-ability-cards/BT/lash-out.png",
+    "xws": "lashout"
+  },
+  {
+    "name": "maul",
+    "points": 105,
+    "image": "character-ability-cards/BT/maul.png",
+    "xws": "maul"
+  },
+  {
+    "name": "natural remedy",
+    "points": 106,
+    "image": "character-ability-cards/BT/natural-remedy.png",
+    "xws": "naturalremedy"
+  },
+  {
+    "name": "patch fur",
+    "points": 107,
+    "image": "character-ability-cards/BT/patch-fur.png",
+    "xws": "patchfur"
+  },
+  {
+    "name": "primal blessing",
+    "points": 108,
+    "image": "character-ability-cards/BT/primal-blessing.png",
+    "xws": "primalblessing"
+  },
+  {
+    "name": "punch through",
+    "points": 109,
+    "image": "character-ability-cards/BT/punch-through.png",
+    "xws": "punchthrough"
+  },
+  {
+    "name": "rampage",
+    "points": 110,
+    "image": "character-ability-cards/BT/rampage.png",
+    "xws": "rampage"
+  },
+  {
+    "name": "relentless ally",
+    "points": 111,
+    "image": "character-ability-cards/BT/relentless-ally.png",
+    "xws": "relentlessally"
+  },
+  {
+    "name": "soaring ally",
+    "points": 112,
+    "image": "character-ability-cards/BT/soaring-ally.png",
+    "xws": "soaringally"
+  },
+  {
+    "name": "spirit swap",
+    "points": 113,
+    "image": "character-ability-cards/BT/spirit-swap.png",
+    "xws": "spiritswap"
+  },
+  {
+    "name": "stone sigil",
+    "points": 114,
+    "image": "character-ability-cards/BT/stone-sigil.png",
+    "xws": "stonesigil"
+  },
+  {
+    "name": "storm sigil",
+    "points": 115,
+    "image": "character-ability-cards/BT/storm-sigil.png",
+    "xws": "stormsigil"
+  },
+  {
+    "name": "tribal sigil",
+    "points": 116,
+    "image": "character-ability-cards/BT/tribal-sigil.png",
+    "xws": "tribalsigil"
+  },
+  {
+    "name": "tyrannical force",
+    "points": 117,
+    "image": "character-ability-cards/BT/tyrannical-force.png",
+    "xws": "tyrannicalforce"
+  },
+  {
+    "name": "unstoppable beast",
+    "points": 118,
+    "image": "character-ability-cards/BT/unstoppable-beast.png",
+    "xws": "unstoppablebeast"
+  },
+  {
+    "name": "venomous ally",
+    "points": 119,
+    "image": "character-ability-cards/BT/venomous-ally.png",
+    "xws": "venomousally"
+  },
+  {
+    "name": "vicious ally",
+    "points": 120,
+    "image": "character-ability-cards/BT/vicious-ally.png",
+    "xws": "viciousally"
+  },
+  {
+    "name": "avalanche",
+    "points": 121,
+    "image": "character-ability-cards/CH/avalanche.png",
+    "xws": "avalanche"
+  },
+  {
+    "name": "backup ammunition",
+    "points": 122,
+    "image": "character-ability-cards/CH/backup-ammunition.png",
+    "xws": "backupammunition"
+  },
+  {
+    "name": "blind destruction",
+    "points": 123,
+    "image": "character-ability-cards/CH/blind-destruction.png",
+    "xws": "blinddestruction"
+  },
+  {
+    "name": "blunt force",
+    "points": 124,
+    "image": "character-ability-cards/CH/blunt-force.png",
+    "xws": "bluntforce"
+  },
+  {
+    "name": "brutal momentum",
+    "points": 125,
+    "image": "character-ability-cards/CH/brutal-momentum.png",
+    "xws": "brutalmomentum"
+  },
+  {
+    "name": "cataclysm",
+    "points": 126,
+    "image": "character-ability-cards/CH/cataclysm.png",
+    "xws": "cataclysm"
+  },
+  {
+    "name": "ch-back",
+    "points": 127,
+    "image": "character-ability-cards/CH/ch-back.png",
+    "xws": "chback"
+  },
+  {
+    "name": "clear the way",
+    "points": 128,
+    "image": "character-ability-cards/CH/clear-the-way.png",
+    "xws": "cleartheway"
+  },
+  {
+    "name": "crater",
+    "points": 129,
+    "image": "character-ability-cards/CH/crater.png",
+    "xws": "crater"
+  },
+  {
+    "name": "crushing grasp",
+    "points": 130,
+    "image": "character-ability-cards/CH/crushing-grasp.png",
+    "xws": "crushinggrasp"
+  },
+  {
+    "name": "dig pit",
+    "points": 131,
+    "image": "character-ability-cards/CH/dig-pit.png",
+    "xws": "digpit"
+  },
+  {
+    "name": "dirt tornado",
+    "points": 132,
+    "image": "character-ability-cards/CH/dirt-tornado.png",
+    "xws": "dirttornado"
+  },
+  {
+    "name": "earthen clod",
+    "points": 133,
+    "image": "character-ability-cards/CH/earthen-clod.png",
+    "xws": "earthenclod"
+  },
+  {
+    "name": "explosive punch",
+    "points": 134,
+    "image": "character-ability-cards/CH/explosive-punch.png",
+    "xws": "explosivepunch"
+  },
+  {
+    "name": "forceful storm",
+    "points": 135,
+    "image": "character-ability-cards/CH/forceful-storm.png",
+    "xws": "forcefulstorm"
+  },
+  {
+    "name": "heaving swing",
+    "points": 136,
+    "image": "character-ability-cards/CH/heaving-swing.png",
+    "xws": "heavingswing"
+  },
+  {
+    "name": "kinetic assault",
+    "points": 137,
+    "image": "character-ability-cards/CH/kinetic-assault.png",
+    "xws": "kineticassault"
+  },
+  {
+    "name": "lumbering bash",
+    "points": 138,
+    "image": "character-ability-cards/CH/lumbering-bash.png",
+    "xws": "lumberingbash"
+  },
+  {
+    "name": "massive boulder",
+    "points": 139,
+    "image": "character-ability-cards/CH/massive-boulder.png",
+    "xws": "massiveboulder"
+  },
+  {
+    "name": "meteor",
+    "points": 140,
+    "image": "character-ability-cards/CH/meteor.png",
+    "xws": "meteor"
+  },
+  {
+    "name": "nature's lift",
+    "points": 141,
+    "image": "character-ability-cards/CH/natures-lift.png",
+    "xws": "natureslift"
+  },
+  {
+    "name": "opposing strike",
+    "points": 142,
+    "image": "character-ability-cards/CH/opposing-strike.png",
+    "xws": "opposingstrike"
+  },
+  {
+    "name": "petrify",
+    "points": 143,
+    "image": "character-ability-cards/CH/petrify.png",
+    "xws": "petrify"
+  },
+  {
+    "name": "pulverize",
+    "points": 144,
+    "image": "character-ability-cards/CH/pulverize.png",
+    "xws": "pulverize"
+  },
+  {
+    "name": "rock slide",
+    "points": 145,
+    "image": "character-ability-cards/CH/rock-slide.png",
+    "xws": "rockslide"
+  },
+  {
+    "name": "rock tunnel",
+    "points": 146,
+    "image": "character-ability-cards/CH/rock-tunnel.png",
+    "xws": "rocktunnel"
+  },
+  {
+    "name": "rocky end",
+    "points": 147,
+    "image": "character-ability-cards/CH/rocky-end.png",
+    "xws": "rockyend"
+  },
+  {
+    "name": "rumbling advance",
+    "points": 148,
+    "image": "character-ability-cards/CH/rumbling-advance.png",
+    "xws": "rumblingadvance"
+  },
+  {
+    "name": "sentient growth",
+    "points": 149,
+    "image": "character-ability-cards/CH/sentient-growth.png",
+    "xws": "sentientgrowth"
+  },
+  {
+    "name": "stone pummel",
+    "points": 150,
+    "image": "character-ability-cards/CH/stone-pummel.png",
+    "xws": "stonepummel"
+  },
+  {
+    "name": "unstable upheaval",
+    "points": 151,
+    "image": "character-ability-cards/CH/unstable-upheaval.png",
+    "xws": "unstableupheaval"
+  },
+  {
+    "name": "a moment's peace",
+    "points": 152,
+    "image": "character-ability-cards/DS/a-moments-peace.png",
+    "xws": "amomentspeace"
+  },
+  {
+    "name": "camouflage",
+    "points": 153,
+    "image": "character-ability-cards/DS/camouflage.png",
+    "xws": "camouflage"
+  },
+  {
+    "name": "crashing wave",
+    "points": 154,
+    "image": "character-ability-cards/DS/crashing-wave.png",
+    "xws": "crashingwave"
+  },
+  {
+    "name": "crippling noose",
+    "points": 155,
+    "image": "character-ability-cards/DS/crippling-noose.png",
+    "xws": "cripplingnoose"
+  },
+  {
+    "name": "darkened skies",
+    "points": 156,
+    "image": "character-ability-cards/DS/darkened-skies.png",
+    "xws": "darkenedskies"
+  },
+  {
+    "name": "detonation",
+    "points": 157,
+    "image": "character-ability-cards/DS/detonation.png",
+    "xws": "detonation"
+  },
+  {
+    "name": "ds-back",
+    "points": 158,
+    "image": "character-ability-cards/DS/ds-back.png",
+    "xws": "dsback"
+  },
+  {
+    "name": "expose",
+    "points": 159,
+    "image": "character-ability-cards/DS/expose.png",
+    "xws": "expose"
+  },
+  {
+    "name": "felling swoop",
+    "points": 160,
+    "image": "character-ability-cards/DS/felling-swoop.png",
+    "xws": "fellingswoop"
+  },
+  {
+    "name": "feral instincts",
+    "points": 161,
+    "image": "character-ability-cards/DS/feral-instincts.png",
+    "xws": "feralinstincts"
+  },
+  {
+    "name": "flight of flame",
+    "points": 162,
+    "image": "character-ability-cards/DS/flight-of-flame.png",
+    "xws": "flightofflame"
+  },
+  {
+    "name": "foot snare",
+    "points": 163,
+    "image": "character-ability-cards/DS/foot-snare.png",
+    "xws": "footsnare"
+  },
+  {
+    "name": "fresh kill",
+    "points": 164,
+    "image": "character-ability-cards/DS/fresh-kill.png",
+    "xws": "freshkill"
+  },
+  {
+    "name": "frightening curse",
+    "points": 165,
+    "image": "character-ability-cards/DS/frightening-curse.png",
+    "xws": "frighteningcurse"
+  },
+  {
+    "name": "impending end",
+    "points": 166,
+    "image": "character-ability-cards/DS/impending-end.png",
+    "xws": "impendingend"
+  },
+  {
+    "name": "inescapable fate",
+    "points": 167,
+    "image": "character-ability-cards/DS/inescapable-fate.png",
+    "xws": "inescapablefate"
+  },
+  {
+    "name": "lead to slaughter",
+    "points": 168,
+    "image": "character-ability-cards/DS/lead-to-slaughter.png",
+    "xws": "leadtoslaughter"
+  },
+  {
+    "name": "multi-pronged assault",
+    "points": 169,
+    "image": "character-ability-cards/DS/multi-pronged-assault.png",
+    "xws": "multiprongedassault"
+  },
+  {
+    "name": "nature's hunger",
+    "points": 170,
+    "image": "character-ability-cards/DS/natures-hunger.png",
+    "xws": "natureshunger"
+  },
+  {
+    "name": "predator and prey",
+    "points": 171,
+    "image": "character-ability-cards/DS/predator-and-prey.png",
+    "xws": "predatorandprey"
+  },
+  {
+    "name": "press the attack",
+    "points": 172,
+    "image": "character-ability-cards/DS/press-the-attack.png",
+    "xws": "presstheattack"
+  },
+  {
+    "name": "race to the grave",
+    "points": 173,
+    "image": "character-ability-cards/DS/race-to-the-grave.png",
+    "xws": "racetothegrave"
+  },
+  {
+    "name": "rain of arrows",
+    "points": 174,
+    "image": "character-ability-cards/DS/rain-of-arrows.png",
+    "xws": "rainofarrows"
+  },
+  {
+    "name": "relentless offensive",
+    "points": 175,
+    "image": "character-ability-cards/DS/relentless-offensive.png",
+    "xws": "relentlessoffensive"
+  },
+  {
+    "name": "rising momentum",
+    "points": 176,
+    "image": "character-ability-cards/DS/rising-momentum.png",
+    "xws": "risingmomentum"
+  },
+  {
+    "name": "sap life",
+    "points": 177,
+    "image": "character-ability-cards/DS/sap-life.png",
+    "xws": "saplife"
+  },
+  {
+    "name": "singular focus",
+    "points": 178,
+    "image": "character-ability-cards/DS/singular-focus.png",
+    "xws": "singularfocus"
+  },
+  {
+    "name": "solid bow",
+    "points": 179,
+    "image": "character-ability-cards/DS/solid-bow.png",
+    "xws": "solidbow"
+  },
+  {
+    "name": "swift trickery",
+    "points": 180,
+    "image": "character-ability-cards/DS/swift-trickery.png",
+    "xws": "swifttrickery"
+  },
+  {
+    "name": "the hunt begins",
+    "points": 181,
+    "image": "character-ability-cards/DS/the-hunt-begins.png",
+    "xws": "thehuntbegins"
+  },
+  {
+    "name": "vital charge",
+    "points": 182,
+    "image": "character-ability-cards/DS/vital-charge.png",
+    "xws": "vitalcharge"
+  },
+  {
+    "name": "wild command",
+    "points": 183,
+    "image": "character-ability-cards/DS/wild-command.png",
+    "xws": "wildcommand"
+  },
+  {
+    "name": "boiling arc",
+    "points": 184,
+    "image": "character-ability-cards/EL/boiling-arc.png",
+    "xws": "boilingarc"
+  },
+  {
+    "name": "brilliant flash",
+    "points": 185,
+    "image": "character-ability-cards/EL/brilliant-flash.png",
+    "xws": "brilliantflash"
+  },
+  {
+    "name": "burial",
+    "points": 186,
+    "image": "character-ability-cards/EL/burial.png",
+    "xws": "burial"
+  },
+  {
+    "name": "chain lightning",
+    "points": 187,
+    "image": "character-ability-cards/EL/chain-lightning.png",
+    "xws": "chainlightning"
+  },
+  {
+    "name": "crystallizing blast",
+    "points": 188,
+    "image": "character-ability-cards/EL/crystallizing-blast.png",
+    "xws": "crystallizingblast"
+  },
+  {
+    "name": "el-back",
+    "points": 189,
+    "image": "character-ability-cards/EL/el-back.png",
+    "xws": "elback"
+  },
+  {
+    "name": "elemental aegis",
+    "points": 190,
+    "image": "character-ability-cards/EL/elemental-aegis.png",
+    "xws": "elementalaegis"
+  },
+  {
+    "name": "encompassing shadow",
+    "points": 191,
+    "image": "character-ability-cards/EL/encompassing-shadow.png",
+    "xws": "encompassingshadow"
+  },
+  {
+    "name": "eternal equilibrium",
+    "points": 192,
+    "image": "character-ability-cards/EL/eternal-equilibrium.png",
+    "xws": "eternalequilibrium"
+  },
+  {
+    "name": "ethereal manifestation",
+    "points": 193,
+    "image": "character-ability-cards/EL/ethereal-manifestation.png",
+    "xws": "etherealmanifestation"
+  },
+  {
+    "name": "eye of the hurricane",
+    "points": 194,
+    "image": "character-ability-cards/EL/eye-of-the-hurricane.png",
+    "xws": "eyeofthehurricane"
+  },
+  {
+    "name": "formless power",
+    "points": 195,
+    "image": "character-ability-cards/EL/formless-power.png",
+    "xws": "formlesspower"
+  },
+  {
+    "name": "frigid torrent",
+    "points": 196,
+    "image": "character-ability-cards/EL/frigid-torrent.png",
+    "xws": "frigidtorrent"
+  },
+  {
+    "name": "gravel vortex",
+    "points": 197,
+    "image": "character-ability-cards/EL/gravel-vortex.png",
+    "xws": "gravelvortex"
+  },
+  {
+    "name": "ice spikes",
+    "points": 198,
+    "image": "character-ability-cards/EL/ice-spikes.png",
+    "xws": "icespikes"
+  },
+  {
+    "name": "infernal vortex",
+    "points": 199,
+    "image": "character-ability-cards/EL/infernal-vortex.png",
+    "xws": "infernalvortex"
+  },
+  {
+    "name": "lava eruption",
+    "points": 200,
+    "image": "character-ability-cards/EL/lava-eruption.png",
+    "xws": "lavaeruption"
+  },
+  {
+    "name": "malleable evocation",
+    "points": 201,
+    "image": "character-ability-cards/EL/malleable-evocation.png",
+    "xws": "malleableevocation"
+  },
+  {
+    "name": "obsidian shards",
+    "points": 202,
+    "image": "character-ability-cards/EL/obsidian-shards.png",
+    "xws": "obsidianshards"
+  },
+  {
+    "name": "pragmatic reinforcement",
+    "points": 203,
+    "image": "character-ability-cards/EL/pragmatic-reinforcement.png",
+    "xws": "pragmaticreinforcement"
+  },
+  {
+    "name": "primal duality",
+    "points": 204,
+    "image": "character-ability-cards/EL/primal-duality.png",
+    "xws": "primalduality"
+  },
+  {
+    "name": "pure augmentation",
+    "points": 205,
+    "image": "character-ability-cards/EL/pure-augmentation.png",
+    "xws": "pureaugmentation"
+  },
+  {
+    "name": "raw enhancement",
+    "points": 206,
+    "image": "character-ability-cards/EL/raw-enhancement.png",
+    "xws": "rawenhancement"
+  },
+  {
+    "name": "shaping the ether",
+    "points": 207,
+    "image": "character-ability-cards/EL/shaping-the-ether.png",
+    "xws": "shapingtheether"
+  },
+  {
+    "name": "simulacrum",
+    "points": 208,
+    "image": "character-ability-cards/EL/simulacrum.png",
+    "xws": "simulacrum"
+  },
+  {
+    "name": "stoking hail",
+    "points": 209,
+    "image": "character-ability-cards/EL/stoking-hail.png",
+    "xws": "stokinghail"
+  },
+  {
+    "name": "tremulant cyclone",
+    "points": 210,
+    "image": "character-ability-cards/EL/tremulant-cyclone.png",
+    "xws": "tremulantcyclone"
+  },
+  {
+    "name": "vengeance",
+    "points": 211,
+    "image": "character-ability-cards/EL/vengeance.png",
+    "xws": "vengeance"
+  },
+  {
+    "name": "volatile consumption",
+    "points": 212,
+    "image": "character-ability-cards/EL/volatile-consumption.png",
+    "xws": "volatileconsumption"
+  },
+  {
+    "name": "winter's edge",
+    "points": 213,
+    "image": "character-ability-cards/EL/winters-edge.png",
+    "xws": "wintersedge"
+  },
+  {
+    "name": "brain leech",
+    "points": 214,
+    "image": "character-ability-cards/MT/brain-leech.png",
+    "xws": "brainleech"
+  },
+  {
+    "name": "corrupting embrace",
+    "points": 215,
+    "image": "character-ability-cards/MT/corrupting-embrace.png",
+    "xws": "corruptingembrace"
+  },
+  {
+    "name": "cranium overload",
+    "points": 216,
+    "image": "character-ability-cards/MT/cranium-overload.png",
+    "xws": "craniumoverload"
+  },
+  {
+    "name": "dark frenzy",
+    "points": 217,
+    "image": "character-ability-cards/MT/dark-frenzy.png",
+    "xws": "darkfrenzy"
+  },
+  {
+    "name": "domination",
+    "points": 218,
+    "image": "character-ability-cards/MT/domination.png",
+    "xws": "domination"
+  },
+  {
+    "name": "empathetic assault",
+    "points": 219,
+    "image": "character-ability-cards/MT/empathetic-assault.png",
+    "xws": "empatheticassault"
+  },
+  {
+    "name": "fearsome blade",
+    "points": 220,
+    "image": "character-ability-cards/MT/fearsome-blade.png",
+    "xws": "fearsomeblade"
+  },
+  {
+    "name": "feedback loop",
+    "points": 221,
+    "image": "character-ability-cards/MT/feedback-loop.png",
+    "xws": "feedbackloop"
+  },
+  {
+    "name": "frigid apparition",
+    "points": 222,
+    "image": "character-ability-cards/MT/frigid-apparition.png",
+    "xws": "frigidapparition"
+  },
+  {
+    "name": "frozen mind",
+    "points": 223,
+    "image": "character-ability-cards/MT/frozen-mind.png",
+    "xws": "frozenmind"
+  },
+  {
+    "name": "gnawing horde",
+    "points": 224,
+    "image": "character-ability-cards/MT/gnawing-horde.png",
+    "xws": "gnawinghorde"
+  },
+  {
+    "name": "hostile takeover",
+    "points": 225,
+    "image": "character-ability-cards/MT/hostile-takeover.png",
+    "xws": "hostiletakeover"
+  },
+  {
+    "name": "into the night",
+    "points": 226,
+    "image": "character-ability-cards/MT/into-the-night.png",
+    "xws": "intothenight"
+  },
+  {
+    "name": "many as one",
+    "points": 227,
+    "image": "character-ability-cards/MT/many-as-one.png",
+    "xws": "manyasone"
+  },
+  {
+    "name": "mass hysteria",
+    "points": 228,
+    "image": "character-ability-cards/MT/mass-hysteria.png",
+    "xws": "masshysteria"
+  },
+  {
+    "name": "mt-back",
+    "points": 229,
+    "image": "character-ability-cards/MT/mt-back.png",
+    "xws": "mtback"
+  },
+  {
+    "name": "parasitic influence",
+    "points": 230,
+    "image": "character-ability-cards/MT/parasitic-influence.png",
+    "xws": "parasiticinfluence"
+  },
+  {
+    "name": "perverse edge",
+    "points": 231,
+    "image": "character-ability-cards/MT/perverse-edge.png",
+    "xws": "perverseedge"
+  },
+  {
+    "name": "phantasmal killer",
+    "points": 232,
+    "image": "character-ability-cards/MT/phantasmal-killer.png",
+    "xws": "phantasmalkiller"
+  },
+  {
+    "name": "pilfer",
+    "points": 233,
+    "image": "character-ability-cards/MT/pilfer.png",
+    "xws": "pilfer"
+  },
+  {
+    "name": "possession",
+    "points": 234,
+    "image": "character-ability-cards/MT/possession.png",
+    "xws": "possession"
+  },
+  {
+    "name": "psychic projection",
+    "points": 235,
+    "image": "character-ability-cards/MT/psychic-projection.png",
+    "xws": "psychicprojection"
+  },
+  {
+    "name": "scurry",
+    "points": 236,
+    "image": "character-ability-cards/MT/scurry.png",
+    "xws": "scurry"
+  },
+  {
+    "name": "shared nightmare",
+    "points": 237,
+    "image": "character-ability-cards/MT/shared-nightmare.png",
+    "xws": "sharednightmare"
+  },
+  {
+    "name": "silent scream",
+    "points": 238,
+    "image": "character-ability-cards/MT/silent-scream.png",
+    "xws": "silentscream"
+  },
+  {
+    "name": "submissive affliction",
+    "points": 239,
+    "image": "character-ability-cards/MT/submissive-affliction.png",
+    "xws": "submissiveaffliction"
+  },
+  {
+    "name": "the mind's weakness",
+    "points": 240,
+    "image": "character-ability-cards/MT/the-minds-weakness.png",
+    "xws": "themindsweakness"
+  },
+  {
+    "name": "vicious blood",
+    "points": 241,
+    "image": "character-ability-cards/MT/vicious-blood.png",
+    "xws": "viciousblood"
+  },
+  {
+    "name": "withering claw",
+    "points": 242,
+    "image": "character-ability-cards/MT/withering-claw.png",
+    "xws": "witheringclaw"
+  },
+  {
+    "name": "wretched creature",
+    "points": 243,
+    "image": "character-ability-cards/MT/wretched-creature.png",
+    "xws": "wretchedcreature"
+  },
+  {
+    "name": "angel of death",
+    "points": 244,
+    "image": "character-ability-cards/NS/angel-of-death.png",
+    "xws": "angelofdeath"
+  },
+  {
+    "name": "armor of the night",
+    "points": 245,
+    "image": "character-ability-cards/NS/armor-of-the-night.png",
+    "xws": "armorofthenight"
+  },
+  {
+    "name": "black arrow",
+    "points": 246,
+    "image": "character-ability-cards/NS/black-arrow.png",
+    "xws": "blackarrow"
+  },
+  {
+    "name": "black knives",
+    "points": 247,
+    "image": "character-ability-cards/NS/black-knives.png",
+    "xws": "blackknives"
+  },
+  {
+    "name": "claws of the night",
+    "points": 248,
+    "image": "character-ability-cards/NS/claws-of-the-night.png",
+    "xws": "clawsofthenight"
+  },
+  {
+    "name": "cloak of shade",
+    "points": 249,
+    "image": "character-ability-cards/NS/cloak-of-shade.png",
+    "xws": "cloakofshade"
+  },
+  {
+    "name": "concealed dominance",
+    "points": 250,
+    "image": "character-ability-cards/NS/concealed-dominance.png",
+    "xws": "concealeddominance"
+  },
+  {
+    "name": "dancing shadows",
+    "points": 251,
+    "image": "character-ability-cards/NS/dancing-shadows.png",
+    "xws": "dancingshadows"
+  },
+  {
+    "name": "dark cloud",
+    "points": 252,
+    "image": "character-ability-cards/NS/dark-cloud.png",
+    "xws": "darkcloud"
+  },
+  {
+    "name": "doomed breeze",
+    "points": 253,
+    "image": "character-ability-cards/NS/doomed-breeze.png",
+    "xws": "doomedbreeze"
+  },
+  {
+    "name": "empowering void",
+    "points": 254,
+    "image": "character-ability-cards/NS/empowering-void.png",
+    "xws": "empoweringvoid"
+  },
+  {
+    "name": "enervating wound",
+    "points": 255,
+    "image": "character-ability-cards/NS/enervating-wound.png",
+    "xws": "enervatingwound"
+  },
+  {
+    "name": "eyes of the night",
+    "points": 256,
+    "image": "character-ability-cards/NS/eyes-of-the-night.png",
+    "xws": "eyesofthenight"
+  },
+  {
+    "name": "gloom darts",
+    "points": 257,
+    "image": "character-ability-cards/NS/gloom-darts.png",
+    "xws": "gloomdarts"
+  },
+  {
+    "name": "grim sustenance",
+    "points": 258,
+    "image": "character-ability-cards/NS/grim-sustenance.png",
+    "xws": "grimsustenance"
+  },
+  {
+    "name": "lurking ruin",
+    "points": 259,
+    "image": "character-ability-cards/NS/lurking-ruin.png",
+    "xws": "lurkingruin"
+  },
+  {
+    "name": "nightfall",
+    "points": 260,
+    "image": "character-ability-cards/NS/nightfall.png",
+    "xws": "nightfall"
+  },
+  {
+    "name": "ns-back",
+    "points": 261,
+    "image": "character-ability-cards/NS/ns-back.png",
+    "xws": "nsback"
+  },
+  {
+    "name": "prepare for the kill",
+    "points": 262,
+    "image": "character-ability-cards/NS/prepare-for-the-kill.png",
+    "xws": "prepareforthekill"
+  },
+  {
+    "name": "quiet frenzy",
+    "points": 263,
+    "image": "character-ability-cards/NS/quiet-frenzy.png",
+    "xws": "quietfrenzy"
+  },
+  {
+    "name": "silent force",
+    "points": 264,
+    "image": "character-ability-cards/NS/silent-force.png",
+    "xws": "silentforce"
+  },
+  {
+    "name": "smoke step",
+    "points": 265,
+    "image": "character-ability-cards/NS/smoke-step.png",
+    "xws": "smokestep"
+  },
+  {
+    "name": "soulfire",
+    "points": 266,
+    "image": "character-ability-cards/NS/soulfire.png",
+    "xws": "soulfire"
+  },
+  {
+    "name": "spirit of the night",
+    "points": 267,
+    "image": "character-ability-cards/NS/spirit-of-the-night.png",
+    "xws": "spiritofthenight"
+  },
+  {
+    "name": "swallowed by fear",
+    "points": 268,
+    "image": "character-ability-cards/NS/swallowed-by-fear.png",
+    "xws": "swallowedbyfear"
+  },
+  {
+    "name": "terror blade",
+    "points": 269,
+    "image": "character-ability-cards/NS/terror-blade.png",
+    "xws": "terrorblade"
+  },
+  {
+    "name": "unseen dread",
+    "points": 270,
+    "image": "character-ability-cards/NS/unseen-dread.png",
+    "xws": "unseendread"
+  },
+  {
+    "name": "voice of the night",
+    "points": 271,
+    "image": "character-ability-cards/NS/voice-of-the-night.png",
+    "xws": "voiceofthenight"
+  },
+  {
+    "name": "wings of the night",
+    "points": 272,
+    "image": "character-ability-cards/NS/wings-of-the-night.png",
+    "xws": "wingsofthenight"
+  },
+  {
+    "name": "accelerated end",
+    "points": 273,
+    "image": "character-ability-cards/PH/accelerated-end.png",
+    "xws": "acceleratedend"
+  },
+  {
+    "name": "airborne toxin",
+    "points": 274,
+    "image": "character-ability-cards/PH/airborne-toxin.png",
+    "xws": "airbornetoxin"
+  },
+  {
+    "name": "baneful hex",
+    "points": 275,
+    "image": "character-ability-cards/PH/baneful-hex.png",
+    "xws": "banefulhex"
+  },
+  {
+    "name": "biting gnats",
+    "points": 276,
+    "image": "character-ability-cards/PH/biting-gnats.png",
+    "xws": "bitinggnats"
+  },
+  {
+    "name": "black tides",
+    "points": 277,
+    "image": "character-ability-cards/PH/black-tides.png",
+    "xws": "blacktides"
+  },
+  {
+    "name": "blistering vortex",
+    "points": 278,
+    "image": "character-ability-cards/PH/blistering-vortex.png",
+    "xws": "blisteringvortex"
+  },
+  {
+    "name": "convert the flock",
+    "points": 279,
+    "image": "character-ability-cards/PH/convert-the-flock.png",
+    "xws": "converttheflock"
+  },
+  {
+    "name": "creeping curse",
+    "points": 280,
+    "image": "character-ability-cards/PH/creeping-curse.png",
+    "xws": "creepingcurse"
+  },
+  {
+    "name": "epidemic",
+    "points": 281,
+    "image": "character-ability-cards/PH/epidemic.png",
+    "xws": "epidemic"
+  },
+  {
+    "name": "fetid flurry",
+    "points": 282,
+    "image": "character-ability-cards/PH/fetid-flurry.png",
+    "xws": "fetidflurry"
+  },
+  {
+    "name": "foul wind",
+    "points": 283,
+    "image": "character-ability-cards/PH/foul-wind.png",
+    "xws": "foulwind"
+  },
+  {
+    "name": "gathering doom",
+    "points": 284,
+    "image": "character-ability-cards/PH/gathering-doom.png",
+    "xws": "gatheringdoom"
+  },
+  {
+    "name": "grasping vermin",
+    "points": 285,
+    "image": "character-ability-cards/PH/grasping-vermin.png",
+    "xws": "graspingvermin"
+  },
+  {
+    "name": "grim bargain",
+    "points": 286,
+    "image": "character-ability-cards/PH/grim-bargain.png",
+    "xws": "grimbargain"
+  },
+  {
+    "name": "mass extinction",
+    "points": 287,
+    "image": "character-ability-cards/PH/mass-extinction.png",
+    "xws": "massextinction"
+  },
+  {
+    "name": "nightmarish affliction",
+    "points": 288,
+    "image": "character-ability-cards/PH/nightmarish-affliction.png",
+    "xws": "nightmarishaffliction"
+  },
+  {
+    "name": "paralyzing bite",
+    "points": 289,
+    "image": "character-ability-cards/PH/paralyzing-bite.png",
+    "xws": "paralyzingbite"
+  },
+  {
+    "name": "ph-back",
+    "points": 290,
+    "image": "character-ability-cards/PH/ph-back.png",
+    "xws": "phback"
+  },
+  {
+    "name": "rot maggots",
+    "points": 291,
+    "image": "character-ability-cards/PH/rot-maggots.png",
+    "xws": "rotmaggots"
+  },
+  {
+    "name": "scattered terror",
+    "points": 292,
+    "image": "character-ability-cards/PH/scattered-terror.png",
+    "xws": "scatteredterror"
+  },
+  {
+    "name": "spreading scourge",
+    "points": 293,
+    "image": "character-ability-cards/PH/spreading-scourge.png",
+    "xws": "spreadingscourge"
+  },
+  {
+    "name": "spread the plague",
+    "points": 294,
+    "image": "character-ability-cards/PH/spread-the-plague.png",
+    "xws": "spreadtheplague"
+  },
+  {
+    "name": "stinging cloud",
+    "points": 295,
+    "image": "character-ability-cards/PH/stinging-cloud.png",
+    "xws": "stingingcloud"
+  },
+  {
+    "name": "storm of wings",
+    "points": 296,
+    "image": "character-ability-cards/PH/storm-of-wings.png",
+    "xws": "stormofwings"
+  },
+  {
+    "name": "succumb to the gift",
+    "points": 297,
+    "image": "character-ability-cards/PH/succumb-to-the-gift.png",
+    "xws": "succumbtothegift"
+  },
+  {
+    "name": "under the skin",
+    "points": 298,
+    "image": "character-ability-cards/PH/under-the-skin.png",
+    "xws": "undertheskin"
+  },
+  {
+    "name": "vile pestilence",
+    "points": 299,
+    "image": "character-ability-cards/PH/vile-pestilence.png",
+    "xws": "vilepestilence"
+  },
+  {
+    "name": "virulent strain",
+    "points": 300,
+    "image": "character-ability-cards/PH/virulent-strain.png",
+    "xws": "virulentstrain"
+  },
+  {
+    "name": "willing sacrifice",
+    "points": 301,
+    "image": "character-ability-cards/PH/willing-sacrifice.png",
+    "xws": "willingsacrifice"
+  },
+  {
+    "name": "winged congregation",
+    "points": 302,
+    "image": "character-ability-cards/PH/winged-congregation.png",
+    "xws": "wingedcongregation"
+  },
+  {
+    "name": "wretched swarm",
+    "points": 303,
+    "image": "character-ability-cards/PH/wretched-swarm.png",
+    "xws": "wretchedswarm"
+  },
+  {
+    "name": "bag of holding",
+    "points": 304,
+    "image": "character-ability-cards/QM/bag-of-holding.png",
+    "xws": "bagofholding"
+  },
+  {
+    "name": "bladed boomerang",
+    "points": 305,
+    "image": "character-ability-cards/QM/bladed-boomerang.png",
+    "xws": "bladedboomerang"
+  },
+  {
+    "name": "catastrophic bomb",
+    "points": 306,
+    "image": "character-ability-cards/QM/catastrophic-bomb.png",
+    "xws": "catastrophicbomb"
+  },
+  {
+    "name": "cleaving axe",
+    "points": 307,
+    "image": "character-ability-cards/QM/cleaving-axe.png",
+    "xws": "cleavingaxe"
+  },
+  {
+    "name": "continual supply",
+    "points": 308,
+    "image": "character-ability-cards/QM/continual-supply.png",
+    "xws": "continualsupply"
+  },
+  {
+    "name": "crippling bow",
+    "points": 309,
+    "image": "character-ability-cards/QM/crippling-bow.png",
+    "xws": "cripplingbow"
+  },
+  {
+    "name": "crushing hammer",
+    "points": 310,
+    "image": "character-ability-cards/QM/crushing-hammer.png",
+    "xws": "crushinghammer"
+  },
+  {
+    "name": "fortified position",
+    "points": 311,
+    "image": "character-ability-cards/QM/fortified-position.png",
+    "xws": "fortifiedposition"
+  },
+  {
+    "name": "giant club",
+    "points": 312,
+    "image": "character-ability-cards/QM/giant-club.png",
+    "xws": "giantclub"
+  },
+  {
+    "name": "hastened step",
+    "points": 313,
+    "image": "character-ability-cards/QM/hastened-step.png",
+    "xws": "hastenedstep"
+  },
+  {
+    "name": "impaling spear",
+    "points": 314,
+    "image": "character-ability-cards/QM/impaling-spear.png",
+    "xws": "impalingspear"
+  },
+  {
+    "name": "iron bulwark",
+    "points": 315,
+    "image": "character-ability-cards/QM/iron-bulwark.png",
+    "xws": "ironbulwark"
+  },
+  {
+    "name": "oversized pack",
+    "points": 316,
+    "image": "character-ability-cards/QM/oversized-pack.png",
+    "xws": "oversizedpack"
+  },
+  {
+    "name": "portable ballista",
+    "points": 317,
+    "image": "character-ability-cards/QM/portable-ballista.png",
+    "xws": "portableballista"
+  },
+  {
+    "name": "proficiency",
+    "points": 318,
+    "image": "character-ability-cards/QM/proficiency.png",
+    "xws": "proficiency"
+  },
+  {
+    "name": "qm-back",
+    "points": 319,
+    "image": "character-ability-cards/QM/qm-back.png",
+    "xws": "qmback"
+  },
+  {
+    "name": "quiver of arrows",
+    "points": 320,
+    "image": "character-ability-cards/QM/quiver-of-arrows.png",
+    "xws": "quiverofarrows"
+  },
+  {
+    "name": "refreshment",
+    "points": 321,
+    "image": "character-ability-cards/QM/refreshment.png",
+    "xws": "refreshment"
+  },
+  {
+    "name": "reforge",
+    "points": 322,
+    "image": "character-ability-cards/QM/reforge.png",
+    "xws": "reforge"
+  },
+  {
+    "name": "reinforced steel",
+    "points": 323,
+    "image": "character-ability-cards/QM/reinforced-steel.png",
+    "xws": "reinforcedsteel"
+  },
+  {
+    "name": "reserved energy",
+    "points": 324,
+    "image": "character-ability-cards/QM/reserved-energy.png",
+    "xws": "reservedenergy"
+  },
+  {
+    "name": "restock",
+    "points": 325,
+    "image": "character-ability-cards/QM/restock.png",
+    "xws": "restock"
+  },
+  {
+    "name": "scroll of annihilation",
+    "points": 326,
+    "image": "character-ability-cards/QM/scroll-of-annihilation.png",
+    "xws": "scrollofannihilation"
+  },
+  {
+    "name": "scroll of blizzards",
+    "points": 327,
+    "image": "character-ability-cards/QM/scroll-of-blizzards.png",
+    "xws": "scrollofblizzards"
+  },
+  {
+    "name": "scroll of judgment",
+    "points": 328,
+    "image": "character-ability-cards/QM/scroll-of-judgment.png",
+    "xws": "scrollofjudgment"
+  },
+  {
+    "name": "scroll of lightning",
+    "points": 329,
+    "image": "character-ability-cards/QM/scroll-of-lightning.png",
+    "xws": "scrolloflightning"
+  },
+  {
+    "name": "scroll of recall",
+    "points": 330,
+    "image": "character-ability-cards/QM/scroll-of-recall.png",
+    "xws": "scrollofrecall"
+  },
+  {
+    "name": "sharpening kit",
+    "points": 331,
+    "image": "character-ability-cards/QM/sharpening-kit.png",
+    "xws": "sharpeningkit"
+  },
+  {
+    "name": "side pouch",
+    "points": 332,
+    "image": "character-ability-cards/QM/side-pouch.png",
+    "xws": "sidepouch"
+  },
+  {
+    "name": "amputate",
+    "points": 333,
+    "image": "character-ability-cards/SB/amputate.png",
+    "xws": "amputate"
+  },
+  {
+    "name": "battlefield medicine",
+    "points": 334,
+    "image": "character-ability-cards/SB/battlefield-medicine.png",
+    "xws": "battlefieldmedicine"
+  },
+  {
+    "name": "bedside manner",
+    "points": 335,
+    "image": "character-ability-cards/SB/bedside-manner.png",
+    "xws": "bedsidemanner"
+  },
+  {
+    "name": "blood transfusion",
+    "points": 336,
+    "image": "character-ability-cards/SB/blood-transfusion.png",
+    "xws": "bloodtransfusion"
+  },
+  {
+    "name": "bloody saw",
+    "points": 337,
+    "image": "character-ability-cards/SB/bloody-saw.png",
+    "xws": "bloodysaw"
+  },
+  {
+    "name": "booster shot",
+    "points": 338,
+    "image": "character-ability-cards/SB/booster-shot.png",
+    "xws": "boostershot"
+  },
+  {
+    "name": "curative mixture",
+    "points": 339,
+    "image": "character-ability-cards/SB/curative-mixture.png",
+    "xws": "curativemixture"
+  },
+  {
+    "name": "do no harm",
+    "points": 340,
+    "image": "character-ability-cards/SB/do-no-harm.png",
+    "xws": "donoharm"
+  },
+  {
+    "name": "euthanize",
+    "points": 341,
+    "image": "character-ability-cards/SB/euthanize.png",
+    "xws": "euthanize"
+  },
+  {
+    "name": "first aid",
+    "points": 342,
+    "image": "character-ability-cards/SB/first-aid.png",
+    "xws": "firstaid"
+  },
+  {
+    "name": "gentleman's anger",
+    "points": 343,
+    "image": "character-ability-cards/SB/gentlemans-anger.png",
+    "xws": "gentlemansanger"
+  },
+  {
+    "name": "grisly trauma",
+    "points": 344,
+    "image": "character-ability-cards/SB/grisly-trauma.png",
+    "xws": "grislytrauma"
+  },
+  {
+    "name": "hamstring",
+    "points": 345,
+    "image": "character-ability-cards/SB/hamstring.png",
+    "xws": "hamstring"
+  },
+  {
+    "name": "hand of the surgeon",
+    "points": 346,
+    "image": "character-ability-cards/SB/hand-of-the-surgeon.png",
+    "xws": "handofthesurgeon"
+  },
+  {
+    "name": "hold back the pain",
+    "points": 347,
+    "image": "character-ability-cards/SB/hold-back-the-pain.png",
+    "xws": "holdbackthepain"
+  },
+  {
+    "name": "large medical pack",
+    "points": 348,
+    "image": "character-ability-cards/SB/large-medical-pack.png",
+    "xws": "largemedicalpack"
+  },
+  {
+    "name": "master physician",
+    "points": 349,
+    "image": "character-ability-cards/SB/master-physician.png",
+    "xws": "masterphysician"
+  },
+  {
+    "name": "medical pack",
+    "points": 350,
+    "image": "character-ability-cards/SB/medical-pack.png",
+    "xws": "medicalpack"
+  },
+  {
+    "name": "precaution",
+    "points": 351,
+    "image": "character-ability-cards/SB/precaution.png",
+    "xws": "precaution"
+  },
+  {
+    "name": "prep for surgery",
+    "points": 352,
+    "image": "character-ability-cards/SB/prep-for-surgery.png",
+    "xws": "prepforsurgery"
+  },
+  {
+    "name": "prescription",
+    "points": 353,
+    "image": "character-ability-cards/SB/prescription.png",
+    "xws": "prescription"
+  },
+  {
+    "name": "prevention is key",
+    "points": 354,
+    "image": "character-ability-cards/SB/prevention-is-key.png",
+    "xws": "preventioniskey"
+  },
+  {
+    "name": "regenerative tissue",
+    "points": 355,
+    "image": "character-ability-cards/SB/regenerative-tissue.png",
+    "xws": "regenerativetissue"
+  },
+  {
+    "name": "research the cure",
+    "points": 356,
+    "image": "character-ability-cards/SB/research-the-cure.png",
+    "xws": "researchthecure"
+  },
+  {
+    "name": "sb-back",
+    "points": 357,
+    "image": "character-ability-cards/SB/sb-back.png",
+    "xws": "sbback"
+  },
+  {
+    "name": "surgeon's satchel",
+    "points": 358,
+    "image": "character-ability-cards/SB/surgeons-satchel.png",
+    "xws": "surgeonssatchel"
+  },
+  {
+    "name": "syringe",
+    "points": 359,
+    "image": "character-ability-cards/SB/syringe.png",
+    "xws": "syringe"
+  },
+  {
+    "name": "teamwork",
+    "points": 360,
+    "image": "character-ability-cards/SB/teamwork.png",
+    "xws": "teamwork"
+  },
+  {
+    "name": "triage",
+    "points": 361,
+    "image": "character-ability-cards/SB/triage.png",
+    "xws": "triage"
+  },
+  {
+    "name": "vaccine",
+    "points": 362,
+    "image": "character-ability-cards/SB/vaccine.png",
+    "xws": "vaccine"
+  },
+  {
+    "name": "vital strike",
+    "points": 363,
+    "image": "character-ability-cards/SB/vital-strike.png",
+    "xws": "vitalstrike"
+  },
+  {
+    "name": "backstab",
+    "points": 364,
+    "image": "character-ability-cards/SC/backstab.png",
+    "xws": "backstab"
+  },
+  {
+    "name": "burning oil",
+    "points": 365,
+    "image": "character-ability-cards/SC/burning-oil.png",
+    "xws": "burningoil"
+  },
+  {
+    "name": "crippling poison",
+    "points": 366,
+    "image": "character-ability-cards/SC/crippling-poison.png",
+    "xws": "cripplingpoison"
+  },
+  {
+    "name": "cull the weak",
+    "points": 367,
+    "image": "character-ability-cards/SC/cull-the-weak.png",
+    "xws": "culltheweak"
+  },
+  {
+    "name": "duelist's advance",
+    "points": 368,
+    "image": "character-ability-cards/SC/duelists-advance.png",
+    "xws": "duelistsadvance"
+  },
+  {
+    "name": "flanking strike",
+    "points": 369,
+    "image": "character-ability-cards/SC/flanking-strike.png",
+    "xws": "flankingstrike"
+  },
+  {
+    "name": "flintlock",
+    "points": 370,
+    "image": "character-ability-cards/SC/flintlock.png",
+    "xws": "flintlock"
+  },
+  {
+    "name": "flurry of blades",
+    "points": 371,
+    "image": "character-ability-cards/SC/flurry-of-blades.png",
+    "xws": "flurryofblades"
+  },
+  {
+    "name": "gruesome advantage",
+    "points": 372,
+    "image": "character-ability-cards/SC/gruesome-advantage.png",
+    "xws": "gruesomeadvantage"
+  },
+  {
+    "name": "hidden daggers",
+    "points": 373,
+    "image": "character-ability-cards/SC/hidden-daggers.png",
+    "xws": "hiddendaggers"
+  },
+  {
+    "name": "long con",
+    "points": 374,
+    "image": "character-ability-cards/SC/long-con.png",
+    "xws": "longcon"
+  },
+  {
+    "name": "open wound",
+    "points": 375,
+    "image": "character-ability-cards/SC/open-wound.png",
+    "xws": "openwound"
+  },
+  {
+    "name": "pain's end",
+    "points": 376,
+    "image": "character-ability-cards/SC/pains-end.png",
+    "xws": "painsend"
+  },
+  {
+    "name": "quick hands",
+    "points": 377,
+    "image": "character-ability-cards/SC/quick-hands.png",
+    "xws": "quickhands"
+  },
+  {
+    "name": "sc-back",
+    "points": 378,
+    "image": "character-ability-cards/SC/sc-back.png",
+    "xws": "scback"
+  },
+  {
+    "name": "single out",
+    "points": 379,
+    "image": "character-ability-cards/SC/single-out.png",
+    "xws": "singleout"
+  },
+  {
+    "name": "sinister opportunity",
+    "points": 380,
+    "image": "character-ability-cards/SC/sinister-opportunity.png",
+    "xws": "sinisteropportunity"
+  },
+  {
+    "name": "smoke bomb",
+    "points": 381,
+    "image": "character-ability-cards/SC/smoke-bomb.png",
+    "xws": "smokebomb"
+  },
+  {
+    "name": "special mixture",
+    "points": 382,
+    "image": "character-ability-cards/SC/special-mixture.png",
+    "xws": "specialmixture"
+  },
+  {
+    "name": "spring the trap",
+    "points": 383,
+    "image": "character-ability-cards/SC/spring-the-trap.png",
+    "xws": "springthetrap"
+  },
+  {
+    "name": "stick to the shadows",
+    "points": 384,
+    "image": "character-ability-cards/SC/stick-to-the-shadows.png",
+    "xws": "sticktotheshadows"
+  },
+  {
+    "name": "stiletto storm",
+    "points": 385,
+    "image": "character-ability-cards/SC/stiletto-storm.png",
+    "xws": "stilettostorm"
+  },
+  {
+    "name": "swift bow",
+    "points": 386,
+    "image": "character-ability-cards/SC/swift-bow.png",
+    "xws": "swiftbow"
+  },
+  {
+    "name": "thief's knack",
+    "points": 387,
+    "image": "character-ability-cards/SC/thiefs-knack.png",
+    "xws": "thiefsknack"
+  },
+  {
+    "name": "throwing knives",
+    "points": 388,
+    "image": "character-ability-cards/SC/throwing-knives.png",
+    "xws": "throwingknives"
+  },
+  {
+    "name": "trickster's reversal",
+    "points": 389,
+    "image": "character-ability-cards/SC/tricksters-reversal.png",
+    "xws": "trickstersreversal"
+  },
+  {
+    "name": "venom shiv",
+    "points": 390,
+    "image": "character-ability-cards/SC/venom-shiv.png",
+    "xws": "venomshiv"
+  },
+  {
+    "name": "visage of the inevitable",
+    "points": 391,
+    "image": "character-ability-cards/SC/visage-of-the-inevitable.png",
+    "xws": "visageoftheinevitable"
+  },
+  {
+    "name": "watch it burn",
+    "points": 392,
+    "image": "character-ability-cards/SC/watch-it-burn.png",
+    "xws": "watchitburn"
+  },
+  {
+    "name": "angelic ascension",
+    "points": 393,
+    "image": "character-ability-cards/SK/angelic-ascension.png",
+    "xws": "angelicascension"
+  },
+  {
+    "name": "beacon of light",
+    "points": 394,
+    "image": "character-ability-cards/SK/beacon-of-light.png",
+    "xws": "beaconoflight"
+  },
+  {
+    "name": "bright aegis",
+    "points": 395,
+    "image": "character-ability-cards/SK/bright-aegis.png",
+    "xws": "brightaegis"
+  },
+  {
+    "name": "brilliant prayer",
+    "points": 396,
+    "image": "character-ability-cards/SK/brilliant-prayer.png",
+    "xws": "brilliantprayer"
+  },
+  {
+    "name": "burning flash",
+    "points": 397,
+    "image": "character-ability-cards/SK/burning-flash.png",
+    "xws": "burningflash"
+  },
+  {
+    "name": "cautious advance",
+    "points": 398,
+    "image": "character-ability-cards/SK/cautious-advance.png",
+    "xws": "cautiousadvance"
+  },
+  {
+    "name": "cleansing force",
+    "points": 399,
+    "image": "character-ability-cards/SK/cleansing-force.png",
+    "xws": "cleansingforce"
+  },
+  {
+    "name": "daybreak",
+    "points": 400,
+    "image": "character-ability-cards/SK/daybreak.png",
+    "xws": "daybreak"
+  },
+  {
+    "name": "dazzling charge",
+    "points": 401,
+    "image": "character-ability-cards/SK/dazzling-charge.png",
+    "xws": "dazzlingcharge"
+  },
+  {
+    "name": "defensive stance",
+    "points": 402,
+    "image": "character-ability-cards/SK/defensive-stance.png",
+    "xws": "defensivestance"
+  },
+  {
+    "name": "divine intervention",
+    "points": 403,
+    "image": "character-ability-cards/SK/divine-intervention.png",
+    "xws": "divineintervention"
+  },
+  {
+    "name": "empowering command",
+    "points": 404,
+    "image": "character-ability-cards/SK/empowering-command.png",
+    "xws": "empoweringcommand"
+  },
+  {
+    "name": "engulfing radiance",
+    "points": 405,
+    "image": "character-ability-cards/SK/engulfing-radiance.png",
+    "xws": "engulfingradiance"
+  },
+  {
+    "name": "glorious bolt",
+    "points": 406,
+    "image": "character-ability-cards/SK/glorious-bolt.png",
+    "xws": "gloriousbolt"
+  },
+  {
+    "name": "hammer blow",
+    "points": 407,
+    "image": "character-ability-cards/SK/hammer-blow.png",
+    "xws": "hammerblow"
+  },
+  {
+    "name": "holy strike",
+    "points": 408,
+    "image": "character-ability-cards/SK/holy-strike.png",
+    "xws": "holystrike"
+  },
+  {
+    "name": "illuminate the target",
+    "points": 409,
+    "image": "character-ability-cards/SK/illuminate-the-target.png",
+    "xws": "illuminatethetarget"
+  },
+  {
+    "name": "inspiring sanctity",
+    "points": 410,
+    "image": "character-ability-cards/SK/inspiring-sanctity.png",
+    "xws": "inspiringsanctity"
+  },
+  {
+    "name": "lay on hands",
+    "points": 411,
+    "image": "character-ability-cards/SK/lay-on-hands.png",
+    "xws": "layonhands"
+  },
+  {
+    "name": "mobilizing axiom",
+    "points": 412,
+    "image": "character-ability-cards/SK/mobilizing-axiom.png",
+    "xws": "mobilizingaxiom"
+  },
+  {
+    "name": "path of glory",
+    "points": 413,
+    "image": "character-ability-cards/SK/path-of-glory.png",
+    "xws": "pathofglory"
+  },
+  {
+    "name": "practical plans",
+    "points": 414,
+    "image": "character-ability-cards/SK/practical-plans.png",
+    "xws": "practicalplans"
+  },
+  {
+    "name": "protective blessing",
+    "points": 415,
+    "image": "character-ability-cards/SK/protective-blessing.png",
+    "xws": "protectiveblessing"
+  },
+  {
+    "name": "purifying aura",
+    "points": 416,
+    "image": "character-ability-cards/SK/purifying-aura.png",
+    "xws": "purifyingaura"
+  },
+  {
+    "name": "righteous strength",
+    "points": 417,
+    "image": "character-ability-cards/SK/righteous-strength.png",
+    "xws": "righteousstrength"
+  },
+  {
+    "name": "scales of justice",
+    "points": 418,
+    "image": "character-ability-cards/SK/scales-of-justice.png",
+    "xws": "scalesofjustice"
+  },
+  {
+    "name": "sk-back",
+    "points": 419,
+    "image": "character-ability-cards/SK/sk-back.png",
+    "xws": "skback"
+  },
+  {
+    "name": "supportive chant",
+    "points": 420,
+    "image": "character-ability-cards/SK/supportive-chant.png",
+    "xws": "supportivechant"
+  },
+  {
+    "name": "tactical order",
+    "points": 421,
+    "image": "character-ability-cards/SK/tactical-order.png",
+    "xws": "tacticalorder"
+  },
+  {
+    "name": "unwavering mandate",
+    "points": 422,
+    "image": "character-ability-cards/SK/unwavering-mandate.png",
+    "xws": "visageoftheinevitable"
+  },
+  {
+    "name": "weapon of purity",
+    "points": 423,
+    "image": "character-ability-cards/SK/weapon-of-purity.png",
+    "xws": "weaponofpurity"
+  },
+  {
+    "name": "booming proclamation",
+    "points": 424,
+    "image": "character-ability-cards/SS/booming-proclamation.png",
+    "xws": "boomingproclamation"
+  },
+  {
+    "name": "call to action",
+    "points": 425,
+    "image": "character-ability-cards/SS/call-to-action.png",
+    "xws": "calltoaction"
+  },
+  {
+    "name": "captivating performance",
+    "points": 426,
+    "image": "character-ability-cards/SS/captivating-performance.png",
+    "xws": "captivatingperformance"
+  },
+  {
+    "name": "change tempo",
+    "points": 427,
+    "image": "character-ability-cards/SS/change-tempo.png",
+    "xws": "changetempo"
+  },
+  {
+    "name": "commanding presence",
+    "points": 428,
+    "image": "character-ability-cards/SS/commanding-presence.png",
+    "xws": "commandingpresence"
+  },
+  {
+    "name": "crippling chorus",
+    "points": 429,
+    "image": "character-ability-cards/SS/crippling-chorus.png",
+    "xws": "cripplingchorus"
+  },
+  {
+    "name": "defensive ditty",
+    "points": 430,
+    "image": "character-ability-cards/SS/defensive-ditty.png",
+    "xws": "defensiveditty"
+  },
+  {
+    "name": "disorienting dirge",
+    "points": 431,
+    "image": "character-ability-cards/SS/disorienting-dirge.png",
+    "xws": "disorientingdirge"
+  },
+  {
+    "name": "echoing aria",
+    "points": 432,
+    "image": "character-ability-cards/SS/echoing-aria.png",
+    "xws": "echoingaria"
+  },
+  {
+    "name": "inspiring anthem",
+    "points": 433,
+    "image": "character-ability-cards/SS/inspiring-anthem.png",
+    "xws": "inspiringanthem"
+  },
+  {
+    "name": "marching beat",
+    "points": 434,
+    "image": "character-ability-cards/SS/marching-beat.png",
+    "xws": "marchingbeat"
+  },
+  {
+    "name": "melody and harmony",
+    "points": 435,
+    "image": "character-ability-cards/SS/melody-and-harmony.png",
+    "xws": "melodyandharmony"
+  },
+  {
+    "name": "mobilizing measure",
+    "points": 436,
+    "image": "character-ability-cards/SS/mobilizing-measure.png",
+    "xws": "mobilizingmeasure"
+  },
+  {
+    "name": "nightmare serenade",
+    "points": 437,
+    "image": "character-ability-cards/SS/nightmare-serenade.png",
+    "xws": "nightmareserenade"
+  },
+  {
+    "name": "nimble knife",
+    "points": 438,
+    "image": "character-ability-cards/SS/nimble-knife.png",
+    "xws": "nimbleknife"
+  },
+  {
+    "name": "power ballad",
+    "points": 439,
+    "image": "character-ability-cards/SS/power-ballad.png",
+    "xws": "powerballad"
+  },
+  {
+    "name": "provoke terror",
+    "points": 440,
+    "image": "character-ability-cards/SS/provoke-terror.png",
+    "xws": "provoketerror"
+  },
+  {
+    "name": "pull the strings",
+    "points": 441,
+    "image": "character-ability-cards/SS/pull-the-strings.png",
+    "xws": "pullthestrings"
+  },
+  {
+    "name": "shadow puppets",
+    "points": 442,
+    "image": "character-ability-cards/SS/shadow-puppets.png",
+    "xws": "shadowpuppets"
+  },
+  {
+    "name": "singing arrow",
+    "points": 443,
+    "image": "character-ability-cards/SS/singing-arrow.png",
+    "xws": "singingarrow"
+  },
+  {
+    "name": "song of speed",
+    "points": 444,
+    "image": "character-ability-cards/SS/song-of-speed.png",
+    "xws": "songofspeed"
+  },
+  {
+    "name": "soothing lullaby",
+    "points": 445,
+    "image": "character-ability-cards/SS/soothing-lullaby.png",
+    "xws": "soothinglullaby"
+  },
+  {
+    "name": "ss-back",
+    "points": 446,
+    "image": "character-ability-cards/SS/ss-back.png",
+    "xws": "ssback"
+  },
+  {
+    "name": "throw voice",
+    "points": 447,
+    "image": "character-ability-cards/SS/throw-voice.png",
+    "xws": "throwvoice"
+  },
+  {
+    "name": "tranquil trill",
+    "points": 448,
+    "image": "character-ability-cards/SS/tranquil-trill.png",
+    "xws": "tranquiltrill"
+  },
+  {
+    "name": "tuning the outcome",
+    "points": 449,
+    "image": "character-ability-cards/SS/tuning-the-outcome.png",
+    "xws": "tuningtheoutcome"
+  },
+  {
+    "name": "unending chant",
+    "points": 450,
+    "image": "character-ability-cards/SS/unending-chant.png",
+    "xws": "unendingchant"
+  },
+  {
+    "name": "warding dagger",
+    "points": 451,
+    "image": "character-ability-cards/SS/warding-dagger.png",
+    "xws": "wardingdagger"
+  },
+  {
+    "name": "wistful wounding",
+    "points": 452,
+    "image": "character-ability-cards/SS/wistful-wounding.png",
+    "xws": "wistfulwounding"
+  },
+  {
+    "name": "biting wind",
+    "points": 453,
+    "image": "character-ability-cards/SU/biting-wind.png",
+    "xws": "bitingwind"
+  },
+  {
+    "name": "black fire",
+    "points": 454,
+    "image": "character-ability-cards/SU/black-fire.png",
+    "xws": "blackfire"
+  },
+  {
+    "name": "bonded might",
+    "points": 455,
+    "image": "character-ability-cards/SU/bonded-might.png",
+    "xws": "bondedmight"
+  },
+  {
+    "name": "conjured aid",
+    "points": 456,
+    "image": "character-ability-cards/SU/conjured-aid.png",
+    "xws": "conjuredaid"
+  },
+  {
+    "name": "divided mind",
+    "points": 457,
+    "image": "character-ability-cards/SU/divided-mind.png",
+    "xws": "dividedmind"
+  },
+  {
+    "name": "earthen steed",
+    "points": 458,
+    "image": "character-ability-cards/SU/earthen-steed.png",
+    "xws": "earthensteed"
+  },
+  {
+    "name": "endless spikes",
+    "points": 459,
+    "image": "character-ability-cards/SU/endless-spikes.png",
+    "xws": "endlessspikes"
+  },
+  {
+    "name": "ethereal vines",
+    "points": 460,
+    "image": "character-ability-cards/SU/ethereal-vines.png",
+    "xws": "etherealvines"
+  },
+  {
+    "name": "forged ferocity",
+    "points": 461,
+    "image": "character-ability-cards/SU/forged-ferocity.png",
+    "xws": "forgedferocity"
+  },
+  {
+    "name": "grasping the void",
+    "points": 462,
+    "image": "character-ability-cards/SU/grasping-the-void.png",
+    "xws": "graspingthevoid"
+  },
+  {
+    "name": "horned majesty",
+    "points": 463,
+    "image": "character-ability-cards/SU/horned-majesty.png",
+    "xws": "hornedmajesty"
+  },
+  {
+    "name": "inexorable momentum",
+    "points": 464,
+    "image": "character-ability-cards/SU/inexorable-momentum.png",
+    "xws": "inexorablemomentum"
+  },
+  {
+    "name": "interplanar mastery",
+    "points": 465,
+    "image": "character-ability-cards/SU/interplanar-mastery.png",
+    "xws": "interplanarmastery"
+  },
+  {
+    "name": "intervening apparitions",
+    "points": 466,
+    "image": "character-ability-cards/SU/intervening-apparitions.png",
+    "xws": "interveningapparitions"
+  },
+  {
+    "name": "leathery wings",
+    "points": 467,
+    "image": "character-ability-cards/SU/leathery-wings.png",
+    "xws": "leatherywings"
+  },
+  {
+    "name": "living mountain",
+    "points": 468,
+    "image": "character-ability-cards/SU/living-mountain.png",
+    "xws": "livingmountain"
+  },
+  {
+    "name": "living night",
+    "points": 469,
+    "image": "character-ability-cards/SU/living-night.png",
+    "xws": "livingnight"
+  },
+  {
+    "name": "mighty bond",
+    "points": 470,
+    "image": "character-ability-cards/SU/mighty-bond.png",
+    "xws": "mightybond"
+  },
+  {
+    "name": "negative energy",
+    "points": 471,
+    "image": "character-ability-cards/SU/negative-energy.png",
+    "xws": "negativeenergy"
+  },
+  {
+    "name": "oozing manifestation",
+    "points": 472,
+    "image": "character-ability-cards/SU/oozing-manifestation.png",
+    "xws": "oozingmanifestation"
+  },
+  {
+    "name": "otherworldly rage",
+    "points": 473,
+    "image": "character-ability-cards/SU/otherworldly-rage.png",
+    "xws": "otherworldlyrage"
+  },
+  {
+    "name": "staff of visions",
+    "points": 474,
+    "image": "character-ability-cards/SU/staff-of-visions.png",
+    "xws": "staffofvisions"
+  },
+  {
+    "name": "strength in numbers",
+    "points": 475,
+    "image": "character-ability-cards/SU/strength-in-numbers.png",
+    "xws": "strengthinnumbers"
+  },
+  {
+    "name": "su-back",
+    "points": 476,
+    "image": "character-ability-cards/SU/su-back.png",
+    "xws": "suback"
+  },
+  {
+    "name": "tear the fabric",
+    "points": 477,
+    "image": "character-ability-cards/SU/tear-the-fabric.png",
+    "xws": "tearthefabric"
+  },
+  {
+    "name": "unending dominance",
+    "points": 478,
+    "image": "character-ability-cards/SU/unending-dominance.png",
+    "xws": "unendingdominance"
+  },
+  {
+    "name": "unwavering hand",
+    "points": 479,
+    "image": "character-ability-cards/SU/unwavering-hand.png",
+    "xws": "unwaveringhand"
+  },
+  {
+    "name": "volatile flame",
+    "points": 480,
+    "image": "character-ability-cards/SU/volatile-flame.png",
+    "xws": "volatileflame"
+  },
+  {
+    "name": "wild animation",
+    "points": 481,
+    "image": "character-ability-cards/SU/wild-animation.png",
+    "xws": "wildanimation"
+  },
+  {
+    "name": "aid from the ether",
+    "points": 482,
+    "image": "character-ability-cards/SW/aid-from-the-ether.png",
+    "xws": "aidfromtheether"
+  },
+  {
+    "name": "black hole",
+    "points": 483,
+    "image": "character-ability-cards/SW/black-hole.png",
+    "xws": "blackhole"
+  },
+  {
+    "name": "chromatic explosion",
+    "points": 484,
+    "image": "character-ability-cards/SW/chromatic-explosion.png",
+    "xws": "chromaticexplosion"
+  },
+  {
+    "name": "cold fire",
+    "points": 485,
+    "image": "character-ability-cards/SW/cold-fire.png",
+    "xws": "coldfire"
+  },
+  {
+    "name": "cold front",
+    "points": 486,
+    "image": "character-ability-cards/SW/cold-front.png",
+    "xws": "coldfront"
+  },
+  {
+    "name": "crackling air",
+    "points": 487,
+    "image": "character-ability-cards/SW/crackling-air.png",
+    "xws": "cracklingair"
+  },
+  {
+    "name": "elemental aid",
+    "points": 488,
+    "image": "character-ability-cards/SW/elemental-aid.png",
+    "xws": "elementalaid"
+  },
+  {
+    "name": "engulfed in flames",
+    "points": 489,
+    "image": "character-ability-cards/SW/engulfed-in-flames.png",
+    "xws": "engulfedinflames"
+  },
+  {
+    "name": "fire orbs",
+    "points": 490,
+    "image": "character-ability-cards/SW/fire-orbs.png",
+    "xws": "fireorbs"
+  },
+  {
+    "name": "flame strike",
+    "points": 491,
+    "image": "character-ability-cards/SW/flame-strike.png",
+    "xws": "flamestrike"
+  },
+  {
+    "name": "flashing burst",
+    "points": 492,
+    "image": "character-ability-cards/SW/flashing-burst.png",
+    "xws": "flashingburst"
+  },
+  {
+    "name": "forked beam",
+    "points": 493,
+    "image": "character-ability-cards/SW/forked-beam.png",
+    "xws": "forkedbeam"
+  },
+  {
+    "name": "freezing nova",
+    "points": 494,
+    "image": "character-ability-cards/SW/freezing-nova.png",
+    "xws": "freezingnova"
+  },
+  {
+    "name": "frost armor",
+    "points": 495,
+    "image": "character-ability-cards/SW/frost-armor.png",
+    "xws": "frostarmor"
+  },
+  {
+    "name": "frozen night",
+    "points": 496,
+    "image": "character-ability-cards/SW/frozen-night.png",
+    "xws": "frozennight"
+  },
+  {
+    "name": "hardened spikes",
+    "points": 497,
+    "image": "character-ability-cards/SW/hardened-spikes.png",
+    "xws": "hardenedspikes"
+  },
+  {
+    "name": "icy blast",
+    "points": 498,
+    "image": "character-ability-cards/SW/icy-blast.png",
+    "xws": "icyblast"
+  },
+  {
+    "name": "impaling eruption",
+    "points": 499,
+    "image": "character-ability-cards/SW/impaling-eruption.png",
+    "xws": "impalingeruption"
+  },
+  {
+    "name": "inferno",
+    "points": 500,
+    "image": "character-ability-cards/SW/inferno.png",
+    "xws": "inferno"
+  },
+  {
+    "name": "living torch",
+    "points": 501,
+    "image": "character-ability-cards/SW/living-torch.png",
+    "xws": "livingtorch"
+  },
+  {
+    "name": "mana bolt",
+    "points": 502,
+    "image": "character-ability-cards/SW/mana-bolt.png",
+    "xws": "manabolt"
+  },
+  {
+    "name": "reviving ether",
+    "points": 503,
+    "image": "character-ability-cards/SW/reviving-ether.png",
+    "xws": "revivingether"
+  },
+  {
+    "name": "ride the wind",
+    "points": 504,
+    "image": "character-ability-cards/SW/ride-the-wind.png",
+    "xws": "ridethewind"
+  },
+  {
+    "name": "spirit of doom",
+    "points": 505,
+    "image": "character-ability-cards/SW/spirit-of-doom.png",
+    "xws": "spiritofdoom"
+  },
+  {
+    "name": "stone fists",
+    "points": 506,
+    "image": "character-ability-cards/SW/stone-fists.png",
+    "xws": "stonefists"
+  },
+  {
+    "name": "sw-back",
+    "points": 507,
+    "image": "character-ability-cards/SW/sw-back.png",
+    "xws": "swback"
+  },
+  {
+    "name": "twin restoration",
+    "points": 508,
+    "image": "character-ability-cards/SW/twin-restoration.png",
+    "xws": "twinrestoration"
+  },
+  {
+    "name": "zephyr wings",
+    "points": 509,
+    "image": "character-ability-cards/SW/zephyr-wings.png",
+    "xws": "zephyrwings"
+  },
+  {
+    "name": "auto turret",
+    "points": 510,
+    "image": "character-ability-cards/TI/auto-turret.png",
+    "xws": "autoturret"
+  },
+  {
+    "name": "chimeric formula",
+    "points": 511,
+    "image": "character-ability-cards/TI/chimeric-formula.png",
+    "xws": "chimericformula"
+  },
+  {
+    "name": "crank bow",
+    "points": 512,
+    "image": "character-ability-cards/TI/crank-bow.png",
+    "xws": "crankbow"
+  },
+  {
+    "name": "curative aerosol",
+    "points": 513,
+    "image": "character-ability-cards/TI/curative-aerosol.png",
+    "xws": "curativeaerosol"
+  },
+  {
+    "name": "dangerous contraption",
+    "points": 514,
+    "image": "character-ability-cards/TI/dangerous-contraption.png",
+    "xws": "dangerouscontraption"
+  },
+  {
+    "name": "disintegration beam",
+    "points": 515,
+    "image": "character-ability-cards/TI/disintegration-beam.png",
+    "xws": "disintegrationbeam"
+  },
+  {
+    "name": "disorienting flash",
+    "points": 516,
+    "image": "character-ability-cards/TI/disorienting-flash.png",
+    "xws": "disorientingflash"
+  },
+  {
+    "name": "energizing tonic",
+    "points": 517,
+    "image": "character-ability-cards/TI/energizing-tonic.png",
+    "xws": "energizingtonic"
+  },
+  {
+    "name": "enhancement field",
+    "points": 518,
+    "image": "character-ability-cards/TI/enhancement-field.png",
+    "xws": "enhancementfield"
+  },
+  {
+    "name": "flamethrower",
+    "points": 519,
+    "image": "character-ability-cards/TI/flamethrower.png",
+    "xws": "flamethrower"
+  },
+  {
+    "name": "gas canister",
+    "points": 520,
+    "image": "character-ability-cards/TI/gas-canister.png",
+    "xws": "gascanister"
+  },
+  {
+    "name": "harmless contraption",
+    "points": 521,
+    "image": "character-ability-cards/TI/harmless-contraption.png",
+    "xws": "harmlesscontraption"
+  },
+  {
+    "name": "harsh stimulants",
+    "points": 522,
+    "image": "character-ability-cards/TI/harsh-stimulants.png",
+    "xws": "harshstimulants"
+  },
+  {
+    "name": "hook gun",
+    "points": 523,
+    "image": "character-ability-cards/TI/hook-gun.png",
+    "xws": "hookgun"
+  },
+  {
+    "name": "ink bomb",
+    "points": 524,
+    "image": "character-ability-cards/TI/ink-bomb.png",
+    "xws": "inkbomb"
+  },
+  {
+    "name": "jet propulsion",
+    "points": 525,
+    "image": "character-ability-cards/TI/jet-propulsion.png",
+    "xws": "jetpropulsion"
+  },
+  {
+    "name": "lethal injection",
+    "points": 526,
+    "image": "character-ability-cards/TI/lethal-injection.png",
+    "xws": "lethalinjection"
+  },
+  {
+    "name": "micro bots",
+    "points": 527,
+    "image": "character-ability-cards/TI/micro-bots.png",
+    "xws": "microbots"
+  },
+  {
+    "name": "murderous contraption",
+    "points": 528,
+    "image": "character-ability-cards/TI/murderous-contraption.png",
+    "xws": "murderouscontraption"
+  },
+  {
+    "name": "net shooter",
+    "points": 529,
+    "image": "character-ability-cards/TI/net-shooter.png",
+    "xws": "netshooter"
+  },
+  {
+    "name": "noxious vials",
+    "points": 530,
+    "image": "character-ability-cards/TI/noxious-vials.png",
+    "xws": "noxiousvials"
+  },
+  {
+    "name": "potent potables",
+    "points": 531,
+    "image": "character-ability-cards/TI/potent-potables.png",
+    "xws": "potentpotables"
+  },
+  {
+    "name": "proximity mine",
+    "points": 532,
+    "image": "character-ability-cards/TI/proximity-mine.png",
+    "xws": "proximitymine"
+  },
+  {
+    "name": "reinvigorating elixir",
+    "points": 533,
+    "image": "character-ability-cards/TI/reinvigorating-elixir.png",
+    "xws": "reinvigorating-elixir"
+  },
+  {
+    "name": "restorative mist",
+    "points": 534,
+    "image": "character-ability-cards/TI/restorative-mist.png",
+    "xws": "restorativemist"
+  },
+  {
+    "name": "reviving shock",
+    "points": 535,
+    "image": "character-ability-cards/TI/reviving-shock.png",
+    "xws": "revivingshock"
+  },
+  {
+    "name": "stamina booster",
+    "points": 536,
+    "image": "character-ability-cards/TI/stamina-booster.png",
+    "xws": "staminabooster"
+  },
+  {
+    "name": "stun shot",
+    "points": 537,
+    "image": "character-ability-cards/TI/stun-shot.png",
+    "xws": "stunshot"
+  },
+  {
+    "name": "ti-back",
+    "points": 538,
+    "image": "character-ability-cards/TI/ti-back.png",
+    "xws": "tiback"
+  },
+  {
+    "name": "tinkerer's tools",
+    "points": 539,
+    "image": "character-ability-cards/TI/tinkerers-tools.png",
+    "xws": "tinkererstools"
+  },
+  {
+    "name": "toxic bolt",
+    "points": 540,
+    "image": "character-ability-cards/TI/toxic-bolt.png",
+    "xws": "toxicbolt"
+  },
+  {
+    "name": "volatile concoction",
+    "points": 541,
+    "image": "character-ability-cards/TI/volatile-concoction.png",
+    "xws": "volatileconcoction"
+  },
+  {
+    "name": "anguish and salvation",
+    "points": 542,
+    "image": "character-ability-cards/DR/anguish-and-salvation.png",
+    "xws": "anguishandsalvation"
+  },
+  {
+    "name": "anticipate intricacies",
+    "points": 543,
+    "image": "character-ability-cards/DR/anticipate-intricacies.png",
+    "xws": "anticipateintricacies"
+  },
+  {
+    "name": "bad omen",
+    "points": 544,
+    "image": "character-ability-cards/DR/bad-omen.png",
+    "xws": "badomen"
+  },
+  {
+    "name": "call of the nether",
+    "points": 545,
+    "image": "character-ability-cards/DR/call-of-the-nether.png",
+    "xws": "callofthenether"
+  },
+  {
+    "name": "careful attunement",
+    "points": 546,
+    "image": "character-ability-cards/DR/careful-attunement.png",
+    "xws": "carefulattunement"
+  },
+  {
+    "name": "clairvoyance",
+    "points": 547,
+    "image": "character-ability-cards/DR/clairvoyance.png",
+    "xws": "clairvoyance"
+  },
+  {
+    "name": "cleansing rite",
+    "points": 548,
+    "image": "character-ability-cards/DR/cleansing-rite.png",
+    "xws": "cleansingrite"
+  },
+  {
+    "name": "curative flux",
+    "points": 549,
+    "image": "character-ability-cards/DR/curative-flux.png",
+    "xws": "curativeflux"
+  },
+  {
+    "name": "cursed ground",
+    "points": 550,
+    "image": "character-ability-cards/DR/cursed-ground.png",
+    "xws": "cursedground"
+  },
+  {
+    "name": "deep contemplation",
+    "points": 551,
+    "image": "character-ability-cards/DR/deep-contemplation.png",
+    "xws": "deepcontemplation"
+  },
+  {
+    "name": "dimensional divide",
+    "points": 552,
+    "image": "character-ability-cards/DR/dimensional-divide.png",
+    "xws": "dimensionaldivide"
+  },
+  {
+    "name": "dimensional transfer",
+    "points": 553,
+    "image": "character-ability-cards/DR/dimensional-transfer.png",
+    "xws": "dimensionaltransfer"
+  },
+  {
+    "name": "dr-back",
+    "points": 554,
+    "image": "character-ability-cards/DR/dr-back.png",
+    "xws": "drback"
+  },
+  {
+    "name": "duality shards",
+    "points": 555,
+    "image": "character-ability-cards/DR/duality-shards.png",
+    "xws": "dualityshards"
+  },
+  {
+    "name": "enfeebling hex",
+    "points": 556,
+    "image": "character-ability-cards/DR/enfeebling-hex.png",
+    "xws": "enfeeblinghex"
+  },
+  {
+    "name": "envision the course",
+    "points": 557,
+    "image": "character-ability-cards/DR/envision-the-course.png",
+    "xws": "envisionthecourse"
+  },
+  {
+    "name": "ethereal vortex",
+    "points": 558,
+    "image": "character-ability-cards/DR/ethereal-vortex.png",
+    "xws": "etherealvortex"
+  },
+  {
+    "name": "gift of the void",
+    "points": 559,
+    "image": "character-ability-cards/DR/gift-of-the-void.png",
+    "xws": "giftofthevoid"
+  },
+  {
+    "name": "hand of destiny",
+    "points": 560,
+    "image": "character-ability-cards/DR/hand-of-destiny.png",
+    "xws": "handofdestiny"
+  },
+  {
+    "name": "inspiration from beyond",
+    "points": 561,
+    "image": "character-ability-cards/DR/inspiration-from-beyond.png",
+    "xws": "inspirationfrombeyond"
+  },
+  {
+    "name": "otherworldly journey",
+    "points": 562,
+    "image": "character-ability-cards/DR/otherworldly-journey.png",
+    "xws": "otherworldlyjourney"
+  },
+  {
+    "name": "peer into battle",
+    "points": 563,
+    "image": "character-ability-cards/DR/peer-into-battle.png",
+    "xws": "peerintobattle"
+  },
+  {
+    "name": "planar fissure",
+    "points": 564,
+    "image": "character-ability-cards/DR/planar-fissure.png",
+    "xws": "planarfissure"
+  },
+  {
+    "name": "preordain the path",
+    "points": 565,
+    "image": "character-ability-cards/DR/preordain-the-path.png",
+    "xws": "preordainthepath"
+  },
+  {
+    "name": "protective aura",
+    "points": 567,
+    "image": "character-ability-cards/DR/protective-aura.png",
+    "xws": "protectiveaura"
+  },
+  {
+    "name": "ray of light",
+    "points": 568,
+    "image": "character-ability-cards/DR/ray-of-light.png",
+    "xws": "rayoflight"
+  },
+  {
+    "name": "revitalizing fount",
+    "points": 569,
+    "image": "character-ability-cards/DR/revitalizing-fount.png",
+    "xws": "revitalizingfount"
+  },
+  {
+    "name": "seal their fate",
+    "points": 570,
+    "image": "character-ability-cards/DR/seal-their-fate.png",
+    "xws": "sealtheirfate"
+  },
+  {
+    "name": "void snare",
+    "points": 571,
+    "image": "character-ability-cards/DR/void-snare.png",
+    "xws": "voidsnare"
+  },
+  {
+    "name": "bear-reference",
+    "points": 572,
+    "image": "character-ability-cards/BT/bear-reference.png",
+    "xws": "bearreference"
+  },
+  {
+    "name": "mobile response",
+    "points": 573,
+    "image": "character-ability-cards/SB/mobile-response.png",
+    "xws": "mobileresponse"
+  },
+  {
+    "name": "lightning moths",
+    "points": 574,
+    "image": "character-ability-cards/BS/bioluminescence.png",
+    "xws": "bioluminescence"
+  },
+  {
+    "name": "soul leeches",
+    "points": 575,
+    "image": "character-ability-cards/BS/corrupting-parasites.png",
+    "xws": "corruptingparasites"
+  },
+  {
+    "name": "creeping beetles",
+    "points": 576,
+    "image": "character-ability-cards/BS/death-march.png",
+    "xws": "deathmarch"
+  },
+  {
+    "name": "angry wasps",
+    "points": 577,
+    "image": "character-ability-cards/BS/engulfing-stingers.png",
+    "xws": "engulfingstingers"
+  },
+  {
+    "name": "bloat maggots",
+    "points": 578,
+    "image": "character-ability-cards/BS/putrid-grubs.png",
+    "xws": "putridgrubs"
+  },
+  {
+    "name": "dueling hornets",
+    "points": 579,
+    "image": "character-ability-cards/BS/solitary-horde.png",
+    "xws": "solitaryhorde"
+  },
+  {
+    "name": "steel scarabs",
+    "points": 580,
+    "image": "character-ability-cards/BS/unstoppable-army.png",
+    "xws": "unstoppablearmy"
+  },
+  {
+    "name": "rust vermin",
+    "points": 581,
+    "image": "character-ability-cards/BS/wasteland.png",
+    "xws": "wasteland"
+  },
+  {
+    "name": "tattered wolf",
+    "points": 582,
+    "image": "character-ability-cards/BT/relentless-ally.png",
+    "xws": "relentlessally"
+  },
+  {
+    "name": "red falcon",
+    "points": 583,
+    "image": "character-ability-cards/BT/soaring-ally.png",
+    "xws": "soaringally"
+  },
+  {
+    "name": "monolith",
+    "points": 584,
+    "image": "character-ability-cards/BT/stone-sigil.png",
+    "xws": "stonesigil"
+  },
+  {
+    "name": "wind totem",
+    "points": 585,
+    "image": "character-ability-cards/BT/storm-sigil.png",
+    "xws": "stormsigil"
+  },
+  {
+    "name": "spirit banner",
+    "points": 586,
+    "image": "character-ability-cards/BT/tribal-sigil.png",
+    "xws": "tribalsigil"
+  },
+  {
+    "name": "green adder",
+    "points": 587,
+    "image": "character-ability-cards/BT/venomous-ally.png",
+    "xws": "venomousally"
+  },
+  {
+    "name": "swamp alligator",
+    "points": 588,
+    "image": "character-ability-cards/BT/vicious-ally.png",
+    "xws": "viciousally"
+  },
+  {
+    "name": "war hawk",
+    "points": 589,
+    "image": "character-ability-cards/DS/felling-swoop.png",
+    "xws": "fellingswoop"
+  },
+  {
+    "name": "giant toad",
+    "points": 590,
+    "image": "character-ability-cards/DS/natures-hunger.png",
+    "xws": "natureshunger"
+  },
+  {
+    "name": "spitting cobra",
+    "points": 591,
+    "image": "character-ability-cards/DS/predator-and-prey.png",
+    "xws": "predatorandprey"
+  },
+  {
+    "name": "vicious jackal",
+    "points": 592,
+    "image": "character-ability-cards/DS/the-hunt-begins.png",
+    "xws": "thehuntbegins"
+  },
+  {
+    "name": "battle boar",
+    "points": 593,
+    "image": "character-ability-cards/DS/vital-charge.png",
+    "xws": "vitalcharge"
+  },
+  {
+    "name": "mana sphere",
+    "points": 594,
+    "image": "character-ability-cards/EL/ethereal-manifestation.png",
+    "xws": "etherealmanifestation"
+  },
+  {
+    "name": "doppelganger",
+    "points": 595,
+    "image": "character-ability-cards/EL/simulacrum.png",
+    "xws": "simulacrum"
+  },
+  {
+    "name": "rat swarm",
+    "points": 596,
+    "image": "character-ability-cards/MT/gnawing-horde.png",
+    "xws": "gnawinghorde"
+  },
+  {
+    "name": "rat king",
+    "points": 597,
+    "image": "character-ability-cards/MT/many-as-one.png",
+    "xws": "manyasone"
+  },
+  {
+    "name": "monstrous rat",
+    "points": 598,
+    "image": "character-ability-cards/MT/wretched-creature.png",
+    "xws": "wretchedcreature"
+  },
+  {
+    "name": "healing sprite",
+    "points": 599,
+    "image": "character-ability-cards/SU/conjured-aid.png",
+    "xws": "conjuredaid"
+  },
+  {
+    "name": "nail spheres",
+    "points": 600,
+    "image": "character-ability-cards/SU/endless-spikes.png",
+    "xws": "endlessspikes"
+  },
+  {
+    "name": "iron beast",
+    "points": 601,
+    "image": "character-ability-cards/SU/forged-ferocity.png",
+    "xws": "forgedferocity"
+  },
+  {
+    "name": "black unicorn",
+    "points": 602,
+    "image": "character-ability-cards/SU/horned-majesty.png",
+    "xws": "hornedmajesty"
+  },
+  {
+    "name": "bat swarm",
+    "points": 603,
+    "image": "character-ability-cards/SU/leathery-wings.png",
+    "xws": "leatherywings"
+  },
+  {
+    "name": "rock colossus",
+    "points": 604,
+    "image": "character-ability-cards/SU/living-mountain.png",
+    "xws": "livingmountain"
+  },
+  {
+    "name": "shadow wolves",
+    "points": 605,
+    "image": "character-ability-cards/SU/living-night.png",
+    "xws": "livingnight"
+  },
+  {
+    "name": "void eater",
+    "points": 606,
+    "image": "character-ability-cards/SU/negative-energy.png",
+    "xws": "negativeenergy"
+  },
+  {
+    "name": "slime spirit",
+    "points": 607,
+    "image": "character-ability-cards/SU/oozing-manifestation.png",
+    "xws": "oozingmanifestation"
+  },
+  {
+    "name": "lava golem",
+    "points": 608,
+    "image": "character-ability-cards/SU/unending-dominance.png",
+    "xws": "unendingdominance"
+  },
+  {
+    "name": "living bomb",
+    "points": 609,
+    "image": "character-ability-cards/SU/volatile-flame.png",
+    "xws": "volatileflame"
+  },
+  {
+    "name": "thorn shooter",
+    "points": 610,
+    "image": "character-ability-cards/SU/wild-animation.png",
+    "xws": "wildanimation"
+  },
+  {
+    "name": "mystic ally",
+    "points": 611,
+    "image": "character-ability-cards/SW/aid-from-the-ether.png",
+    "xws": "aidfromtheether"
+  },
+  {
+    "name": "burning avatar",
+    "points": 612,
+    "image": "character-ability-cards/SW/living-torch.png",
+    "xws": "livingtorch"
+  },
+  {
+    "name": "battle bot",
+    "points": 613,
+    "image": "character-ability-cards/TI/dangerous-contraption.png",
+    "xws": "dangerouscontraption"
+  },
+  {
+    "name": "decoy",
+    "points": 614,
+    "image": "character-ability-cards/TI/harmless-contraption.png",
+    "xws": "harmlesscontraption"
+  },
+  {
+    "name": "kill bot",
+    "points": 615,
+    "image": "character-ability-cards/TI/murderous-contraption.png",
+    "xws": "murderouscontraption"
+  },
+  {
+    "name": "ghost falcons",
+    "points": 616,
+    "image": "character-ability-cards/DR/envision-the-course.png",
+    "xws": "envisionthecourse"
+  },
+  {
+    "name": "twilight archon",
+    "points": 617,
+    "image": "character-ability-cards/DR/planar-fissure.png",
+    "xws": "planarfissure"
+  }
+]

--- a/data/events.json
+++ b/data/events.json
@@ -1,0 +1,2270 @@
+[
+  {
+    "name": "ce-01-b",
+    "points": 0,
+    "image": "events/base/city/ce-01-b.png",
+    "xws": "ce01b"
+  },
+  {
+    "name": "ce-01-f",
+    "points": 1,
+    "image": "events/base/city/ce-01-f.png",
+    "xws": "ce01f"
+  },
+  {
+    "name": "ce-02-b",
+    "points": 2,
+    "image": "events/base/city/ce-02-b.png",
+    "xws": "ce02b"
+  },
+  {
+    "name": "ce-02-f",
+    "points": 3,
+    "image": "events/base/city/ce-02-f.png",
+    "xws": "ce02f"
+  },
+  {
+    "name": "ce-03-b",
+    "points": 4,
+    "image": "events/base/city/ce-03-b.png",
+    "xws": "ce03b"
+  },
+  {
+    "name": "ce-03-f",
+    "points": 5,
+    "image": "events/base/city/ce-03-f.png",
+    "xws": "ce03f"
+  },
+  {
+    "name": "ce-04-b",
+    "points": 6,
+    "image": "events/base/city/ce-04-b.png",
+    "xws": "ce04b"
+  },
+  {
+    "name": "ce-04-f",
+    "points": 7,
+    "image": "events/base/city/ce-04-f.png",
+    "xws": "ce04f"
+  },
+  {
+    "name": "ce-05-b",
+    "points": 8,
+    "image": "events/base/city/ce-05-b.png",
+    "xws": "ce05b"
+  },
+  {
+    "name": "ce-05-f",
+    "points": 9,
+    "image": "events/base/city/ce-05-f.png",
+    "xws": "ce05f"
+  },
+  {
+    "name": "ce-06-b",
+    "points": 10,
+    "image": "events/base/city/ce-06-b.png",
+    "xws": "ce06b"
+  },
+  {
+    "name": "ce-06-f",
+    "points": 11,
+    "image": "events/base/city/ce-06-f.png",
+    "xws": "ce06f"
+  },
+  {
+    "name": "ce-07-b",
+    "points": 12,
+    "image": "events/base/city/ce-07-b.png",
+    "xws": "ce07b"
+  },
+  {
+    "name": "ce-07-f",
+    "points": 13,
+    "image": "events/base/city/ce-07-f.png",
+    "xws": "ce07f"
+  },
+  {
+    "name": "ce-08-b",
+    "points": 14,
+    "image": "events/base/city/ce-08-b.png",
+    "xws": "ce08b"
+  },
+  {
+    "name": "ce-08-f",
+    "points": 15,
+    "image": "events/base/city/ce-08-f.png",
+    "xws": "ce08f"
+  },
+  {
+    "name": "ce-09-b",
+    "points": 16,
+    "image": "events/base/city/ce-09-b.png",
+    "xws": "ce09b"
+  },
+  {
+    "name": "ce-09-f",
+    "points": 17,
+    "image": "events/base/city/ce-09-f.png",
+    "xws": "ce09f"
+  },
+  {
+    "name": "ce-10-b",
+    "points": 18,
+    "image": "events/base/city/ce-10-b.png",
+    "xws": "ce10b"
+  },
+  {
+    "name": "ce-10-f",
+    "points": 19,
+    "image": "events/base/city/ce-10-f.png",
+    "xws": "ce10f"
+  },
+  {
+    "name": "ce-11-b",
+    "points": 20,
+    "image": "events/base/city/ce-11-b.png",
+    "xws": "ce11b"
+  },
+  {
+    "name": "ce-11-f",
+    "points": 21,
+    "image": "events/base/city/ce-11-f.png",
+    "xws": "ce11f"
+  },
+  {
+    "name": "ce-12-b",
+    "points": 22,
+    "image": "events/base/city/ce-12-b.png",
+    "xws": "ce12b"
+  },
+  {
+    "name": "ce-12-f",
+    "points": 23,
+    "image": "events/base/city/ce-12-f.png",
+    "xws": "ce12f"
+  },
+  {
+    "name": "ce-13-b",
+    "points": 24,
+    "image": "events/base/city/ce-13-b.png",
+    "xws": "ce13b"
+  },
+  {
+    "name": "ce-13-f",
+    "points": 25,
+    "image": "events/base/city/ce-13-f.png",
+    "xws": "ce13f"
+  },
+  {
+    "name": "ce-14-b",
+    "points": 26,
+    "image": "events/base/city/ce-14-b.png",
+    "xws": "ce14b"
+  },
+  {
+    "name": "ce-14-f",
+    "points": 27,
+    "image": "events/base/city/ce-14-f.png",
+    "xws": "ce14f"
+  },
+  {
+    "name": "ce-15-b",
+    "points": 28,
+    "image": "events/base/city/ce-15-b.png",
+    "xws": "ce15b"
+  },
+  {
+    "name": "ce-15-f",
+    "points": 29,
+    "image": "events/base/city/ce-15-f.png",
+    "xws": "ce15f"
+  },
+  {
+    "name": "ce-16-b",
+    "points": 30,
+    "image": "events/base/city/ce-16-b.png",
+    "xws": "ce16b"
+  },
+  {
+    "name": "ce-16-f",
+    "points": 31,
+    "image": "events/base/city/ce-16-f.png",
+    "xws": "ce16f"
+  },
+  {
+    "name": "ce-17-b",
+    "points": 32,
+    "image": "events/base/city/ce-17-b.png",
+    "xws": "ce17b"
+  },
+  {
+    "name": "ce-17-f",
+    "points": 33,
+    "image": "events/base/city/ce-17-f.png",
+    "xws": "ce17f"
+  },
+  {
+    "name": "ce-18-b",
+    "points": 34,
+    "image": "events/base/city/ce-18-b.png",
+    "xws": "ce18b"
+  },
+  {
+    "name": "ce-18-f",
+    "points": 35,
+    "image": "events/base/city/ce-18-f.png",
+    "xws": "ce18f"
+  },
+  {
+    "name": "ce-19-b",
+    "points": 36,
+    "image": "events/base/city/ce-19-b.png",
+    "xws": "ce19b"
+  },
+  {
+    "name": "ce-19-f",
+    "points": 37,
+    "image": "events/base/city/ce-19-f.png",
+    "xws": "ce19f"
+  },
+  {
+    "name": "ce-20-b",
+    "points": 38,
+    "image": "events/base/city/ce-20-b.png",
+    "xws": "ce20b"
+  },
+  {
+    "name": "ce-20-f",
+    "points": 39,
+    "image": "events/base/city/ce-20-f.png",
+    "xws": "ce20f"
+  },
+  {
+    "name": "ce-21-b",
+    "points": 40,
+    "image": "events/base/city/ce-21-b.png",
+    "xws": "ce21b"
+  },
+  {
+    "name": "ce-21-f",
+    "points": 41,
+    "image": "events/base/city/ce-21-f.png",
+    "xws": "ce21f"
+  },
+  {
+    "name": "ce-22-b",
+    "points": 42,
+    "image": "events/base/city/ce-22-b.png",
+    "xws": "ce22b"
+  },
+  {
+    "name": "ce-22-f",
+    "points": 43,
+    "image": "events/base/city/ce-22-f.png",
+    "xws": "ce22f"
+  },
+  {
+    "name": "ce-23-b",
+    "points": 44,
+    "image": "events/base/city/ce-23-b.png",
+    "xws": "ce23b"
+  },
+  {
+    "name": "ce-23-f",
+    "points": 45,
+    "image": "events/base/city/ce-23-f.png",
+    "xws": "ce23f"
+  },
+  {
+    "name": "ce-24-b",
+    "points": 46,
+    "image": "events/base/city/ce-24-b.png",
+    "xws": "ce24b"
+  },
+  {
+    "name": "ce-24-f",
+    "points": 47,
+    "image": "events/base/city/ce-24-f.png",
+    "xws": "ce24f"
+  },
+  {
+    "name": "ce-25-b",
+    "points": 48,
+    "image": "events/base/city/ce-25-b.png",
+    "xws": "ce25b"
+  },
+  {
+    "name": "ce-25-f",
+    "points": 49,
+    "image": "events/base/city/ce-25-f.png",
+    "xws": "ce25f"
+  },
+  {
+    "name": "ce-26-b",
+    "points": 50,
+    "image": "events/base/city/ce-26-b.png",
+    "xws": "ce26b"
+  },
+  {
+    "name": "ce-26-f",
+    "points": 51,
+    "image": "events/base/city/ce-26-f.png",
+    "xws": "ce26f"
+  },
+  {
+    "name": "ce-27-b",
+    "points": 52,
+    "image": "events/base/city/ce-27-b.png",
+    "xws": "ce27b"
+  },
+  {
+    "name": "ce-27-f",
+    "points": 53,
+    "image": "events/base/city/ce-27-f.png",
+    "xws": "ce27f"
+  },
+  {
+    "name": "ce-28-b",
+    "points": 54,
+    "image": "events/base/city/ce-28-b.png",
+    "xws": "ce28b"
+  },
+  {
+    "name": "ce-28-f",
+    "points": 55,
+    "image": "events/base/city/ce-28-f.png",
+    "xws": "ce28f"
+  },
+  {
+    "name": "ce-29-b",
+    "points": 56,
+    "image": "events/base/city/ce-29-b.png",
+    "xws": "ce29b"
+  },
+  {
+    "name": "ce-29-f",
+    "points": 57,
+    "image": "events/base/city/ce-29-f.png",
+    "xws": "ce29f"
+  },
+  {
+    "name": "ce-30-b",
+    "points": 58,
+    "image": "events/base/city/ce-30-b.png",
+    "xws": "ce30b"
+  },
+  {
+    "name": "ce-30-f",
+    "points": 59,
+    "image": "events/base/city/ce-30-f.png",
+    "xws": "ce30f"
+  },
+  {
+    "name": "ce-31-b",
+    "points": 60,
+    "image": "events/base/city/ce-31-b.png",
+    "xws": "ce31b"
+  },
+  {
+    "name": "ce-31-f",
+    "points": 61,
+    "image": "events/base/city/ce-31-f.png",
+    "xws": "ce31f"
+  },
+  {
+    "name": "ce-32-b",
+    "points": 62,
+    "image": "events/base/city/ce-32-b.png",
+    "xws": "ce32b"
+  },
+  {
+    "name": "ce-32-f",
+    "points": 63,
+    "image": "events/base/city/ce-32-f.png",
+    "xws": "ce32f"
+  },
+  {
+    "name": "ce-33-b",
+    "points": 64,
+    "image": "events/base/city/ce-33-b.png",
+    "xws": "ce33b"
+  },
+  {
+    "name": "ce-33-f",
+    "points": 65,
+    "image": "events/base/city/ce-33-f.png",
+    "xws": "ce33f"
+  },
+  {
+    "name": "ce-34-b",
+    "points": 66,
+    "image": "events/base/city/ce-34-b.png",
+    "xws": "ce34b"
+  },
+  {
+    "name": "ce-34-f",
+    "points": 67,
+    "image": "events/base/city/ce-34-f.png",
+    "xws": "ce34f"
+  },
+  {
+    "name": "ce-35-b",
+    "points": 68,
+    "image": "events/base/city/ce-35-b.png",
+    "xws": "ce35b"
+  },
+  {
+    "name": "ce-35-f",
+    "points": 69,
+    "image": "events/base/city/ce-35-f.png",
+    "xws": "ce35f"
+  },
+  {
+    "name": "ce-36-b",
+    "points": 70,
+    "image": "events/base/city/ce-36-b.png",
+    "xws": "ce36b"
+  },
+  {
+    "name": "ce-36-f",
+    "points": 71,
+    "image": "events/base/city/ce-36-f.png",
+    "xws": "ce36f"
+  },
+  {
+    "name": "ce-37-b",
+    "points": 72,
+    "image": "events/base/city/ce-37-b.png",
+    "xws": "ce37b"
+  },
+  {
+    "name": "ce-37-f",
+    "points": 73,
+    "image": "events/base/city/ce-37-f.png",
+    "xws": "ce37f"
+  },
+  {
+    "name": "ce-38-b",
+    "points": 74,
+    "image": "events/base/city/ce-38-b.png",
+    "xws": "ce38b"
+  },
+  {
+    "name": "ce-38-f",
+    "points": 75,
+    "image": "events/base/city/ce-38-f.png",
+    "xws": "ce38f"
+  },
+  {
+    "name": "ce-39-b",
+    "points": 76,
+    "image": "events/base/city/ce-39-b.png",
+    "xws": "ce39b"
+  },
+  {
+    "name": "ce-39-f",
+    "points": 77,
+    "image": "events/base/city/ce-39-f.png",
+    "xws": "ce39f"
+  },
+  {
+    "name": "ce-40-b",
+    "points": 78,
+    "image": "events/base/city/ce-40-b.png",
+    "xws": "ce40b"
+  },
+  {
+    "name": "ce-40-f",
+    "points": 79,
+    "image": "events/base/city/ce-40-f.png",
+    "xws": "ce40f"
+  },
+  {
+    "name": "ce-41-b",
+    "points": 80,
+    "image": "events/base/city/ce-41-b.png",
+    "xws": "ce41b"
+  },
+  {
+    "name": "ce-41-f",
+    "points": 81,
+    "image": "events/base/city/ce-41-f.png",
+    "xws": "ce41f"
+  },
+  {
+    "name": "ce-42-b",
+    "points": 82,
+    "image": "events/base/city/ce-42-b.png",
+    "xws": "ce42b"
+  },
+  {
+    "name": "ce-42-f",
+    "points": 83,
+    "image": "events/base/city/ce-42-f.png",
+    "xws": "ce42f"
+  },
+  {
+    "name": "ce-43-b",
+    "points": 84,
+    "image": "events/base/city/ce-43-b.png",
+    "xws": "ce43b"
+  },
+  {
+    "name": "ce-43-f",
+    "points": 85,
+    "image": "events/base/city/ce-43-f.png",
+    "xws": "ce43f"
+  },
+  {
+    "name": "ce-44-b",
+    "points": 86,
+    "image": "events/base/city/ce-44-b.png",
+    "xws": "ce44b"
+  },
+  {
+    "name": "ce-44-f",
+    "points": 87,
+    "image": "events/base/city/ce-44-f.png",
+    "xws": "ce44f"
+  },
+  {
+    "name": "ce-45-b",
+    "points": 88,
+    "image": "events/base/city/ce-45-b.png",
+    "xws": "ce45b"
+  },
+  {
+    "name": "ce-45-f",
+    "points": 89,
+    "image": "events/base/city/ce-45-f.png",
+    "xws": "ce45f"
+  },
+  {
+    "name": "ce-46-b",
+    "points": 90,
+    "image": "events/base/city/ce-46-b.png",
+    "xws": "ce46b"
+  },
+  {
+    "name": "ce-46-f",
+    "points": 91,
+    "image": "events/base/city/ce-46-f.png",
+    "xws": "ce46f"
+  },
+  {
+    "name": "ce-47-b",
+    "points": 92,
+    "image": "events/base/city/ce-47-b.png",
+    "xws": "ce47b"
+  },
+  {
+    "name": "ce-47-f",
+    "points": 93,
+    "image": "events/base/city/ce-47-f.png",
+    "xws": "ce47f"
+  },
+  {
+    "name": "ce-48-b",
+    "points": 94,
+    "image": "events/base/city/ce-48-b.png",
+    "xws": "ce48b"
+  },
+  {
+    "name": "ce-48-f",
+    "points": 95,
+    "image": "events/base/city/ce-48-f.png",
+    "xws": "ce48f"
+  },
+  {
+    "name": "ce-49-b",
+    "points": 96,
+    "image": "events/base/city/ce-49-b.png",
+    "xws": "ce49b"
+  },
+  {
+    "name": "ce-49-f",
+    "points": 97,
+    "image": "events/base/city/ce-49-f.png",
+    "xws": "ce49f"
+  },
+  {
+    "name": "ce-50-b",
+    "points": 98,
+    "image": "events/base/city/ce-50-b.png",
+    "xws": "ce50b"
+  },
+  {
+    "name": "ce-50-f",
+    "points": 99,
+    "image": "events/base/city/ce-50-f.png",
+    "xws": "ce50f"
+  },
+  {
+    "name": "ce-51-b",
+    "points": 100,
+    "image": "events/base/city/ce-51-b.png",
+    "xws": "ce51b"
+  },
+  {
+    "name": "ce-51-f",
+    "points": 101,
+    "image": "events/base/city/ce-51-f.png",
+    "xws": "ce51f"
+  },
+  {
+    "name": "ce-52-b",
+    "points": 102,
+    "image": "events/base/city/ce-52-b.png",
+    "xws": "ce52b"
+  },
+  {
+    "name": "ce-52-f",
+    "points": 103,
+    "image": "events/base/city/ce-52-f.png",
+    "xws": "ce52f"
+  },
+  {
+    "name": "ce-53-b",
+    "points": 104,
+    "image": "events/base/city/ce-53-b.png",
+    "xws": "ce53b"
+  },
+  {
+    "name": "ce-53-f",
+    "points": 105,
+    "image": "events/base/city/ce-53-f.png",
+    "xws": "ce53f"
+  },
+  {
+    "name": "ce-54-b",
+    "points": 106,
+    "image": "events/base/city/ce-54-b.png",
+    "xws": "ce54b"
+  },
+  {
+    "name": "ce-54-f",
+    "points": 107,
+    "image": "events/base/city/ce-54-f.png",
+    "xws": "ce54f"
+  },
+  {
+    "name": "ce-55-b",
+    "points": 108,
+    "image": "events/base/city/ce-55-b.png",
+    "xws": "ce55b"
+  },
+  {
+    "name": "ce-55-f",
+    "points": 109,
+    "image": "events/base/city/ce-55-f.png",
+    "xws": "ce55f"
+  },
+  {
+    "name": "ce-56-b",
+    "points": 110,
+    "image": "events/base/city/ce-56-b.png",
+    "xws": "ce56b"
+  },
+  {
+    "name": "ce-56-f",
+    "points": 111,
+    "image": "events/base/city/ce-56-f.png",
+    "xws": "ce56f"
+  },
+  {
+    "name": "ce-57-b",
+    "points": 112,
+    "image": "events/base/city/ce-57-b.png",
+    "xws": "ce57b"
+  },
+  {
+    "name": "ce-57-f",
+    "points": 113,
+    "image": "events/base/city/ce-57-f.png",
+    "xws": "ce57f"
+  },
+  {
+    "name": "ce-58-b",
+    "points": 114,
+    "image": "events/base/city/ce-58-b.png",
+    "xws": "ce58b"
+  },
+  {
+    "name": "ce-58-f",
+    "points": 115,
+    "image": "events/base/city/ce-58-f.png",
+    "xws": "ce58f"
+  },
+  {
+    "name": "ce-59-b",
+    "points": 116,
+    "image": "events/base/city/ce-59-b.png",
+    "xws": "ce59b"
+  },
+  {
+    "name": "ce-59-f",
+    "points": 117,
+    "image": "events/base/city/ce-59-f.png",
+    "xws": "ce59f"
+  },
+  {
+    "name": "ce-60-b",
+    "points": 118,
+    "image": "events/base/city/ce-60-b.png",
+    "xws": "ce60b"
+  },
+  {
+    "name": "ce-60-f",
+    "points": 119,
+    "image": "events/base/city/ce-60-f.png",
+    "xws": "ce60f"
+  },
+  {
+    "name": "ce-61-b",
+    "points": 120,
+    "image": "events/base/city/ce-61-b.png",
+    "xws": "ce61b"
+  },
+  {
+    "name": "ce-61-f",
+    "points": 121,
+    "image": "events/base/city/ce-61-f.png",
+    "xws": "ce61f"
+  },
+  {
+    "name": "ce-62-b",
+    "points": 122,
+    "image": "events/base/city/ce-62-b.png",
+    "xws": "ce62b"
+  },
+  {
+    "name": "ce-62-f",
+    "points": 123,
+    "image": "events/base/city/ce-62-f.png",
+    "xws": "ce62f"
+  },
+  {
+    "name": "ce-63-b",
+    "points": 124,
+    "image": "events/base/city/ce-63-b.png",
+    "xws": "ce63b"
+  },
+  {
+    "name": "ce-63-f",
+    "points": 125,
+    "image": "events/base/city/ce-63-f.png",
+    "xws": "ce63f"
+  },
+  {
+    "name": "ce-64-b",
+    "points": 126,
+    "image": "events/base/city/ce-64-b.png",
+    "xws": "ce64b"
+  },
+  {
+    "name": "ce-64-f",
+    "points": 127,
+    "image": "events/base/city/ce-64-f.png",
+    "xws": "ce64f"
+  },
+  {
+    "name": "ce-65-b",
+    "points": 128,
+    "image": "events/base/city/ce-65-b.png",
+    "xws": "ce65b"
+  },
+  {
+    "name": "ce-65-f",
+    "points": 129,
+    "image": "events/base/city/ce-65-f.png",
+    "xws": "ce65f"
+  },
+  {
+    "name": "ce-66-b",
+    "points": 130,
+    "image": "events/base/city/ce-66-b.png",
+    "xws": "ce66b"
+  },
+  {
+    "name": "ce-66-f",
+    "points": 131,
+    "image": "events/base/city/ce-66-f.png",
+    "xws": "ce66f"
+  },
+  {
+    "name": "ce-67-b",
+    "points": 132,
+    "image": "events/base/city/ce-67-b.png",
+    "xws": "ce67b"
+  },
+  {
+    "name": "ce-67-f",
+    "points": 133,
+    "image": "events/base/city/ce-67-f.png",
+    "xws": "ce67f"
+  },
+  {
+    "name": "ce-68-b",
+    "points": 134,
+    "image": "events/base/city/ce-68-b.png",
+    "xws": "ce68b"
+  },
+  {
+    "name": "ce-68-f",
+    "points": 135,
+    "image": "events/base/city/ce-68-f.png",
+    "xws": "ce68f"
+  },
+  {
+    "name": "ce-69-b",
+    "points": 136,
+    "image": "events/base/city/ce-69-b.png",
+    "xws": "ce69b"
+  },
+  {
+    "name": "ce-69-f",
+    "points": 137,
+    "image": "events/base/city/ce-69-f.png",
+    "xws": "ce69f"
+  },
+  {
+    "name": "ce-70-b",
+    "points": 138,
+    "image": "events/base/city/ce-70-b.png",
+    "xws": "ce70b"
+  },
+  {
+    "name": "ce-70-f",
+    "points": 139,
+    "image": "events/base/city/ce-70-f.png",
+    "xws": "ce70f"
+  },
+  {
+    "name": "ce-71-b",
+    "points": 140,
+    "image": "events/base/city/ce-71-b.png",
+    "xws": "ce71b"
+  },
+  {
+    "name": "ce-71-f",
+    "points": 141,
+    "image": "events/base/city/ce-71-f.png",
+    "xws": "ce71f"
+  },
+  {
+    "name": "ce-72-b",
+    "points": 142,
+    "image": "events/base/city/ce-72-b.png",
+    "xws": "ce72b"
+  },
+  {
+    "name": "ce-72-f",
+    "points": 143,
+    "image": "events/base/city/ce-72-f.png",
+    "xws": "ce72f"
+  },
+  {
+    "name": "ce-73-b",
+    "points": 144,
+    "image": "events/base/city/ce-73-b.png",
+    "xws": "ce73b"
+  },
+  {
+    "name": "ce-73-f",
+    "points": 145,
+    "image": "events/base/city/ce-73-f.png",
+    "xws": "ce73f"
+  },
+  {
+    "name": "ce-74-b",
+    "points": 146,
+    "image": "events/base/city/ce-74-b.png",
+    "xws": "ce74b"
+  },
+  {
+    "name": "ce-74-f",
+    "points": 147,
+    "image": "events/base/city/ce-74-f.png",
+    "xws": "ce74f"
+  },
+  {
+    "name": "ce-75-b",
+    "points": 148,
+    "image": "events/base/city/ce-75-b.png",
+    "xws": "ce75b"
+  },
+  {
+    "name": "ce-75-f",
+    "points": 149,
+    "image": "events/base/city/ce-75-f.png",
+    "xws": "ce75f"
+  },
+  {
+    "name": "ce-76-b",
+    "points": 150,
+    "image": "events/base/city/ce-76-b.png",
+    "xws": "ce76b"
+  },
+  {
+    "name": "ce-76-f",
+    "points": 151,
+    "image": "events/base/city/ce-76-f.png",
+    "xws": "ce76f"
+  },
+  {
+    "name": "ce-77-b",
+    "points": 152,
+    "image": "events/base/city/ce-77-b.png",
+    "xws": "ce77b"
+  },
+  {
+    "name": "ce-77-f",
+    "points": 153,
+    "image": "events/base/city/ce-77-f.png",
+    "xws": "ce77f"
+  },
+  {
+    "name": "ce-78-b",
+    "points": 154,
+    "image": "events/base/city/ce-78-b.png",
+    "xws": "ce78b"
+  },
+  {
+    "name": "ce-78-f",
+    "points": 155,
+    "image": "events/base/city/ce-78-f.png",
+    "xws": "ce78f"
+  },
+  {
+    "name": "ce-79-b",
+    "points": 156,
+    "image": "events/base/city/ce-79-b.png",
+    "xws": "ce79b"
+  },
+  {
+    "name": "ce-79-f",
+    "points": 157,
+    "image": "events/base/city/ce-79-f.png",
+    "xws": "ce79f"
+  },
+  {
+    "name": "ce-80-b",
+    "points": 158,
+    "image": "events/base/city/ce-80-b.png",
+    "xws": "ce80b"
+  },
+  {
+    "name": "ce-80-f",
+    "points": 159,
+    "image": "events/base/city/ce-80-f.png",
+    "xws": "ce80f"
+  },
+  {
+    "name": "ce-81-b",
+    "points": 160,
+    "image": "events/base/city/ce-81-b.png",
+    "xws": "ce81b"
+  },
+  {
+    "name": "ce-81-f",
+    "points": 161,
+    "image": "events/base/city/ce-81-f.png",
+    "xws": "ce81f"
+  },
+  {
+    "name": "re-01-b",
+    "points": 162,
+    "image": "events/base/road/re-01-b.png",
+    "xws": "re01b"
+  },
+  {
+    "name": "re-01-f",
+    "points": 163,
+    "image": "events/base/road/re-01-f.png",
+    "xws": "re01f"
+  },
+  {
+    "name": "re-02-b",
+    "points": 164,
+    "image": "events/base/road/re-02-b.png",
+    "xws": "re02b"
+  },
+  {
+    "name": "re-02-f",
+    "points": 165,
+    "image": "events/base/road/re-02-f.png",
+    "xws": "re02f"
+  },
+  {
+    "name": "re-03-b",
+    "points": 166,
+    "image": "events/base/road/re-03-b.png",
+    "xws": "re03b"
+  },
+  {
+    "name": "re-03-f",
+    "points": 167,
+    "image": "events/base/road/re-03-f.png",
+    "xws": "re03f"
+  },
+  {
+    "name": "re-04-b",
+    "points": 168,
+    "image": "events/base/road/re-04-b.png",
+    "xws": "re04b"
+  },
+  {
+    "name": "re-04-f",
+    "points": 169,
+    "image": "events/base/road/re-04-f.png",
+    "xws": "re04f"
+  },
+  {
+    "name": "re-05-b",
+    "points": 170,
+    "image": "events/base/road/re-05-b.png",
+    "xws": "re05b"
+  },
+  {
+    "name": "re-05-f",
+    "points": 171,
+    "image": "events/base/road/re-05-f.png",
+    "xws": "re05f"
+  },
+  {
+    "name": "re-06-b",
+    "points": 172,
+    "image": "events/base/road/re-06-b.png",
+    "xws": "re06b"
+  },
+  {
+    "name": "re-06-f",
+    "points": 173,
+    "image": "events/base/road/re-06-f.png",
+    "xws": "re06f"
+  },
+  {
+    "name": "re-07-b",
+    "points": 174,
+    "image": "events/base/road/re-07-b.png",
+    "xws": "re07b"
+  },
+  {
+    "name": "re-07-f",
+    "points": 175,
+    "image": "events/base/road/re-07-f.png",
+    "xws": "re07f"
+  },
+  {
+    "name": "re-08-b",
+    "points": 176,
+    "image": "events/base/road/re-08-b.png",
+    "xws": "re08b"
+  },
+  {
+    "name": "re-08-f",
+    "points": 177,
+    "image": "events/base/road/re-08-f.png",
+    "xws": "re08f"
+  },
+  {
+    "name": "re-09-b",
+    "points": 178,
+    "image": "events/base/road/re-09-b.png",
+    "xws": "re09b"
+  },
+  {
+    "name": "re-09-f",
+    "points": 179,
+    "image": "events/base/road/re-09-f.png",
+    "xws": "re09f"
+  },
+  {
+    "name": "re-10-b",
+    "points": 180,
+    "image": "events/base/road/re-10-b.png",
+    "xws": "re10b"
+  },
+  {
+    "name": "re-10-f",
+    "points": 181,
+    "image": "events/base/road/re-10-f.png",
+    "xws": "re10f"
+  },
+  {
+    "name": "re-11-b",
+    "points": 182,
+    "image": "events/base/road/re-11-b.png",
+    "xws": "re11b"
+  },
+  {
+    "name": "re-11-f",
+    "points": 183,
+    "image": "events/base/road/re-11-f.png",
+    "xws": "re11f"
+  },
+  {
+    "name": "re-12-b",
+    "points": 184,
+    "image": "events/base/road/re-12-b.png",
+    "xws": "re12b"
+  },
+  {
+    "name": "re-12-f",
+    "points": 185,
+    "image": "events/base/road/re-12-f.png",
+    "xws": "re12f"
+  },
+  {
+    "name": "re-13-b",
+    "points": 186,
+    "image": "events/base/road/re-13-b.png",
+    "xws": "re13b"
+  },
+  {
+    "name": "re-13-f",
+    "points": 187,
+    "image": "events/base/road/re-13-f.png",
+    "xws": "re13f"
+  },
+  {
+    "name": "re-14-b",
+    "points": 188,
+    "image": "events/base/road/re-14-b.png",
+    "xws": "re14b"
+  },
+  {
+    "name": "re-14-f",
+    "points": 189,
+    "image": "events/base/road/re-14-f.png",
+    "xws": "re14f"
+  },
+  {
+    "name": "re-15-b",
+    "points": 190,
+    "image": "events/base/road/re-15-b.png",
+    "xws": "re15b"
+  },
+  {
+    "name": "re-15-f",
+    "points": 191,
+    "image": "events/base/road/re-15-f.png",
+    "xws": "re15f"
+  },
+  {
+    "name": "re-16-b",
+    "points": 192,
+    "image": "events/base/road/re-16-b.png",
+    "xws": "re16b"
+  },
+  {
+    "name": "re-16-f",
+    "points": 193,
+    "image": "events/base/road/re-16-f.png",
+    "xws": "re16f"
+  },
+  {
+    "name": "re-17-b",
+    "points": 194,
+    "image": "events/base/road/re-17-b.png",
+    "xws": "re17b"
+  },
+  {
+    "name": "re-17-f",
+    "points": 195,
+    "image": "events/base/road/re-17-f.png",
+    "xws": "re17f"
+  },
+  {
+    "name": "re-18-b",
+    "points": 196,
+    "image": "events/base/road/re-18-b.png",
+    "xws": "re18b"
+  },
+  {
+    "name": "re-18-f",
+    "points": 197,
+    "image": "events/base/road/re-18-f.png",
+    "xws": "re18f"
+  },
+  {
+    "name": "re-19-b",
+    "points": 198,
+    "image": "events/base/road/re-19-b.png",
+    "xws": "re19b"
+  },
+  {
+    "name": "re-19-f",
+    "points": 199,
+    "image": "events/base/road/re-19-f.png",
+    "xws": "re19f"
+  },
+  {
+    "name": "re-20-b",
+    "points": 200,
+    "image": "events/base/road/re-20-b.png",
+    "xws": "re20b"
+  },
+  {
+    "name": "re-20-f",
+    "points": 201,
+    "image": "events/base/road/re-20-f.png",
+    "xws": "re20f"
+  },
+  {
+    "name": "re-21-b",
+    "points": 202,
+    "image": "events/base/road/re-21-b.png",
+    "xws": "re21b"
+  },
+  {
+    "name": "re-21-f",
+    "points": 203,
+    "image": "events/base/road/re-21-f.png",
+    "xws": "re21f"
+  },
+  {
+    "name": "re-22-b",
+    "points": 204,
+    "image": "events/base/road/re-22-b.png",
+    "xws": "re22b"
+  },
+  {
+    "name": "re-22-f",
+    "points": 205,
+    "image": "events/base/road/re-22-f.png",
+    "xws": "re22f"
+  },
+  {
+    "name": "re-23-b",
+    "points": 206,
+    "image": "events/base/road/re-23-b.png",
+    "xws": "re23b"
+  },
+  {
+    "name": "re-23-f",
+    "points": 207,
+    "image": "events/base/road/re-23-f.png",
+    "xws": "re23f"
+  },
+  {
+    "name": "re-24-b",
+    "points": 208,
+    "image": "events/base/road/re-24-b.png",
+    "xws": "re24b"
+  },
+  {
+    "name": "re-24-f",
+    "points": 209,
+    "image": "events/base/road/re-24-f.png",
+    "xws": "re24f"
+  },
+  {
+    "name": "re-25-b",
+    "points": 210,
+    "image": "events/base/road/re-25-b.png",
+    "xws": "re25b"
+  },
+  {
+    "name": "re-25-f",
+    "points": 211,
+    "image": "events/base/road/re-25-f.png",
+    "xws": "re25f"
+  },
+  {
+    "name": "re-26-b",
+    "points": 212,
+    "image": "events/base/road/re-26-b.png",
+    "xws": "re26b"
+  },
+  {
+    "name": "re-26-f",
+    "points": 213,
+    "image": "events/base/road/re-26-f.png",
+    "xws": "re26f"
+  },
+  {
+    "name": "re-27-b",
+    "points": 214,
+    "image": "events/base/road/re-27-b.png",
+    "xws": "re27b"
+  },
+  {
+    "name": "re-27-f",
+    "points": 215,
+    "image": "events/base/road/re-27-f.png",
+    "xws": "re27f"
+  },
+  {
+    "name": "re-28-b",
+    "points": 216,
+    "image": "events/base/road/re-28-b.png",
+    "xws": "re28b"
+  },
+  {
+    "name": "re-28-f",
+    "points": 217,
+    "image": "events/base/road/re-28-f.png",
+    "xws": "re28f"
+  },
+  {
+    "name": "re-29-b",
+    "points": 218,
+    "image": "events/base/road/re-29-b.png",
+    "xws": "re29b"
+  },
+  {
+    "name": "re-29-f",
+    "points": 219,
+    "image": "events/base/road/re-29-f.png",
+    "xws": "re29f"
+  },
+  {
+    "name": "re-30-b",
+    "points": 220,
+    "image": "events/base/road/re-30-b.png",
+    "xws": "re30b"
+  },
+  {
+    "name": "re-30-f",
+    "points": 221,
+    "image": "events/base/road/re-30-f.png",
+    "xws": "re30f"
+  },
+  {
+    "name": "re-31-b",
+    "points": 222,
+    "image": "events/base/road/re-31-b.png",
+    "xws": "re31b"
+  },
+  {
+    "name": "re-31-f",
+    "points": 223,
+    "image": "events/base/road/re-31-f.png",
+    "xws": "re31f"
+  },
+  {
+    "name": "re-32-b",
+    "points": 224,
+    "image": "events/base/road/re-32-b.png",
+    "xws": "re32b"
+  },
+  {
+    "name": "re-32-f",
+    "points": 225,
+    "image": "events/base/road/re-32-f.png",
+    "xws": "re32f"
+  },
+  {
+    "name": "re-33-b",
+    "points": 226,
+    "image": "events/base/road/re-33-b.png",
+    "xws": "re33b"
+  },
+  {
+    "name": "re-33-f",
+    "points": 227,
+    "image": "events/base/road/re-33-f.png",
+    "xws": "re33f"
+  },
+  {
+    "name": "re-34-b",
+    "points": 228,
+    "image": "events/base/road/re-34-b.png",
+    "xws": "re34b"
+  },
+  {
+    "name": "re-34-f",
+    "points": 229,
+    "image": "events/base/road/re-34-f.png",
+    "xws": "re34f"
+  },
+  {
+    "name": "re-35-b",
+    "points": 230,
+    "image": "events/base/road/re-35-b.png",
+    "xws": "re35b"
+  },
+  {
+    "name": "re-35-f",
+    "points": 231,
+    "image": "events/base/road/re-35-f.png",
+    "xws": "re35f"
+  },
+  {
+    "name": "re-36-b",
+    "points": 232,
+    "image": "events/base/road/re-36-b.png",
+    "xws": "re36b"
+  },
+  {
+    "name": "re-36-f",
+    "points": 233,
+    "image": "events/base/road/re-36-f.png",
+    "xws": "re36f"
+  },
+  {
+    "name": "re-37-b",
+    "points": 234,
+    "image": "events/base/road/re-37-b.png",
+    "xws": "re37b"
+  },
+  {
+    "name": "re-37-f",
+    "points": 235,
+    "image": "events/base/road/re-37-f.png",
+    "xws": "re37f"
+  },
+  {
+    "name": "re-38-b",
+    "points": 236,
+    "image": "events/base/road/re-38-b.png",
+    "xws": "re38b"
+  },
+  {
+    "name": "re-38-f",
+    "points": 237,
+    "image": "events/base/road/re-38-f.png",
+    "xws": "re38f"
+  },
+  {
+    "name": "re-39-b",
+    "points": 238,
+    "image": "events/base/road/re-39-b.png",
+    "xws": "re39b"
+  },
+  {
+    "name": "re-39-f",
+    "points": 239,
+    "image": "events/base/road/re-39-f.png",
+    "xws": "re39f"
+  },
+  {
+    "name": "re-40-b",
+    "points": 240,
+    "image": "events/base/road/re-40-b.png",
+    "xws": "re40b"
+  },
+  {
+    "name": "re-40-f",
+    "points": 241,
+    "image": "events/base/road/re-40-f.png",
+    "xws": "re40f"
+  },
+  {
+    "name": "re-41-b",
+    "points": 242,
+    "image": "events/base/road/re-41-b.png",
+    "xws": "re41b"
+  },
+  {
+    "name": "re-41-f",
+    "points": 243,
+    "image": "events/base/road/re-41-f.png",
+    "xws": "re41f"
+  },
+  {
+    "name": "re-42-b",
+    "points": 244,
+    "image": "events/base/road/re-42-b.png",
+    "xws": "re42b"
+  },
+  {
+    "name": "re-42-f",
+    "points": 245,
+    "image": "events/base/road/re-42-f.png",
+    "xws": "re42f"
+  },
+  {
+    "name": "re-43-b",
+    "points": 246,
+    "image": "events/base/road/re-43-b.png",
+    "xws": "re43b"
+  },
+  {
+    "name": "re-43-f",
+    "points": 247,
+    "image": "events/base/road/re-43-f.png",
+    "xws": "re43f"
+  },
+  {
+    "name": "re-44-b",
+    "points": 248,
+    "image": "events/base/road/re-44-b.png",
+    "xws": "re44b"
+  },
+  {
+    "name": "re-44-f",
+    "points": 249,
+    "image": "events/base/road/re-44-f.png",
+    "xws": "re44f"
+  },
+  {
+    "name": "re-45-b",
+    "points": 250,
+    "image": "events/base/road/re-45-b.png",
+    "xws": "re45b"
+  },
+  {
+    "name": "re-45-f",
+    "points": 251,
+    "image": "events/base/road/re-45-f.png",
+    "xws": "re45f"
+  },
+  {
+    "name": "re-46-b",
+    "points": 252,
+    "image": "events/base/road/re-46-b.png",
+    "xws": "re46b"
+  },
+  {
+    "name": "re-46-f",
+    "points": 253,
+    "image": "events/base/road/re-46-f.png",
+    "xws": "re46f"
+  },
+  {
+    "name": "re-47-b",
+    "points": 254,
+    "image": "events/base/road/re-47-b.png",
+    "xws": "re47b"
+  },
+  {
+    "name": "re-47-f",
+    "points": 255,
+    "image": "events/base/road/re-47-f.png",
+    "xws": "re47f"
+  },
+  {
+    "name": "re-48-b",
+    "points": 256,
+    "image": "events/base/road/re-48-b.png",
+    "xws": "re48b"
+  },
+  {
+    "name": "re-48-f",
+    "points": 257,
+    "image": "events/base/road/re-48-f.png",
+    "xws": "re48f"
+  },
+  {
+    "name": "re-49-b",
+    "points": 258,
+    "image": "events/base/road/re-49-b.png",
+    "xws": "re49b"
+  },
+  {
+    "name": "re-49-f",
+    "points": 259,
+    "image": "events/base/road/re-49-f.png",
+    "xws": "re49f"
+  },
+  {
+    "name": "re-50-b",
+    "points": 260,
+    "image": "events/base/road/re-50-b.png",
+    "xws": "re50b"
+  },
+  {
+    "name": "re-50-f",
+    "points": 261,
+    "image": "events/base/road/re-50-f.png",
+    "xws": "re50f"
+  },
+  {
+    "name": "re-51-b",
+    "points": 262,
+    "image": "events/base/road/re-51-b.png",
+    "xws": "re51b"
+  },
+  {
+    "name": "re-51-f",
+    "points": 263,
+    "image": "events/base/road/re-51-f.png",
+    "xws": "re51f"
+  },
+  {
+    "name": "re-52-b",
+    "points": 264,
+    "image": "events/base/road/re-52-b.png",
+    "xws": "re52b"
+  },
+  {
+    "name": "re-52-f",
+    "points": 265,
+    "image": "events/base/road/re-52-f.png",
+    "xws": "re52f"
+  },
+  {
+    "name": "re-53-b",
+    "points": 266,
+    "image": "events/base/road/re-53-b.png",
+    "xws": "re53b"
+  },
+  {
+    "name": "re-53-f",
+    "points": 267,
+    "image": "events/base/road/re-53-f.png",
+    "xws": "re53f"
+  },
+  {
+    "name": "re-54-b",
+    "points": 268,
+    "image": "events/base/road/re-54-b.png",
+    "xws": "re54b"
+  },
+  {
+    "name": "re-54-f",
+    "points": 269,
+    "image": "events/base/road/re-54-f.png",
+    "xws": "re54f"
+  },
+  {
+    "name": "re-55-b",
+    "points": 270,
+    "image": "events/base/road/re-55-b.png",
+    "xws": "re55b"
+  },
+  {
+    "name": "re-55-f",
+    "points": 271,
+    "image": "events/base/road/re-55-f.png",
+    "xws": "re55f"
+  },
+  {
+    "name": "re-56-b",
+    "points": 272,
+    "image": "events/base/road/re-56-b.png",
+    "xws": "re56b"
+  },
+  {
+    "name": "re-56-f",
+    "points": 273,
+    "image": "events/base/road/re-56-f.png",
+    "xws": "re56f"
+  },
+  {
+    "name": "re-57-b",
+    "points": 274,
+    "image": "events/base/road/re-57-b.png",
+    "xws": "re57b"
+  },
+  {
+    "name": "re-57-f",
+    "points": 275,
+    "image": "events/base/road/re-57-f.png",
+    "xws": "re57f"
+  },
+  {
+    "name": "re-58-b",
+    "points": 276,
+    "image": "events/base/road/re-58-b.png",
+    "xws": "re58b"
+  },
+  {
+    "name": "re-58-f",
+    "points": 277,
+    "image": "events/base/road/re-58-f.png",
+    "xws": "re58f"
+  },
+  {
+    "name": "re-59-b",
+    "points": 278,
+    "image": "events/base/road/re-59-b.png",
+    "xws": "re59b"
+  },
+  {
+    "name": "re-59-f",
+    "points": 279,
+    "image": "events/base/road/re-59-f.png",
+    "xws": "re59f"
+  },
+  {
+    "name": "re-60-b",
+    "points": 280,
+    "image": "events/base/road/re-60-b.png",
+    "xws": "re60b"
+  },
+  {
+    "name": "re-60-f",
+    "points": 281,
+    "image": "events/base/road/re-60-f.png",
+    "xws": "re60f"
+  },
+  {
+    "name": "re-61-b",
+    "points": 282,
+    "image": "events/base/road/re-61-b.png",
+    "xws": "re61b"
+  },
+  {
+    "name": "re-61-f",
+    "points": 283,
+    "image": "events/base/road/re-61-f.png",
+    "xws": "re61f"
+  },
+  {
+    "name": "re-62-b",
+    "points": 284,
+    "image": "events/base/road/re-62-b.png",
+    "xws": "re62b"
+  },
+  {
+    "name": "re-62-f",
+    "points": 285,
+    "image": "events/base/road/re-62-f.png",
+    "xws": "re62f"
+  },
+  {
+    "name": "re-63-b",
+    "points": 286,
+    "image": "events/base/road/re-63-b.png",
+    "xws": "re63b"
+  },
+  {
+    "name": "re-63-f",
+    "points": 287,
+    "image": "events/base/road/re-63-f.png",
+    "xws": "re63f"
+  },
+  {
+    "name": "re-64-b",
+    "points": 288,
+    "image": "events/base/road/re-64-b.png",
+    "xws": "re64b"
+  },
+  {
+    "name": "re-64-f",
+    "points": 289,
+    "image": "events/base/road/re-64-f.png",
+    "xws": "re64f"
+  },
+  {
+    "name": "re-65-b",
+    "points": 290,
+    "image": "events/base/road/re-65-b.png",
+    "xws": "re65b"
+  },
+  {
+    "name": "re-65-f",
+    "points": 291,
+    "image": "events/base/road/re-65-f.png",
+    "xws": "re65f"
+  },
+  {
+    "name": "re-66-b",
+    "points": 292,
+    "image": "events/base/road/re-66-b.png",
+    "xws": "re66b"
+  },
+  {
+    "name": "re-66-f",
+    "points": 293,
+    "image": "events/base/road/re-66-f.png",
+    "xws": "re66f"
+  },
+  {
+    "name": "re-67-b",
+    "points": 294,
+    "image": "events/base/road/re-67-b.png",
+    "xws": "re67b"
+  },
+  {
+    "name": "re-67-f",
+    "points": 295,
+    "image": "events/base/road/re-67-f.png",
+    "xws": "re67f"
+  },
+  {
+    "name": "re-68-b",
+    "points": 296,
+    "image": "events/base/road/re-68-b.png",
+    "xws": "re68b"
+  },
+  {
+    "name": "re-68-f",
+    "points": 297,
+    "image": "events/base/road/re-68-f.png",
+    "xws": "re68f"
+  },
+  {
+    "name": "re-69-b",
+    "points": 298,
+    "image": "events/base/road/re-69-b.png",
+    "xws": "re69b"
+  },
+  {
+    "name": "re-69-f",
+    "points": 299,
+    "image": "events/base/road/re-69-f.png",
+    "xws": "re69f"
+  },
+  {
+    "name": "ce-ci-1-b",
+    "points": 300,
+    "image": "events/expeditions/capital-intrigue/ce-ci-1-b.png",
+    "xws": "ceci1b"
+  },
+  {
+    "name": "ce-ci-1-f",
+    "points": 301,
+    "image": "events/expeditions/capital-intrigue/ce-ci-1-f.png",
+    "xws": "ceci1f"
+  },
+  {
+    "name": "ce-ci-2-b",
+    "points": 302,
+    "image": "events/expeditions/capital-intrigue/ce-ci-2-b.png",
+    "xws": "ceci2b"
+  },
+  {
+    "name": "ce-ci-2-f",
+    "points": 303,
+    "image": "events/expeditions/capital-intrigue/ce-ci-2-f.png",
+    "xws": "ceci2f"
+  },
+  {
+    "name": "ce-ci-3-b",
+    "points": 304,
+    "image": "events/expeditions/capital-intrigue/ce-ci-3-b.png",
+    "xws": "ceci3b"
+  },
+  {
+    "name": "ce-ci-3-f",
+    "points": 305,
+    "image": "events/expeditions/capital-intrigue/ce-ci-3-f.png",
+    "xws": "ceci3f"
+  },
+  {
+    "name": "ce-ci-4-b",
+    "points": 306,
+    "image": "events/expeditions/capital-intrigue/ce-ci-4-b.png",
+    "xws": "ceci4b"
+  },
+  {
+    "name": "ce-ci-4-f",
+    "points": 307,
+    "image": "events/expeditions/capital-intrigue/ce-ci-4-f.png",
+    "xws": "ceci4f"
+  },
+  {
+    "name": "ce-ci-5-b",
+    "points": 308,
+    "image": "events/expeditions/capital-intrigue/ce-ci-5-b.png",
+    "xws": "ceci5b"
+  },
+  {
+    "name": "ce-ci-5-f",
+    "points": 309,
+    "image": "events/expeditions/capital-intrigue/ce-ci-5-f.png",
+    "xws": "ceci5f"
+  },
+  {
+    "name": "re-m1-f",
+    "points": 310,
+    "image": "events/expeditions/into-the-unknown/re-m1-f.png",
+    "xws": "rem1f"
+  },
+  {
+    "name": "re-m2-f",
+    "points": 311,
+    "image": "events/expeditions/into-the-unknown/re-m2-f.png",
+    "xws": "rem2f"
+  },
+  {
+    "name": "re-m3-f",
+    "points": 312,
+    "image": "events/expeditions/into-the-unknown/re-m3-f.png",
+    "xws": "rem3f"
+  },
+  {
+    "name": "re-m4-f",
+    "points": 313,
+    "image": "events/expeditions/into-the-unknown/re-m4-f.png",
+    "xws": "rem4f"
+  },
+  {
+    "name": "re-m5-f",
+    "points": 314,
+    "image": "events/expeditions/into-the-unknown/re-m5-f.png",
+    "xws": "rem5f"
+  },
+  {
+    "name": "re-m6-f",
+    "points": 315,
+    "image": "events/expeditions/into-the-unknown/re-m6-f.png",
+    "xws": "rem6f"
+  },
+  {
+    "name": "ce-82-b",
+    "points": 316,
+    "image": "events/base/city/ce-82-b.png",
+    "xws": "ce82b"
+  },
+  {
+    "name": "ce-82-f",
+    "points": 317,
+    "image": "events/base/city/ce-82-f.png",
+    "xws": "ce82f"
+  },
+  {
+    "name": "ce-83-b",
+    "points": 318,
+    "image": "events/base/city/ce-83-b.png",
+    "xws": "ce83b"
+  },
+  {
+    "name": "ce-83-f",
+    "points": 319,
+    "image": "events/base/city/ce-83-f.png",
+    "xws": "ce83f"
+  },
+  {
+    "name": "ce-84-b",
+    "points": 320,
+    "image": "events/base/city/ce-84-b.png",
+    "xws": "ce84b"
+  },
+  {
+    "name": "ce-84-f",
+    "points": 321,
+    "image": "events/base/city/ce-84-f.png",
+    "xws": "ce84f"
+  },
+  {
+    "name": "ce-85-b",
+    "points": 322,
+    "image": "events/base/city/ce-85-b.png",
+    "xws": "ce85b"
+  },
+  {
+    "name": "ce-85-f",
+    "points": 323,
+    "image": "events/base/city/ce-85-f.png",
+    "xws": "ce85f"
+  },
+  {
+    "name": "ce-86-b",
+    "points": 324,
+    "image": "events/base/city/ce-86-b.png",
+    "xws": "ce86b"
+  },
+  {
+    "name": "ce-86-f",
+    "points": 325,
+    "image": "events/base/city/ce-86-f.png",
+    "xws": "ce86f"
+  },
+  {
+    "name": "ce-87-b",
+    "points": 326,
+    "image": "events/base/city/ce-87-b.png",
+    "xws": "ce87b"
+  },
+  {
+    "name": "ce-87-f",
+    "points": 327,
+    "image": "events/base/city/ce-87-f.png",
+    "xws": "ce87f"
+  },
+  {
+    "name": "ce-88-b",
+    "points": 328,
+    "image": "events/base/city/ce-88-b.png",
+    "xws": "ce88b"
+  },
+  {
+    "name": "ce-88-f",
+    "points": 329,
+    "image": "events/base/city/ce-88-f.png",
+    "xws": "ce88f"
+  },
+  {
+    "name": "ce-89-b",
+    "points": 330,
+    "image": "events/base/city/ce-89-b.png",
+    "xws": "ce89b"
+  },
+  {
+    "name": "ce-89-f",
+    "points": 331,
+    "image": "events/base/city/ce-89-f.png",
+    "xws": "ce89f"
+  },
+  {
+    "name": "ce-90-b",
+    "points": 332,
+    "image": "events/base/city/ce-90-b.png",
+    "xws": "ce90b"
+  },
+  {
+    "name": "ce-90-f",
+    "points": 333,
+    "image": "events/base/city/ce-90-f.png",
+    "xws": "ce90f"
+  },
+  {
+    "name": "re-82-b",
+    "points": 334,
+    "image": "events/base/road/re-82-b.png",
+    "xws": "re82b"
+  },
+  {
+    "name": "re-82-f",
+    "points": 335,
+    "image": "events/base/road/re-82-f.png",
+    "xws": "re82f"
+  },
+  {
+    "name": "re-83-b",
+    "points": 336,
+    "image": "events/base/road/re-83-b.png",
+    "xws": "re83b"
+  },
+  {
+    "name": "re-83-f",
+    "points": 337,
+    "image": "events/base/road/re-83-f.png",
+    "xws": "re83f"
+  },
+  {
+    "name": "rf-01-b",
+    "points": 338,
+    "image": "events/base/rift/rf-01-b.png",
+    "xws": "rf01b"
+  },
+  {
+    "name": "rf-01-f",
+    "points": 339,
+    "image": "events/base/rift/rf-01-f.png",
+    "xws": "rf01f"
+  },
+  {
+    "name": "rf-02-b",
+    "points": 340,
+    "image": "events/base/rift/rf-02-b.png",
+    "xws": "rf02b"
+  },
+  {
+    "name": "rf-02-f",
+    "points": 341,
+    "image": "events/base/rift/rf-02-f.png",
+    "xws": "rf02f"
+  },
+  {
+    "name": "rf-03-b",
+    "points": 342,
+    "image": "events/base/rift/rf-03-b.png",
+    "xws": "rf03b"
+  },
+  {
+    "name": "rf-03-f",
+    "points": 343,
+    "image": "events/base/rift/rf-03-f.png",
+    "xws": "rf03f"
+  },
+  {
+    "name": "rf-04-b",
+    "points": 344,
+    "image": "events/base/rift/rf-04-b.png",
+    "xws": "rf04b"
+  },
+  {
+    "name": "rf-04-f",
+    "points": 345,
+    "image": "events/base/rift/rf-04-f.png",
+    "xws": "rf04f"
+  },
+  {
+    "name": "rf-05-b",
+    "points": 346,
+    "image": "events/base/rift/rf-05-b.png",
+    "xws": "rf05b"
+  },
+  {
+    "name": "rf-05-f",
+    "points": 347,
+    "image": "events/base/rift/rf-05-f.png",
+    "xws": "rf05f"
+  },
+  {
+    "name": "rf-06-b",
+    "points": 348,
+    "image": "events/base/rift/rf-06-b.png",
+    "xws": "rf06b"
+  },
+  {
+    "name": "rf-06-f",
+    "points": 349,
+    "image": "events/base/rift/rf-06-f.png",
+    "xws": "rf06f"
+  },
+  {
+    "name": "rf-07-b",
+    "points": 350,
+    "image": "events/base/rift/rf-07-b.png",
+    "xws": "rf07b"
+  },
+  {
+    "name": "rf-07-f",
+    "points": 351,
+    "image": "events/base/rift/rf-07-f.png",
+    "xws": "rf07f"
+  },
+  {
+    "name": "rf-08-b",
+    "points": 352,
+    "image": "events/base/rift/rf-08-b.png",
+    "xws": "rf08b"
+  },
+  {
+    "name": "rf-08-f",
+    "points": 353,
+    "image": "events/base/rift/rf-08-f.png",
+    "xws": "rf08f"
+  },
+  {
+    "name": "rf-09-b",
+    "points": 354,
+    "image": "events/base/rift/rf-09-b.png",
+    "xws": "rf09b"
+  },
+  {
+    "name": "rf-09-f",
+    "points": 355,
+    "image": "events/base/rift/rf-09-f.png",
+    "xws": "rf09f"
+  },
+  {
+    "name": "rf-10-b",
+    "points": 356,
+    "image": "events/base/rift/rf-10-b.png",
+    "xws": "rf10b"
+  },
+  {
+    "name": "rf-10-f",
+    "points": 357,
+    "image": "events/base/rift/rf-10-f.png",
+    "xws": "rf10f"
+  },
+  {
+    "name": "rf-11-b",
+    "points": 358,
+    "image": "events/base/rift/rf-11-b.png",
+    "xws": "rf11b"
+  },
+  {
+    "name": "rf-11-f",
+    "points": 359,
+    "image": "events/base/rift/rf-11-f.png",
+    "xws": "rf11f"
+  },
+  {
+    "name": "rf-12-b",
+    "points": 360,
+    "image": "events/base/rift/rf-12-b.png",
+    "xws": "rf12b"
+  },
+  {
+    "name": "rf-12-f",
+    "points": 361,
+    "image": "events/base/rift/rf-12-f.png",
+    "xws": "rf12f"
+  },
+  {
+    "name": "rf-13-b",
+    "points": 362,
+    "image": "events/base/rift/rf-13-b.png",
+    "xws": "rf13b"
+  },
+  {
+    "name": "rf-13-f",
+    "points": 363,
+    "image": "events/base/rift/rf-13-f.png",
+    "xws": "rf13f"
+  },
+  {
+    "name": "rf-14-b",
+    "points": 364,
+    "image": "events/base/rift/rf-14-b.png",
+    "xws": "rf14b"
+  },
+  {
+    "name": "rf-14-f",
+    "points": 365,
+    "image": "events/base/rift/rf-14-f.png",
+    "xws": "rf14f"
+  },
+  {
+    "name": "rf-15-b",
+    "points": 366,
+    "image": "events/base/rift/rf-15-b.png",
+    "xws": "rf15b"
+  },
+  {
+    "name": "rf-15-f",
+    "points": 367,
+    "image": "events/base/rift/rf-15-f.png",
+    "xws": "rf15f"
+  },
+  {
+    "name": "rf-16-b",
+    "points": 368,
+    "image": "events/base/rift/rf-16-b.png",
+    "xws": "rf16b"
+  },
+  {
+    "name": "rf-16-f",
+    "points": 369,
+    "image": "events/base/rift/rf-16-f.png",
+    "xws": "rf16f"
+  },
+  {
+    "name": "rf-17-b",
+    "points": 370,
+    "image": "events/base/rift/rf-17-b.png",
+    "xws": "rf17b"
+  },
+  {
+    "name": "rf-17-f",
+    "points": 371,
+    "image": "events/base/rift/rf-17-f.png",
+    "xws": "rf17f"
+  },
+  {
+    "name": "rf-18-b",
+    "points": 372,
+    "image": "events/base/rift/rf-18-b.png",
+    "xws": "rf18b"
+  },
+  {
+    "name": "rf-18-f",
+    "points": 373,
+    "image": "events/base/rift/rf-18-f.png",
+    "xws": "rf18f"
+  },
+  {
+    "name": "rf-19-b",
+    "points": 374,
+    "image": "events/base/rift/rf-19-b.png",
+    "xws": "rf19b"
+  },
+  {
+    "name": "rf-19-f",
+    "points": 375,
+    "image": "events/base/rift/rf-19-f.png",
+    "xws": "rf19f"
+  },
+  {
+    "name": "rf-20-b",
+    "points": 376,
+    "image": "events/base/rift/rf-20-b.png",
+    "xws": "rf20b"
+  },
+  {
+    "name": "rf-20-f",
+    "points": 377,
+    "image": "events/base/rift/rf-20-f.png",
+    "xws": "rf20f"
+  }
+]

--- a/data/items.json
+++ b/data/items.json
@@ -1,0 +1,4316 @@
+[
+  {
+    "name": "boots of striding",
+    "points": 0,
+    "image": "items/1-14/boots-of-striding.png",
+    "xws": "bootsofstriding"
+  },
+  {
+    "name": "winged shoes",
+    "points": 1,
+    "image": "items/1-14/winged-shoes.png",
+    "xws": "wingedshoes"
+  },
+  {
+    "name": "hide armor",
+    "points": 2,
+    "image": "items/1-14/hide-armor.png",
+    "xws": "hidearmor"
+  },
+  {
+    "name": "leather armor",
+    "points": 3,
+    "image": "items/1-14/leather-armor.png",
+    "xws": "leatherarmor"
+  },
+  {
+    "name": "cloak of invisibility",
+    "points": 4,
+    "image": "items/1-14/cloak-of-invisibility.png",
+    "xws": "cloakofinvisibility"
+  },
+  {
+    "name": "eagle-eye goggles",
+    "points": 5,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "iron helmet",
+    "points": 6,
+    "image": "items/1-14/iron-helmet.png",
+    "xws": "ironhelmet"
+  },
+  {
+    "name": "heater shield",
+    "points": 7,
+    "image": "items/1-14/heater-shield.png",
+    "xws": "heatershield"
+  },
+  {
+    "name": "piercing bow",
+    "points": 8,
+    "image": "items/1-14/piercing-bow.png",
+    "xws": "piercingbow"
+  },
+  {
+    "name": "war hammer",
+    "points": 9,
+    "image": "items/1-14/war-hammer.png",
+    "xws": "warhammer"
+  },
+  {
+    "name": "poison dagger",
+    "points": 10,
+    "image": "items/1-14/poison-dagger.png",
+    "xws": "poisondagger"
+  },
+  {
+    "name": "minor healing potion",
+    "points": 11,
+    "image": "items/1-14/minor-healing-potion.png",
+    "xws": "minorhealingpotion"
+  },
+  {
+    "name": "minor stamina potion",
+    "points": 12,
+    "image": "items/1-14/minor-stamina-potion.png",
+    "xws": "minorstaminapotion"
+  },
+  {
+    "name": "minor power potion",
+    "points": 13,
+    "image": "items/1-14/minor-power-potion.png",
+    "xws": "minorpowerpotion"
+  },
+  {
+    "name": "boots of speed",
+    "points": 14,
+    "image": "items/15-21/boots-of-speed.png",
+    "xws": "bootsofspeed"
+  },
+  {
+    "name": "cloak of pockets",
+    "points": 15,
+    "image": "items/15-21/cloak-of-pockets.png",
+    "xws": "cloakofpockets"
+  },
+  {
+    "name": "empowering talisman",
+    "points": 16,
+    "image": "items/15-21/empowering-talisman.png",
+    "xws": "empoweringtalisman"
+  },
+  {
+    "name": "battle-axe",
+    "points": 17,
+    "image": "items/15-21/battle-axe.png",
+    "xws": "battleaxe"
+  },
+  {
+    "name": "weighted net",
+    "points": 18,
+    "image": "items/15-21/weighted-net.png",
+    "xws": "weightednet"
+  },
+  {
+    "name": "minor mana potion",
+    "points": 19,
+    "image": "items/15-21/minor-mana-potion.png",
+    "xws": "minormanapotion"
+  },
+  {
+    "name": "stun powder",
+    "points": 20,
+    "image": "items/15-21/stun-powder.png",
+    "xws": "stunpowder"
+  },
+  {
+    "name": "heavy greaves",
+    "points": 21,
+    "image": "items/22-28/heavy-greaves.png",
+    "xws": "heavygreaves"
+  },
+  {
+    "name": "chainmail",
+    "points": 22,
+    "image": "items/22-28/chainmail.png",
+    "xws": "chainmail"
+  },
+  {
+    "name": "amulet of life",
+    "points": 23,
+    "image": "items/22-28/amulet-of-life.png",
+    "xws": "amuletoflife"
+  },
+  {
+    "name": "jagged sword",
+    "points": 24,
+    "image": "items/22-28/jagged-sword.png",
+    "xws": "jaggedsword"
+  },
+  {
+    "name": "long spear",
+    "points": 25,
+    "image": "items/22-28/long-spear.png",
+    "xws": "longspear"
+  },
+  {
+    "name": "major healing potion",
+    "points": 26,
+    "image": "items/22-28/major-healing-potion.png",
+    "xws": "majorhealingpotion"
+  },
+  {
+    "name": "moon earring",
+    "points": 27,
+    "image": "items/22-28/moon-earring.png",
+    "xws": "moonearring"
+  },
+  {
+    "name": "comfortable shoes",
+    "points": 28,
+    "image": "items/29-35/comfortable-shoes.png",
+    "xws": "comfortableshoes"
+  },
+  {
+    "name": "studded leather",
+    "points": 29,
+    "image": "items/29-35/studded-leather.png",
+    "xws": "studdedleather"
+  },
+  {
+    "name": "hawk helm",
+    "points": 30,
+    "image": "items/29-35/hawk-helm.png",
+    "xws": "hawkhelm"
+  },
+  {
+    "name": "tower shield",
+    "points": 31,
+    "image": "items/29-35/tower-shield.png",
+    "xws": "towershield"
+  },
+  {
+    "name": "volatile bomb",
+    "points": 32,
+    "image": "items/29-35/volatile-bomb.png",
+    "xws": "volatilebomb"
+  },
+  {
+    "name": "major stamina potion",
+    "points": 33,
+    "image": "items/29-35/major-stamina-potion.png",
+    "xws": "majorstaminapotion"
+  },
+  {
+    "name": "falcon figurine",
+    "points": 34,
+    "image": "items/29-35/falcon-figurine.png",
+    "xws": "falconfigurine"
+  },
+  {
+    "name": "boots of dashing",
+    "points": 35,
+    "image": "items/36-42/boots-of-dashing.png",
+    "xws": "bootsofdashing"
+  },
+  {
+    "name": "robes of evocation",
+    "points": 36,
+    "image": "items/36-42/robes-of-evocation.png",
+    "xws": "robesofevocation"
+  },
+  {
+    "name": "heavy basinet",
+    "points": 37,
+    "image": "items/36-42/heavy-basinet.png",
+    "xws": "heavybasinet"
+  },
+  {
+    "name": "hooked chain",
+    "points": 38,
+    "image": "items/36-42/hooked-chain.png",
+    "xws": "hookedchain"
+  },
+  {
+    "name": "versatile dagger",
+    "points": 39,
+    "image": "items/36-42/versatile-dagger.png",
+    "xws": "versatiledagger"
+  },
+  {
+    "name": "major power potion",
+    "points": 40,
+    "image": "items/36-42/major-power-potion.png",
+    "xws": "majorpowerpotion"
+  },
+  {
+    "name": "ring of haste",
+    "points": 41,
+    "image": "items/36-42/ring-of-haste.png",
+    "xws": "ringofhaste"
+  },
+  {
+    "name": "boots of quickness",
+    "points": 42,
+    "image": "items/43-49/boots-of-quickness.png",
+    "xws": "bootsofquickness"
+  },
+  {
+    "name": "splintmail",
+    "points": 43,
+    "image": "items/43-49/splintmail.png",
+    "xws": "splintmail"
+  },
+  {
+    "name": "pendant of dark pacts",
+    "points": 44,
+    "image": "items/43-49/pendant-of-dark-pacts.png",
+    "xws": "pendantofdarkpacts"
+  },
+  {
+    "name": "spiked shield",
+    "points": 45,
+    "image": "items/43-49/spiked-shield.png",
+    "xws": "spikedshield"
+  },
+  {
+    "name": "reaping scythe",
+    "points": 46,
+    "image": "items/43-49/reaping-scythe.png",
+    "xws": "reapingscythe"
+  },
+  {
+    "name": "major mana potion",
+    "points": 47,
+    "image": "items/43-49/major-mana-potion.png",
+    "xws": "majormanapotion"
+  },
+  {
+    "name": "sun earring",
+    "points": 48,
+    "image": "items/43-49/sun-earring.png",
+    "xws": "sunearring"
+  },
+  {
+    "name": "steel sabatons",
+    "points": 49,
+    "image": "items/50-56/steel-sabatons.png",
+    "xws": "steelsabatons"
+  },
+  {
+    "name": "shadow armor",
+    "points": 50,
+    "image": "items/50-56/shadow-armor.png",
+    "xws": "shadowarmor"
+  },
+  {
+    "name": "protective charm",
+    "points": 51,
+    "image": "items/50-56/protective-charm.png",
+    "xws": "protectivecharm"
+  },
+  {
+    "name": "black knife",
+    "points": 52,
+    "image": "items/50-56/black-knife.png",
+    "xws": "blackknife"
+  },
+  {
+    "name": "staff of eminence",
+    "points": 53,
+    "image": "items/50-56/staff-of-eminence.png",
+    "xws": "staffofeminence"
+  },
+  {
+    "name": "super healing potion",
+    "points": 54,
+    "image": "items/50-56/super-healing-potion.png",
+    "xws": "superhealingpotion"
+  },
+  {
+    "name": "ring of brutality",
+    "points": 55,
+    "image": "items/50-56/ring-of-brutality.png",
+    "xws": "ringofbrutality"
+  },
+  {
+    "name": "serene sandals",
+    "points": 56,
+    "image": "items/57-63/serene-sandals.png",
+    "xws": "serenesandals"
+  },
+  {
+    "name": "cloak of phasing",
+    "points": 57,
+    "image": "items/57-63/cloak-of-phasing.png",
+    "xws": "cloakofphasing"
+  },
+  {
+    "name": "telescopic lens",
+    "points": 58,
+    "image": "items/57-63/telescopic-lens.png",
+    "xws": "telescopiclens"
+  },
+  {
+    "name": "unstable explosives",
+    "points": 59,
+    "image": "items/57-63/unstable-explosives.png",
+    "xws": "unstableexplosives"
+  },
+  {
+    "name": "wall shield",
+    "points": 60,
+    "image": "items/57-63/wall-shield.png",
+    "xws": "wallshield"
+  },
+  {
+    "name": "doom powder",
+    "points": 61,
+    "image": "items/57-63/doom-powder.png",
+    "xws": "doompowder"
+  },
+  {
+    "name": "lucky eye",
+    "points": 62,
+    "image": "items/57-63/lucky-eye.png",
+    "xws": "luckyeye"
+  },
+  {
+    "name": "boots of sprinting",
+    "points": 63,
+    "image": "items/64-151/boots-of-sprinting.png",
+    "xws": "bootsofsprinting"
+  },
+  {
+    "name": "platemail",
+    "points": 64,
+    "image": "items/64-151/platemail.png",
+    "xws": "platemail"
+  },
+  {
+    "name": "mask of terror",
+    "points": 65,
+    "image": "items/64-151/mask-of-terror.png",
+    "xws": "maskofterror"
+  },
+  {
+    "name": "balanced blade",
+    "points": 66,
+    "image": "items/64-151/balanced-blade.png",
+    "xws": "balancedblade"
+  },
+  {
+    "name": "halberd",
+    "points": 67,
+    "image": "items/64-151/halberd.png",
+    "xws": "halberd"
+  },
+  {
+    "name": "star earring",
+    "points": 68,
+    "image": "items/64-151/star-earring.png",
+    "xws": "starearring"
+  },
+  {
+    "name": "second chance ring",
+    "points": 69,
+    "image": "items/64-151/second-chance-ring.png",
+    "xws": "secondchancering"
+  },
+  {
+    "name": "boots of levitation",
+    "points": 70,
+    "image": "items/64-151/boots-of-levitation.png",
+    "xws": "bootsoflevitation"
+  },
+  {
+    "name": "shoes of happiness",
+    "points": 71,
+    "image": "items/64-151/shoes-of-happiness.png",
+    "xws": "shoesofhappiness"
+  },
+  {
+    "name": "blinking cape",
+    "points": 72,
+    "image": "items/64-151/blinking-cape.png",
+    "xws": "blinkingcape"
+  },
+  {
+    "name": "swordedge armor",
+    "points": 73,
+    "image": "items/64-151/swordedge-armor.png",
+    "xws": "swordedgearmor"
+  },
+  {
+    "name": "circlet of elements",
+    "points": 74,
+    "image": "items/64-151/circlet-of-elements.png",
+    "xws": "circletofelements"
+  },
+  {
+    "name": "chain hood",
+    "points": 75,
+    "image": "items/64-151/chain-hood.png",
+    "xws": "chainhood"
+  },
+  {
+    "name": "frigid blade",
+    "points": 76,
+    "image": "items/64-151/frigid-blade.png",
+    "xws": "frigidblade"
+  },
+  {
+    "name": "storm blade",
+    "points": 77,
+    "image": "items/64-151/storm-blade.png",
+    "xws": "stormblade"
+  },
+  {
+    "name": "inferno blade",
+    "points": 78,
+    "image": "items/64-151/inferno-blade.png",
+    "xws": "infernoblade"
+  },
+  {
+    "name": "tremor blade",
+    "points": 79,
+    "image": "items/64-151/tremor-blade.png",
+    "xws": "tremorblade"
+  },
+  {
+    "name": "brilliant blade",
+    "points": 80,
+    "image": "items/64-151/brilliant-blade.png",
+    "xws": "brilliantblade"
+  },
+  {
+    "name": "night blade",
+    "points": 81,
+    "image": "items/64-151/night-blade.png",
+    "xws": "nightblade"
+  },
+  {
+    "name": "wand of frost",
+    "points": 82,
+    "image": "items/64-151/wand-of-frost.png",
+    "xws": "wandoffrost"
+  },
+  {
+    "name": "wand of storms",
+    "points": 83,
+    "image": "items/64-151/wand-of-storms.png",
+    "xws": "wandofstorms"
+  },
+  {
+    "name": "wand of infernos",
+    "points": 84,
+    "image": "items/64-151/wand-of-infernos.png",
+    "xws": "wandofinfernos"
+  },
+  {
+    "name": "wand of tremors",
+    "points": 85,
+    "image": "items/64-151/wand-of-tremors.png",
+    "xws": "wandoftremors"
+  },
+  {
+    "name": "wand of brilliance",
+    "points": 86,
+    "image": "items/64-151/wand-of-brilliance.png",
+    "xws": "wandofbrilliance"
+  },
+  {
+    "name": "wand of darkness",
+    "points": 87,
+    "image": "items/64-151/wand-of-darkness.png",
+    "xws": "wandofdarkness"
+  },
+  {
+    "name": "minor cure potion",
+    "points": 88,
+    "image": "items/64-151/minor-cure-potion.png",
+    "xws": "minorcurepotion"
+  },
+  {
+    "name": "major cure potion",
+    "points": 89,
+    "image": "items/64-151/major-cure-potion.png",
+    "xws": "majorcurepotion"
+  },
+  {
+    "name": "steel ring",
+    "points": 90,
+    "image": "items/64-151/steel-ring.png",
+    "xws": "steelring"
+  },
+  {
+    "name": "dampening ring",
+    "points": 91,
+    "image": "items/64-151/dampening-ring.png",
+    "xws": "dampeningring"
+  },
+  {
+    "name": "scroll of power",
+    "points": 92,
+    "image": "items/64-151/scroll-of-power.png",
+    "xws": "scrollofpower"
+  },
+  {
+    "name": "scroll of healing",
+    "points": 93,
+    "image": "items/64-151/scroll-of-healing.png",
+    "xws": "scrollofhealing"
+  },
+  {
+    "name": "scroll of stamina",
+    "points": 94,
+    "image": "items/64-151/scroll-of-stamina.png",
+    "xws": "scrollofstamina"
+  },
+  {
+    "name": "rocket boots",
+    "points": 95,
+    "image": "items/64-151/rocket-boots.png",
+    "xws": "rocketboots"
+  },
+  {
+    "name": "endurance footwraps",
+    "points": 96,
+    "image": "items/64-151/endurance-footwraps.png",
+    "xws": "endurancefootwraps"
+  },
+  {
+    "name": "drakescale boots",
+    "points": 97,
+    "image": "items/64-151/drakescale-boots.png",
+    "xws": "drakescaleboots"
+  },
+  {
+    "name": "magma waders",
+    "points": 98,
+    "image": "items/64-151/magma-waders.png",
+    "xws": "magmawaders"
+  },
+  {
+    "name": "robes of summoning",
+    "points": 99,
+    "image": "items/64-151/robes-of-summoning.png",
+    "xws": "robesofsummoning"
+  },
+  {
+    "name": "second skin",
+    "points": 100,
+    "image": "items/64-151/second-skin.png",
+    "xws": "secondskin"
+  },
+  {
+    "name": "sacrificial robes",
+    "points": 101,
+    "image": "items/64-151/sacrificial-robes.png",
+    "xws": "sacrificialrobes"
+  },
+  {
+    "name": "drakescale armor",
+    "points": 102,
+    "image": "items/64-151/drakescale-armor.png",
+    "xws": "drakescalearmor"
+  },
+  {
+    "name": "steam armor",
+    "points": 103,
+    "image": "items/64-151/steam-armor.png",
+    "xws": "steamarmor"
+  },
+  {
+    "name": "flea-bitten shawl",
+    "points": 104,
+    "image": "items/64-151/flea-bitten-shawl.png",
+    "xws": "fleabittenshawl"
+  },
+  {
+    "name": "necklace of teeth",
+    "points": 105,
+    "image": "items/64-151/necklace-of-teeth.png",
+    "xws": "necklaceofteeth"
+  },
+  {
+    "name": "horned helm",
+    "points": 106,
+    "image": "items/64-151/horned-helm.png",
+    "xws": "hornedhelm"
+  },
+  {
+    "name": "drakescale helm",
+    "points": 107,
+    "image": "items/64-151/drakescale-helm.png",
+    "xws": "drakescalehelm"
+  },
+  {
+    "name": "thief's hood",
+    "points": 108,
+    "image": "items/64-151/thiefs-hood.png",
+    "xws": "thiefshood"
+  },
+  {
+    "name": "helm of the mountain",
+    "points": 109,
+    "image": "items/64-151/helm-of-the-mountain.png",
+    "xws": "helmofthemountain"
+  },
+  {
+    "name": "wave crest",
+    "points": 110,
+    "image": "items/64-151/wave-crest.png",
+    "xws": "wavecrest"
+  },
+  {
+    "name": "ancient drill",
+    "points": 111,
+    "image": "items/64-151/ancient-drill.png",
+    "xws": "ancientdrill"
+  },
+  {
+    "name": "skullbane axe",
+    "points": 112,
+    "image": "items/64-151/skullbane-axe.png",
+    "xws": "skullbaneaxe"
+  },
+  {
+    "name": "staff of xorn",
+    "points": 113,
+    "image": "items/64-151/staff-of-xorn.png",
+    "xws": "staffofxorn"
+  },
+  {
+    "name": "mountain hammer",
+    "points": 114,
+    "image": "items/64-151/mountain-hammer.png",
+    "xws": "mountainhammer"
+  },
+  {
+    "name": "fueled falchion",
+    "points": 115,
+    "image": "items/64-151/fueled-falchion.png",
+    "xws": "fueledfalchion"
+  },
+  {
+    "name": "bloody axe",
+    "points": 116,
+    "image": "items/64-151/bloody-axe.png",
+    "xws": "bloodyaxe"
+  },
+  {
+    "name": "staff of elements",
+    "points": 117,
+    "image": "items/64-151/staff-of-elements.png",
+    "xws": "staffofelements"
+  },
+  {
+    "name": "skull of hatred",
+    "points": 118,
+    "image": "items/64-151/skull-of-hatred.png",
+    "xws": "skullofhatred"
+  },
+  {
+    "name": "staff of summoning",
+    "points": 119,
+    "image": "items/64-151/staff-of-summoning.png",
+    "xws": "staffofsummoning"
+  },
+  {
+    "name": "orb of dawn",
+    "points": 120,
+    "image": "items/64-151/orb-of-dawn.png",
+    "xws": "orbofdawn"
+  },
+  {
+    "name": "orb of twilight",
+    "points": 121,
+    "image": "items/64-151/orb-of-twilight.png",
+    "xws": "orboftwilight"
+  },
+  {
+    "name": "ring of skulls",
+    "points": 122,
+    "image": "items/64-151/ring-of-skulls.png",
+    "xws": "ringofskulls"
+  },
+  {
+    "name": "doomed compass",
+    "points": 123,
+    "image": "items/64-151/doomed-compass.png",
+    "xws": "doomedcompass"
+  },
+  {
+    "name": "curious gear",
+    "points": 124,
+    "image": "items/64-151/curious-gear.png",
+    "xws": "curiousgear"
+  },
+  {
+    "name": "remote spider",
+    "points": 125,
+    "image": "items/64-151/remote-spider.png",
+    "xws": "remotespider"
+  },
+  {
+    "name": "giant remote spider",
+    "points": 126,
+    "image": "items/64-151/giant-remote-spider.png",
+    "xws": "giantremotespider"
+  },
+  {
+    "name": "black censer",
+    "points": 127,
+    "image": "items/64-151/black-censer.png",
+    "xws": "blackcenser"
+  },
+  {
+    "name": "black card",
+    "points": 128,
+    "image": "items/64-151/black-card.png",
+    "xws": "blackcard"
+  },
+  {
+    "name": "helix ring",
+    "points": 129,
+    "image": "items/64-151/helix-ring.png",
+    "xws": "helixring"
+  },
+  {
+    "name": "heart of the betrayer",
+    "points": 130,
+    "image": "items/64-151/heart-of-the-betrayer.png",
+    "xws": "heartofthebetrayer"
+  },
+  {
+    "name": "power core",
+    "points": 131,
+    "image": "items/64-151/power-core.png",
+    "xws": "powercore"
+  },
+  {
+    "name": "resonant crystal",
+    "points": 132,
+    "image": "items/64-151/resonant-crystal.png",
+    "xws": "resonantcrystal"
+  },
+  {
+    "name": "imposing blade",
+    "points": 133,
+    "image": "items/64-151/imposing-blade.png",
+    "xws": "imposingblade"
+  },
+  {
+    "name": "focusing ray",
+    "points": 134,
+    "image": "items/64-151/focusing-ray.png",
+    "xws": "focusingray"
+  },
+  {
+    "name": "volatile elixir",
+    "points": 135,
+    "image": "items/64-151/volatile-elixir.png",
+    "xws": "volatileelixir"
+  },
+  {
+    "name": "silent stiletto",
+    "points": 136,
+    "image": "items/64-151/silent-stiletto.png",
+    "xws": "silentstiletto"
+  },
+  {
+    "name": "stone charm",
+    "points": 137,
+    "image": "items/64-151/stone-charm.png",
+    "xws": "stonecharm"
+  },
+  {
+    "name": "psychic knife",
+    "points": 138,
+    "image": "items/64-151/psychic-knife.png",
+    "xws": "psychicknife"
+  },
+  {
+    "name": "sun shield",
+    "points": 139,
+    "image": "items/64-151/sun-shield.png",
+    "xws": "sunshield"
+  },
+  {
+    "name": "utility belt",
+    "points": 140,
+    "image": "items/64-151/utility-belt.png",
+    "xws": "utilitybelt"
+  },
+  {
+    "name": "phasing idol",
+    "points": 141,
+    "image": "items/64-151/phasing-idol.png",
+    "xws": "phasingidol"
+  },
+  {
+    "name": "smoke elixir",
+    "points": 142,
+    "image": "items/64-151/smoke-elixir.png",
+    "xws": "smokeelixir"
+  },
+  {
+    "name": "pendant of the plague",
+    "points": 143,
+    "image": "items/64-151/pendant-of-the-plague.png",
+    "xws": "pendantoftheplague"
+  },
+  {
+    "name": "mask of death",
+    "points": 144,
+    "image": "items/64-151/mask-of-death.png",
+    "xws": "maskofdeath"
+  },
+  {
+    "name": "master's lute",
+    "points": 145,
+    "image": "items/64-151/masters-lute.png",
+    "xws": "masterslute"
+  },
+  {
+    "name": "cloak of the hunter",
+    "points": 146,
+    "image": "items/64-151/cloak-of-the-hunter.png",
+    "xws": "cloakofthehunter"
+  },
+  {
+    "name": "doctor's coat",
+    "points": 147,
+    "image": "items/64-151/doctors-coat.png",
+    "xws": "doctors coat"
+  },
+  {
+    "name": "elemental boots",
+    "points": 148,
+    "image": "items/64-151/elemental-boots.png",
+    "xws": "elementalboots"
+  },
+  {
+    "name": "staff of command",
+    "points": 149,
+    "image": "items/64-151/staff-of-command.png",
+    "xws": "staffofcommand"
+  },
+  {
+    "name": "sword of the sands",
+    "points": 150,
+    "image": "items/64-151/sword-of-the-sands.png",
+    "xws": "swordofthesands"
+  },
+  {
+    "name": "item 1",
+    "points": 151,
+    "image": "items/1-14/boots-of-striding.png",
+    "xws": "bootsofstriding"
+  },
+  {
+    "name": "item 01",
+    "points": 152,
+    "image": "items/1-14/boots-of-striding.png",
+    "xws": "bootsofstriding"
+  },
+  {
+    "name": "item 001",
+    "points": 153,
+    "image": "items/1-14/boots-of-striding.png",
+    "xws": "bootsofstriding"
+  },
+  {
+    "name": "item #1",
+    "points": 154,
+    "image": "items/1-14/boots-of-striding.png",
+    "xws": "bootsofstriding"
+  },
+  {
+    "name": "item #01",
+    "points": 155,
+    "image": "items/1-14/boots-of-striding.png",
+    "xws": "bootsofstriding"
+  },
+  {
+    "name": "item #001",
+    "points": 156,
+    "image": "items/1-14/boots-of-striding.png",
+    "xws": "bootsofstriding"
+  },
+  {
+    "name": "item 2",
+    "points": 157,
+    "image": "items/1-14/winged-shoes.png",
+    "xws": "wingedshoes"
+  },
+  {
+    "name": "item 02",
+    "points": 158,
+    "image": "items/1-14/winged-shoes.png",
+    "xws": "wingedshoes"
+  },
+  {
+    "name": "item 002",
+    "points": 159,
+    "image": "items/1-14/winged-shoes.png",
+    "xws": "wingedshoes"
+  },
+  {
+    "name": "item #2",
+    "points": 160,
+    "image": "items/1-14/winged-shoes.png",
+    "xws": "wingedshoes"
+  },
+  {
+    "name": "item #02",
+    "points": 161,
+    "image": "items/1-14/winged-shoes.png",
+    "xws": "wingedshoes"
+  },
+  {
+    "name": "item #002",
+    "points": 162,
+    "image": "items/1-14/winged-shoes.png",
+    "xws": "wingedshoes"
+  },
+  {
+    "name": "item 3",
+    "points": 163,
+    "image": "items/1-14/hide-armor.png",
+    "xws": "hidearmor"
+  },
+  {
+    "name": "item 03",
+    "points": 164,
+    "image": "items/1-14/hide-armor.png",
+    "xws": "hidearmor"
+  },
+  {
+    "name": "item 003",
+    "points": 165,
+    "image": "items/1-14/hide-armor.png",
+    "xws": "hidearmor"
+  },
+  {
+    "name": "item #3",
+    "points": 166,
+    "image": "items/1-14/hide-armor.png",
+    "xws": "hidearmor"
+  },
+  {
+    "name": "item #03",
+    "points": 167,
+    "image": "items/1-14/hide-armor.png",
+    "xws": "hidearmor"
+  },
+  {
+    "name": "item #003",
+    "points": 168,
+    "image": "items/1-14/hide-armor.png",
+    "xws": "hidearmor"
+  },
+  {
+    "name": "item 4",
+    "points": 169,
+    "image": "items/1-14/leather-armor.png",
+    "xws": "leatherarmor"
+  },
+  {
+    "name": "item 04",
+    "points": 170,
+    "image": "items/1-14/leather-armor.png",
+    "xws": "leatherarmor"
+  },
+  {
+    "name": "item 004",
+    "points": 171,
+    "image": "items/1-14/leather-armor.png",
+    "xws": "leatherarmor"
+  },
+  {
+    "name": "item #4",
+    "points": 172,
+    "image": "items/1-14/leather-armor.png",
+    "xws": "leatherarmor"
+  },
+  {
+    "name": "item #04",
+    "points": 173,
+    "image": "items/1-14/leather-armor.png",
+    "xws": "leatherarmor"
+  },
+  {
+    "name": "item #004",
+    "points": 174,
+    "image": "items/1-14/leather-armor.png",
+    "xws": "leatherarmor"
+  },
+  {
+    "name": "item 5",
+    "points": 175,
+    "image": "items/1-14/cloak-of-invisibility.png",
+    "xws": "cloakofinvisibility"
+  },
+  {
+    "name": "item 05",
+    "points": 176,
+    "image": "items/1-14/cloak-of-invisibility.png",
+    "xws": "cloakofinvisibility"
+  },
+  {
+    "name": "item 005",
+    "points": 177,
+    "image": "items/1-14/cloak-of-invisibility.png",
+    "xws": "cloakofinvisibility"
+  },
+  {
+    "name": "item #5",
+    "points": 178,
+    "image": "items/1-14/cloak-of-invisibility.png",
+    "xws": "cloakofinvisibility"
+  },
+  {
+    "name": "item #05",
+    "points": 179,
+    "image": "items/1-14/cloak-of-invisibility.png",
+    "xws": "cloakofinvisibility"
+  },
+  {
+    "name": "item #005",
+    "points": 180,
+    "image": "items/1-14/cloak-of-invisibility.png",
+    "xws": "cloakofinvisibility"
+  },
+  {
+    "name": "eagle eye goggles",
+    "points": 181,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "item 6",
+    "points": 182,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "item 06",
+    "points": 183,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "item 006",
+    "points": 184,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "item #6",
+    "points": 185,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "item #06",
+    "points": 186,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "item #006",
+    "points": 187,
+    "image": "items/1-14/eagle-eye-goggles.png",
+    "xws": "eagleeyegoggles"
+  },
+  {
+    "name": "item 7",
+    "points": 188,
+    "image": "items/1-14/iron-helmet.png",
+    "xws": "ironhelmet"
+  },
+  {
+    "name": "item 07",
+    "points": 189,
+    "image": "items/1-14/iron-helmet.png",
+    "xws": "ironhelmet"
+  },
+  {
+    "name": "item 007",
+    "points": 190,
+    "image": "items/1-14/iron-helmet.png",
+    "xws": "ironhelmet"
+  },
+  {
+    "name": "item #7",
+    "points": 191,
+    "image": "items/1-14/iron-helmet.png",
+    "xws": "ironhelmet"
+  },
+  {
+    "name": "item #07",
+    "points": 192,
+    "image": "items/1-14/iron-helmet.png",
+    "xws": "ironhelmet"
+  },
+  {
+    "name": "item #007",
+    "points": 193,
+    "image": "items/1-14/iron-helmet.png",
+    "xws": "ironhelmet"
+  },
+  {
+    "name": "item 8",
+    "points": 194,
+    "image": "items/1-14/heater-shield.png",
+    "xws": "heatershield"
+  },
+  {
+    "name": "item 08",
+    "points": 195,
+    "image": "items/1-14/heater-shield.png",
+    "xws": "heatershield"
+  },
+  {
+    "name": "item 008",
+    "points": 196,
+    "image": "items/1-14/heater-shield.png",
+    "xws": "heatershield"
+  },
+  {
+    "name": "item #8",
+    "points": 197,
+    "image": "items/1-14/heater-shield.png",
+    "xws": "heatershield"
+  },
+  {
+    "name": "item #08",
+    "points": 198,
+    "image": "items/1-14/heater-shield.png",
+    "xws": "heatershield"
+  },
+  {
+    "name": "item #008",
+    "points": 199,
+    "image": "items/1-14/heater-shield.png",
+    "xws": "heatershield"
+  },
+  {
+    "name": "item 9",
+    "points": 200,
+    "image": "items/1-14/piercing-bow.png",
+    "xws": "piercingbow"
+  },
+  {
+    "name": "item 09",
+    "points": 201,
+    "image": "items/1-14/piercing-bow.png",
+    "xws": "piercingbow"
+  },
+  {
+    "name": "item 009",
+    "points": 202,
+    "image": "items/1-14/piercing-bow.png",
+    "xws": "piercingbow"
+  },
+  {
+    "name": "item #9",
+    "points": 203,
+    "image": "items/1-14/piercing-bow.png",
+    "xws": "piercingbow"
+  },
+  {
+    "name": "item #09",
+    "points": 204,
+    "image": "items/1-14/piercing-bow.png",
+    "xws": "piercingbow"
+  },
+  {
+    "name": "item #009",
+    "points": 205,
+    "image": "items/1-14/piercing-bow.png",
+    "xws": "piercingbow"
+  },
+  {
+    "name": "item 10",
+    "points": 206,
+    "image": "items/1-14/war-hammer.png",
+    "xws": "warhammer"
+  },
+  {
+    "name": "item 010",
+    "points": 207,
+    "image": "items/1-14/war-hammer.png",
+    "xws": "warhammer"
+  },
+  {
+    "name": "item #10",
+    "points": 208,
+    "image": "items/1-14/war-hammer.png",
+    "xws": "warhammer"
+  },
+  {
+    "name": "item #010",
+    "points": 209,
+    "image": "items/1-14/war-hammer.png",
+    "xws": "warhammer"
+  },
+  {
+    "name": "item 11",
+    "points": 210,
+    "image": "items/1-14/poison-dagger.png",
+    "xws": "poisondagger"
+  },
+  {
+    "name": "item 011",
+    "points": 211,
+    "image": "items/1-14/poison-dagger.png",
+    "xws": "poisondagger"
+  },
+  {
+    "name": "item #11",
+    "points": 212,
+    "image": "items/1-14/poison-dagger.png",
+    "xws": "poisondagger"
+  },
+  {
+    "name": "item #011",
+    "points": 213,
+    "image": "items/1-14/poison-dagger.png",
+    "xws": "poisondagger"
+  },
+  {
+    "name": "item 12",
+    "points": 214,
+    "image": "items/1-14/minor-healing-potion.png",
+    "xws": "minorhealingpotion"
+  },
+  {
+    "name": "item 012",
+    "points": 215,
+    "image": "items/1-14/minor-healing-potion.png",
+    "xws": "minorhealingpotion"
+  },
+  {
+    "name": "item #12",
+    "points": 216,
+    "image": "items/1-14/minor-healing-potion.png",
+    "xws": "minorhealingpotion"
+  },
+  {
+    "name": "item #012",
+    "points": 217,
+    "image": "items/1-14/minor-healing-potion.png",
+    "xws": "minorhealingpotion"
+  },
+  {
+    "name": "item 13",
+    "points": 218,
+    "image": "items/1-14/minor-stamina-potion.png",
+    "xws": "minorstaminapotion"
+  },
+  {
+    "name": "item 013",
+    "points": 219,
+    "image": "items/1-14/minor-stamina-potion.png",
+    "xws": "minorstaminapotion"
+  },
+  {
+    "name": "item #13",
+    "points": 220,
+    "image": "items/1-14/minor-stamina-potion.png",
+    "xws": "minorstaminapotion"
+  },
+  {
+    "name": "item #013",
+    "points": 221,
+    "image": "items/1-14/minor-stamina-potion.png",
+    "xws": "minorstaminapotion"
+  },
+  {
+    "name": "item 14",
+    "points": 222,
+    "image": "items/1-14/minor-power-potion.png",
+    "xws": "minorpowerpotion"
+  },
+  {
+    "name": "item 014",
+    "points": 223,
+    "image": "items/1-14/minor-power-potion.png",
+    "xws": "minorpowerpotion"
+  },
+  {
+    "name": "item #14",
+    "points": 224,
+    "image": "items/1-14/minor-power-potion.png",
+    "xws": "minorpowerpotion"
+  },
+  {
+    "name": "item #014",
+    "points": 225,
+    "image": "items/1-14/minor-power-potion.png",
+    "xws": "minorpowerpotion"
+  },
+  {
+    "name": "item 15",
+    "points": 226,
+    "image": "items/15-21/boots-of-speed.png",
+    "xws": "bootsofspeed"
+  },
+  {
+    "name": "item 015",
+    "points": 227,
+    "image": "items/15-21/boots-of-speed.png",
+    "xws": "bootsofspeed"
+  },
+  {
+    "name": "item #15",
+    "points": 228,
+    "image": "items/15-21/boots-of-speed.png",
+    "xws": "bootsofspeed"
+  },
+  {
+    "name": "item #015",
+    "points": 229,
+    "image": "items/15-21/boots-of-speed.png",
+    "xws": "bootsofspeed"
+  },
+  {
+    "name": "item 16",
+    "points": 230,
+    "image": "items/15-21/cloak-of-pockets.png",
+    "xws": "cloakofpockets"
+  },
+  {
+    "name": "item 016",
+    "points": 231,
+    "image": "items/15-21/cloak-of-pockets.png",
+    "xws": "cloakofpockets"
+  },
+  {
+    "name": "item #16",
+    "points": 232,
+    "image": "items/15-21/cloak-of-pockets.png",
+    "xws": "cloakofpockets"
+  },
+  {
+    "name": "item #016",
+    "points": 233,
+    "image": "items/15-21/cloak-of-pockets.png",
+    "xws": "cloakofpockets"
+  },
+  {
+    "name": "item 17",
+    "points": 234,
+    "image": "items/15-21/empowering-talisman.png",
+    "xws": "empoweringtalisman"
+  },
+  {
+    "name": "item 017",
+    "points": 235,
+    "image": "items/15-21/empowering-talisman.png",
+    "xws": "empoweringtalisman"
+  },
+  {
+    "name": "item #17",
+    "points": 236,
+    "image": "items/15-21/empowering-talisman.png",
+    "xws": "empoweringtalisman"
+  },
+  {
+    "name": "item #017",
+    "points": 237,
+    "image": "items/15-21/empowering-talisman.png",
+    "xws": "empoweringtalisman"
+  },
+  {
+    "name": "battle axe",
+    "points": 238,
+    "image": "items/15-21/battle-axe.png",
+    "xws": "battleaxe"
+  },
+  {
+    "name": "item 18",
+    "points": 239,
+    "image": "items/15-21/battle-axe.png",
+    "xws": "battleaxe"
+  },
+  {
+    "name": "item 018",
+    "points": 240,
+    "image": "items/15-21/battle-axe.png",
+    "xws": "battleaxe"
+  },
+  {
+    "name": "item #18",
+    "points": 241,
+    "image": "items/15-21/battle-axe.png",
+    "xws": "battleaxe"
+  },
+  {
+    "name": "item #018",
+    "points": 242,
+    "image": "items/15-21/battle-axe.png",
+    "xws": "battleaxe"
+  },
+  {
+    "name": "item 19",
+    "points": 243,
+    "image": "items/15-21/weighted-net.png",
+    "xws": "weightednet"
+  },
+  {
+    "name": "item 019",
+    "points": 244,
+    "image": "items/15-21/weighted-net.png",
+    "xws": "weightednet"
+  },
+  {
+    "name": "item #19",
+    "points": 245,
+    "image": "items/15-21/weighted-net.png",
+    "xws": "weightednet"
+  },
+  {
+    "name": "item #019",
+    "points": 246,
+    "image": "items/15-21/weighted-net.png",
+    "xws": "weightednet"
+  },
+  {
+    "name": "item 20",
+    "points": 247,
+    "image": "items/15-21/minor-mana-potion.png",
+    "xws": "minormanapotion"
+  },
+  {
+    "name": "item 020",
+    "points": 248,
+    "image": "items/15-21/minor-mana-potion.png",
+    "xws": "minormanapotion"
+  },
+  {
+    "name": "item #20",
+    "points": 249,
+    "image": "items/15-21/minor-mana-potion.png",
+    "xws": "minormanapotion"
+  },
+  {
+    "name": "item #020",
+    "points": 250,
+    "image": "items/15-21/minor-mana-potion.png",
+    "xws": "minormanapotion"
+  },
+  {
+    "name": "item 21",
+    "points": 251,
+    "image": "items/15-21/stun-powder.png",
+    "xws": "stunpowder"
+  },
+  {
+    "name": "item 021",
+    "points": 252,
+    "image": "items/15-21/stun-powder.png",
+    "xws": "stunpowder"
+  },
+  {
+    "name": "item #21",
+    "points": 253,
+    "image": "items/15-21/stun-powder.png",
+    "xws": "stunpowder"
+  },
+  {
+    "name": "item #021",
+    "points": 254,
+    "image": "items/15-21/stun-powder.png",
+    "xws": "stunpowder"
+  },
+  {
+    "name": "item 22",
+    "points": 255,
+    "image": "items/22-28/heavy-greaves.png",
+    "xws": "heavygreaves"
+  },
+  {
+    "name": "item 022",
+    "points": 256,
+    "image": "items/22-28/heavy-greaves.png",
+    "xws": "heavygreaves"
+  },
+  {
+    "name": "item #22",
+    "points": 257,
+    "image": "items/22-28/heavy-greaves.png",
+    "xws": "heavygreaves"
+  },
+  {
+    "name": "item #022",
+    "points": 258,
+    "image": "items/22-28/heavy-greaves.png",
+    "xws": "heavygreaves"
+  },
+  {
+    "name": "item 23",
+    "points": 259,
+    "image": "items/22-28/chainmail.png",
+    "xws": "chainmail"
+  },
+  {
+    "name": "item 023",
+    "points": 260,
+    "image": "items/22-28/chainmail.png",
+    "xws": "chainmail"
+  },
+  {
+    "name": "item #23",
+    "points": 261,
+    "image": "items/22-28/chainmail.png",
+    "xws": "chainmail"
+  },
+  {
+    "name": "item #023",
+    "points": 262,
+    "image": "items/22-28/chainmail.png",
+    "xws": "chainmail"
+  },
+  {
+    "name": "item 24",
+    "points": 263,
+    "image": "items/22-28/amulet-of-life.png",
+    "xws": "amuletoflife"
+  },
+  {
+    "name": "item 024",
+    "points": 264,
+    "image": "items/22-28/amulet-of-life.png",
+    "xws": "amuletoflife"
+  },
+  {
+    "name": "item #24",
+    "points": 265,
+    "image": "items/22-28/amulet-of-life.png",
+    "xws": "amuletoflife"
+  },
+  {
+    "name": "item #024",
+    "points": 266,
+    "image": "items/22-28/amulet-of-life.png",
+    "xws": "amuletoflife"
+  },
+  {
+    "name": "item 25",
+    "points": 267,
+    "image": "items/22-28/jagged-sword.png",
+    "xws": "jaggedsword"
+  },
+  {
+    "name": "item 025",
+    "points": 268,
+    "image": "items/22-28/jagged-sword.png",
+    "xws": "jaggedsword"
+  },
+  {
+    "name": "item #25",
+    "points": 269,
+    "image": "items/22-28/jagged-sword.png",
+    "xws": "jaggedsword"
+  },
+  {
+    "name": "item #025",
+    "points": 270,
+    "image": "items/22-28/jagged-sword.png",
+    "xws": "jaggedsword"
+  },
+  {
+    "name": "item 26",
+    "points": 271,
+    "image": "items/22-28/long-spear.png",
+    "xws": "longspear"
+  },
+  {
+    "name": "item 026",
+    "points": 272,
+    "image": "items/22-28/long-spear.png",
+    "xws": "longspear"
+  },
+  {
+    "name": "item #26",
+    "points": 273,
+    "image": "items/22-28/long-spear.png",
+    "xws": "longspear"
+  },
+  {
+    "name": "item #026",
+    "points": 274,
+    "image": "items/22-28/long-spear.png",
+    "xws": "longspear"
+  },
+  {
+    "name": "item 27",
+    "points": 275,
+    "image": "items/22-28/major-healing-potion.png",
+    "xws": "majorhealingpotion"
+  },
+  {
+    "name": "item 027",
+    "points": 276,
+    "image": "items/22-28/major-healing-potion.png",
+    "xws": "majorhealingpotion"
+  },
+  {
+    "name": "item #27",
+    "points": 277,
+    "image": "items/22-28/major-healing-potion.png",
+    "xws": "majorhealingpotion"
+  },
+  {
+    "name": "item #027",
+    "points": 278,
+    "image": "items/22-28/major-healing-potion.png",
+    "xws": "majorhealingpotion"
+  },
+  {
+    "name": "item 28",
+    "points": 279,
+    "image": "items/22-28/moon-earring.png",
+    "xws": "moonearring"
+  },
+  {
+    "name": "item 028",
+    "points": 280,
+    "image": "items/22-28/moon-earring.png",
+    "xws": "moonearring"
+  },
+  {
+    "name": "item #28",
+    "points": 281,
+    "image": "items/22-28/moon-earring.png",
+    "xws": "moonearring"
+  },
+  {
+    "name": "item #028",
+    "points": 282,
+    "image": "items/22-28/moon-earring.png",
+    "xws": "moonearring"
+  },
+  {
+    "name": "item 29",
+    "points": 283,
+    "image": "items/29-35/comfortable-shoes.png",
+    "xws": "comfortableshoes"
+  },
+  {
+    "name": "item 029",
+    "points": 284,
+    "image": "items/29-35/comfortable-shoes.png",
+    "xws": "comfortableshoes"
+  },
+  {
+    "name": "item #29",
+    "points": 285,
+    "image": "items/29-35/comfortable-shoes.png",
+    "xws": "comfortableshoes"
+  },
+  {
+    "name": "item #029",
+    "points": 286,
+    "image": "items/29-35/comfortable-shoes.png",
+    "xws": "comfortableshoes"
+  },
+  {
+    "name": "item 30",
+    "points": 287,
+    "image": "items/29-35/studded-leather.png",
+    "xws": "studdedleather"
+  },
+  {
+    "name": "item 030",
+    "points": 288,
+    "image": "items/29-35/studded-leather.png",
+    "xws": "studdedleather"
+  },
+  {
+    "name": "item #30",
+    "points": 289,
+    "image": "items/29-35/studded-leather.png",
+    "xws": "studdedleather"
+  },
+  {
+    "name": "item #030",
+    "points": 290,
+    "image": "items/29-35/studded-leather.png",
+    "xws": "studdedleather"
+  },
+  {
+    "name": "item 31",
+    "points": 291,
+    "image": "items/29-35/hawk-helm.png",
+    "xws": "hawkhelm"
+  },
+  {
+    "name": "item 031",
+    "points": 292,
+    "image": "items/29-35/hawk-helm.png",
+    "xws": "hawkhelm"
+  },
+  {
+    "name": "item #31",
+    "points": 293,
+    "image": "items/29-35/hawk-helm.png",
+    "xws": "hawkhelm"
+  },
+  {
+    "name": "item #031",
+    "points": 294,
+    "image": "items/29-35/hawk-helm.png",
+    "xws": "hawkhelm"
+  },
+  {
+    "name": "item 32",
+    "points": 295,
+    "image": "items/29-35/tower-shield.png",
+    "xws": "towershield"
+  },
+  {
+    "name": "item 032",
+    "points": 296,
+    "image": "items/29-35/tower-shield.png",
+    "xws": "towershield"
+  },
+  {
+    "name": "item #32",
+    "points": 297,
+    "image": "items/29-35/tower-shield.png",
+    "xws": "towershield"
+  },
+  {
+    "name": "item #032",
+    "points": 298,
+    "image": "items/29-35/tower-shield.png",
+    "xws": "towershield"
+  },
+  {
+    "name": "item 33",
+    "points": 299,
+    "image": "items/29-35/volatile-bomb.png",
+    "xws": "volatilebomb"
+  },
+  {
+    "name": "item 033",
+    "points": 300,
+    "image": "items/29-35/volatile-bomb.png",
+    "xws": "volatilebomb"
+  },
+  {
+    "name": "item #33",
+    "points": 301,
+    "image": "items/29-35/volatile-bomb.png",
+    "xws": "volatilebomb"
+  },
+  {
+    "name": "item #033",
+    "points": 302,
+    "image": "items/29-35/volatile-bomb.png",
+    "xws": "volatilebomb"
+  },
+  {
+    "name": "item 34",
+    "points": 303,
+    "image": "items/29-35/major-stamina-potion.png",
+    "xws": "majorstaminapotion"
+  },
+  {
+    "name": "item 034",
+    "points": 304,
+    "image": "items/29-35/major-stamina-potion.png",
+    "xws": "majorstaminapotion"
+  },
+  {
+    "name": "item #34",
+    "points": 305,
+    "image": "items/29-35/major-stamina-potion.png",
+    "xws": "majorstaminapotion"
+  },
+  {
+    "name": "item #034",
+    "points": 306,
+    "image": "items/29-35/major-stamina-potion.png",
+    "xws": "majorstaminapotion"
+  },
+  {
+    "name": "item 35",
+    "points": 307,
+    "image": "items/29-35/falcon-figurine.png",
+    "xws": "falconfigurine"
+  },
+  {
+    "name": "item 035",
+    "points": 308,
+    "image": "items/29-35/falcon-figurine.png",
+    "xws": "falconfigurine"
+  },
+  {
+    "name": "item #35",
+    "points": 309,
+    "image": "items/29-35/falcon-figurine.png",
+    "xws": "falconfigurine"
+  },
+  {
+    "name": "item #035",
+    "points": 310,
+    "image": "items/29-35/falcon-figurine.png",
+    "xws": "falconfigurine"
+  },
+  {
+    "name": "item 36",
+    "points": 311,
+    "image": "items/36-42/boots-of-dashing.png",
+    "xws": "bootsofdashing"
+  },
+  {
+    "name": "item 036",
+    "points": 312,
+    "image": "items/36-42/boots-of-dashing.png",
+    "xws": "bootsofdashing"
+  },
+  {
+    "name": "item #36",
+    "points": 313,
+    "image": "items/36-42/boots-of-dashing.png",
+    "xws": "bootsofdashing"
+  },
+  {
+    "name": "item #036",
+    "points": 314,
+    "image": "items/36-42/boots-of-dashing.png",
+    "xws": "bootsofdashing"
+  },
+  {
+    "name": "item 37",
+    "points": 315,
+    "image": "items/36-42/robes-of-evocation.png",
+    "xws": "robesofevocation"
+  },
+  {
+    "name": "item 037",
+    "points": 316,
+    "image": "items/36-42/robes-of-evocation.png",
+    "xws": "robesofevocation"
+  },
+  {
+    "name": "item #37",
+    "points": 317,
+    "image": "items/36-42/robes-of-evocation.png",
+    "xws": "robesofevocation"
+  },
+  {
+    "name": "item #037",
+    "points": 318,
+    "image": "items/36-42/robes-of-evocation.png",
+    "xws": "robesofevocation"
+  },
+  {
+    "name": "item 38",
+    "points": 319,
+    "image": "items/36-42/heavy-basinet.png",
+    "xws": "heavybasinet"
+  },
+  {
+    "name": "item 038",
+    "points": 320,
+    "image": "items/36-42/heavy-basinet.png",
+    "xws": "heavybasinet"
+  },
+  {
+    "name": "item #38",
+    "points": 321,
+    "image": "items/36-42/heavy-basinet.png",
+    "xws": "heavybasinet"
+  },
+  {
+    "name": "item #038",
+    "points": 322,
+    "image": "items/36-42/heavy-basinet.png",
+    "xws": "heavybasinet"
+  },
+  {
+    "name": "item 39",
+    "points": 323,
+    "image": "items/36-42/hooked-chain.png",
+    "xws": "hookedchain"
+  },
+  {
+    "name": "item 039",
+    "points": 324,
+    "image": "items/36-42/hooked-chain.png",
+    "xws": "hookedchain"
+  },
+  {
+    "name": "item #39",
+    "points": 325,
+    "image": "items/36-42/hooked-chain.png",
+    "xws": "hookedchain"
+  },
+  {
+    "name": "item #039",
+    "points": 326,
+    "image": "items/36-42/hooked-chain.png",
+    "xws": "hookedchain"
+  },
+  {
+    "name": "item 40",
+    "points": 327,
+    "image": "items/36-42/versatile-dagger.png",
+    "xws": "versatiledagger"
+  },
+  {
+    "name": "item 040",
+    "points": 328,
+    "image": "items/36-42/versatile-dagger.png",
+    "xws": "versatiledagger"
+  },
+  {
+    "name": "item #40",
+    "points": 329,
+    "image": "items/36-42/versatile-dagger.png",
+    "xws": "versatiledagger"
+  },
+  {
+    "name": "item #040",
+    "points": 330,
+    "image": "items/36-42/versatile-dagger.png",
+    "xws": "versatiledagger"
+  },
+  {
+    "name": "item 41",
+    "points": 331,
+    "image": "items/36-42/major-power-potion.png",
+    "xws": "majorpowerpotion"
+  },
+  {
+    "name": "item 041",
+    "points": 332,
+    "image": "items/36-42/major-power-potion.png",
+    "xws": "majorpowerpotion"
+  },
+  {
+    "name": "item #41",
+    "points": 333,
+    "image": "items/36-42/major-power-potion.png",
+    "xws": "majorpowerpotion"
+  },
+  {
+    "name": "item #041",
+    "points": 334,
+    "image": "items/36-42/major-power-potion.png",
+    "xws": "majorpowerpotion"
+  },
+  {
+    "name": "item 42",
+    "points": 335,
+    "image": "items/36-42/ring-of-haste.png",
+    "xws": "ringofhaste"
+  },
+  {
+    "name": "item 042",
+    "points": 336,
+    "image": "items/36-42/ring-of-haste.png",
+    "xws": "ringofhaste"
+  },
+  {
+    "name": "item #42",
+    "points": 337,
+    "image": "items/36-42/ring-of-haste.png",
+    "xws": "ringofhaste"
+  },
+  {
+    "name": "item #042",
+    "points": 338,
+    "image": "items/36-42/ring-of-haste.png",
+    "xws": "ringofhaste"
+  },
+  {
+    "name": "item 43",
+    "points": 339,
+    "image": "items/43-49/boots-of-quickness.png",
+    "xws": "bootsofquickness"
+  },
+  {
+    "name": "item 043",
+    "points": 340,
+    "image": "items/43-49/boots-of-quickness.png",
+    "xws": "bootsofquickness"
+  },
+  {
+    "name": "item #43",
+    "points": 341,
+    "image": "items/43-49/boots-of-quickness.png",
+    "xws": "bootsofquickness"
+  },
+  {
+    "name": "item #043",
+    "points": 342,
+    "image": "items/43-49/boots-of-quickness.png",
+    "xws": "bootsofquickness"
+  },
+  {
+    "name": "item 44",
+    "points": 343,
+    "image": "items/43-49/splintmail.png",
+    "xws": "splintmail"
+  },
+  {
+    "name": "item 044",
+    "points": 344,
+    "image": "items/43-49/splintmail.png",
+    "xws": "splintmail"
+  },
+  {
+    "name": "item #44",
+    "points": 345,
+    "image": "items/43-49/splintmail.png",
+    "xws": "splintmail"
+  },
+  {
+    "name": "item #044",
+    "points": 346,
+    "image": "items/43-49/splintmail.png",
+    "xws": "splintmail"
+  },
+  {
+    "name": "item 45",
+    "points": 347,
+    "image": "items/43-49/pendant-of-dark-pacts.png",
+    "xws": "pendantofdarkpacts"
+  },
+  {
+    "name": "item 045",
+    "points": 348,
+    "image": "items/43-49/pendant-of-dark-pacts.png",
+    "xws": "pendantofdarkpacts"
+  },
+  {
+    "name": "item #45",
+    "points": 349,
+    "image": "items/43-49/pendant-of-dark-pacts.png",
+    "xws": "pendantofdarkpacts"
+  },
+  {
+    "name": "item #045",
+    "points": 350,
+    "image": "items/43-49/pendant-of-dark-pacts.png",
+    "xws": "pendantofdarkpacts"
+  },
+  {
+    "name": "item 46",
+    "points": 351,
+    "image": "items/43-49/spiked-shield.png",
+    "xws": "spikedshield"
+  },
+  {
+    "name": "item 046",
+    "points": 352,
+    "image": "items/43-49/spiked-shield.png",
+    "xws": "spikedshield"
+  },
+  {
+    "name": "item #46",
+    "points": 353,
+    "image": "items/43-49/spiked-shield.png",
+    "xws": "spikedshield"
+  },
+  {
+    "name": "item #046",
+    "points": 354,
+    "image": "items/43-49/spiked-shield.png",
+    "xws": "spikedshield"
+  },
+  {
+    "name": "item 47",
+    "points": 355,
+    "image": "items/43-49/reaping-scythe.png",
+    "xws": "reapingscythe"
+  },
+  {
+    "name": "item 047",
+    "points": 356,
+    "image": "items/43-49/reaping-scythe.png",
+    "xws": "reapingscythe"
+  },
+  {
+    "name": "item #47",
+    "points": 357,
+    "image": "items/43-49/reaping-scythe.png",
+    "xws": "reapingscythe"
+  },
+  {
+    "name": "item #047",
+    "points": 358,
+    "image": "items/43-49/reaping-scythe.png",
+    "xws": "reapingscythe"
+  },
+  {
+    "name": "item 48",
+    "points": 359,
+    "image": "items/43-49/major-mana-potion.png",
+    "xws": "majormanapotion"
+  },
+  {
+    "name": "item 048",
+    "points": 360,
+    "image": "items/43-49/major-mana-potion.png",
+    "xws": "majormanapotion"
+  },
+  {
+    "name": "item #48",
+    "points": 361,
+    "image": "items/43-49/major-mana-potion.png",
+    "xws": "majormanapotion"
+  },
+  {
+    "name": "item #048",
+    "points": 362,
+    "image": "items/43-49/major-mana-potion.png",
+    "xws": "majormanapotion"
+  },
+  {
+    "name": "item 49",
+    "points": 363,
+    "image": "items/43-49/sun-earring.png",
+    "xws": "sunearring"
+  },
+  {
+    "name": "item 049",
+    "points": 364,
+    "image": "items/43-49/sun-earring.png",
+    "xws": "sunearring"
+  },
+  {
+    "name": "item #49",
+    "points": 365,
+    "image": "items/43-49/sun-earring.png",
+    "xws": "sunearring"
+  },
+  {
+    "name": "item #049",
+    "points": 366,
+    "image": "items/43-49/sun-earring.png",
+    "xws": "sunearring"
+  },
+  {
+    "name": "item 50",
+    "points": 367,
+    "image": "items/50-56/steel-sabatons.png",
+    "xws": "steelsabatons"
+  },
+  {
+    "name": "item 050",
+    "points": 368,
+    "image": "items/50-56/steel-sabatons.png",
+    "xws": "steelsabatons"
+  },
+  {
+    "name": "item #50",
+    "points": 369,
+    "image": "items/50-56/steel-sabatons.png",
+    "xws": "steelsabatons"
+  },
+  {
+    "name": "item #050",
+    "points": 370,
+    "image": "items/50-56/steel-sabatons.png",
+    "xws": "steelsabatons"
+  },
+  {
+    "name": "item 51",
+    "points": 371,
+    "image": "items/50-56/shadow-armor.png",
+    "xws": "shadowarmor"
+  },
+  {
+    "name": "item 051",
+    "points": 372,
+    "image": "items/50-56/shadow-armor.png",
+    "xws": "shadowarmor"
+  },
+  {
+    "name": "item #51",
+    "points": 373,
+    "image": "items/50-56/shadow-armor.png",
+    "xws": "shadowarmor"
+  },
+  {
+    "name": "item #051",
+    "points": 374,
+    "image": "items/50-56/shadow-armor.png",
+    "xws": "shadowarmor"
+  },
+  {
+    "name": "item 52",
+    "points": 375,
+    "image": "items/50-56/protective-charm.png",
+    "xws": "protectivecharm"
+  },
+  {
+    "name": "item 052",
+    "points": 376,
+    "image": "items/50-56/protective-charm.png",
+    "xws": "protectivecharm"
+  },
+  {
+    "name": "item #52",
+    "points": 377,
+    "image": "items/50-56/protective-charm.png",
+    "xws": "protectivecharm"
+  },
+  {
+    "name": "item #052",
+    "points": 378,
+    "image": "items/50-56/protective-charm.png",
+    "xws": "protectivecharm"
+  },
+  {
+    "name": "item 53",
+    "points": 379,
+    "image": "items/50-56/black-knife.png",
+    "xws": "blackknife"
+  },
+  {
+    "name": "item 053",
+    "points": 380,
+    "image": "items/50-56/black-knife.png",
+    "xws": "blackknife"
+  },
+  {
+    "name": "item #53",
+    "points": 381,
+    "image": "items/50-56/black-knife.png",
+    "xws": "blackknife"
+  },
+  {
+    "name": "item #053",
+    "points": 382,
+    "image": "items/50-56/black-knife.png",
+    "xws": "blackknife"
+  },
+  {
+    "name": "item 54",
+    "points": 383,
+    "image": "items/50-56/staff-of-eminence.png",
+    "xws": "staffofeminence"
+  },
+  {
+    "name": "item 054",
+    "points": 384,
+    "image": "items/50-56/staff-of-eminence.png",
+    "xws": "staffofeminence"
+  },
+  {
+    "name": "item #54",
+    "points": 385,
+    "image": "items/50-56/staff-of-eminence.png",
+    "xws": "staffofeminence"
+  },
+  {
+    "name": "item #054",
+    "points": 386,
+    "image": "items/50-56/staff-of-eminence.png",
+    "xws": "staffofeminence"
+  },
+  {
+    "name": "item 55",
+    "points": 387,
+    "image": "items/50-56/super-healing-potion.png",
+    "xws": "superhealingpotion"
+  },
+  {
+    "name": "item 055",
+    "points": 388,
+    "image": "items/50-56/super-healing-potion.png",
+    "xws": "superhealingpotion"
+  },
+  {
+    "name": "item #55",
+    "points": 389,
+    "image": "items/50-56/super-healing-potion.png",
+    "xws": "superhealingpotion"
+  },
+  {
+    "name": "item #055",
+    "points": 390,
+    "image": "items/50-56/super-healing-potion.png",
+    "xws": "superhealingpotion"
+  },
+  {
+    "name": "item 56",
+    "points": 391,
+    "image": "items/50-56/ring-of-brutality.png",
+    "xws": "ringofbrutality"
+  },
+  {
+    "name": "item 056",
+    "points": 392,
+    "image": "items/50-56/ring-of-brutality.png",
+    "xws": "ringofbrutality"
+  },
+  {
+    "name": "item #56",
+    "points": 393,
+    "image": "items/50-56/ring-of-brutality.png",
+    "xws": "ringofbrutality"
+  },
+  {
+    "name": "item #056",
+    "points": 394,
+    "image": "items/50-56/ring-of-brutality.png",
+    "xws": "ringofbrutality"
+  },
+  {
+    "name": "item 57",
+    "points": 395,
+    "image": "items/57-63/serene-sandals.png",
+    "xws": "serenesandals"
+  },
+  {
+    "name": "item 057",
+    "points": 396,
+    "image": "items/57-63/serene-sandals.png",
+    "xws": "serenesandals"
+  },
+  {
+    "name": "item #57",
+    "points": 397,
+    "image": "items/57-63/serene-sandals.png",
+    "xws": "serenesandals"
+  },
+  {
+    "name": "item #057",
+    "points": 398,
+    "image": "items/57-63/serene-sandals.png",
+    "xws": "serenesandals"
+  },
+  {
+    "name": "item 58",
+    "points": 399,
+    "image": "items/57-63/cloak-of-phasing.png",
+    "xws": "cloakofphasing"
+  },
+  {
+    "name": "item 058",
+    "points": 400,
+    "image": "items/57-63/cloak-of-phasing.png",
+    "xws": "cloakofphasing"
+  },
+  {
+    "name": "item #58",
+    "points": 401,
+    "image": "items/57-63/cloak-of-phasing.png",
+    "xws": "cloakofphasing"
+  },
+  {
+    "name": "item #058",
+    "points": 402,
+    "image": "items/57-63/cloak-of-phasing.png",
+    "xws": "cloakofphasing"
+  },
+  {
+    "name": "item 59",
+    "points": 403,
+    "image": "items/57-63/telescopic-lens.png",
+    "xws": "telescopiclens"
+  },
+  {
+    "name": "item 059",
+    "points": 404,
+    "image": "items/57-63/telescopic-lens.png",
+    "xws": "telescopiclens"
+  },
+  {
+    "name": "item #59",
+    "points": 405,
+    "image": "items/57-63/telescopic-lens.png",
+    "xws": "telescopiclens"
+  },
+  {
+    "name": "item #059",
+    "points": 406,
+    "image": "items/57-63/telescopic-lens.png",
+    "xws": "telescopiclens"
+  },
+  {
+    "name": "item 60",
+    "points": 407,
+    "image": "items/57-63/unstable-explosives.png",
+    "xws": "unstableexplosives"
+  },
+  {
+    "name": "item 060",
+    "points": 408,
+    "image": "items/57-63/unstable-explosives.png",
+    "xws": "unstableexplosives"
+  },
+  {
+    "name": "item #60",
+    "points": 409,
+    "image": "items/57-63/unstable-explosives.png",
+    "xws": "unstableexplosives"
+  },
+  {
+    "name": "item #060",
+    "points": 410,
+    "image": "items/57-63/unstable-explosives.png",
+    "xws": "unstableexplosives"
+  },
+  {
+    "name": "item 61",
+    "points": 411,
+    "image": "items/57-63/wall-shield.png",
+    "xws": "wallshield"
+  },
+  {
+    "name": "item 061",
+    "points": 412,
+    "image": "items/57-63/wall-shield.png",
+    "xws": "wallshield"
+  },
+  {
+    "name": "item #61",
+    "points": 413,
+    "image": "items/57-63/wall-shield.png",
+    "xws": "wallshield"
+  },
+  {
+    "name": "item #061",
+    "points": 414,
+    "image": "items/57-63/wall-shield.png",
+    "xws": "wallshield"
+  },
+  {
+    "name": "item 62",
+    "points": 415,
+    "image": "items/57-63/doom-powder.png",
+    "xws": "doompowder"
+  },
+  {
+    "name": "item 062",
+    "points": 416,
+    "image": "items/57-63/doom-powder.png",
+    "xws": "doompowder"
+  },
+  {
+    "name": "item #62",
+    "points": 417,
+    "image": "items/57-63/doom-powder.png",
+    "xws": "doompowder"
+  },
+  {
+    "name": "item #062",
+    "points": 418,
+    "image": "items/57-63/doom-powder.png",
+    "xws": "doompowder"
+  },
+  {
+    "name": "item 63",
+    "points": 419,
+    "image": "items/57-63/lucky-eye.png",
+    "xws": "luckyeye"
+  },
+  {
+    "name": "item 063",
+    "points": 420,
+    "image": "items/57-63/lucky-eye.png",
+    "xws": "luckyeye"
+  },
+  {
+    "name": "item #63",
+    "points": 421,
+    "image": "items/57-63/lucky-eye.png",
+    "xws": "luckyeye"
+  },
+  {
+    "name": "item #063",
+    "points": 422,
+    "image": "items/57-63/lucky-eye.png",
+    "xws": "luckyeye"
+  },
+  {
+    "name": "item 64",
+    "points": 423,
+    "image": "items/64-151/boots-of-sprinting.png",
+    "xws": "bootsofsprinting"
+  },
+  {
+    "name": "item 064",
+    "points": 424,
+    "image": "items/64-151/boots-of-sprinting.png",
+    "xws": "bootsofsprinting"
+  },
+  {
+    "name": "item #64",
+    "points": 425,
+    "image": "items/64-151/boots-of-sprinting.png",
+    "xws": "bootsofsprinting"
+  },
+  {
+    "name": "item #064",
+    "points": 426,
+    "image": "items/64-151/boots-of-sprinting.png",
+    "xws": "bootsofsprinting"
+  },
+  {
+    "name": "item 65",
+    "points": 427,
+    "image": "items/64-151/platemail.png",
+    "xws": "platemail"
+  },
+  {
+    "name": "item 065",
+    "points": 428,
+    "image": "items/64-151/platemail.png",
+    "xws": "platemail"
+  },
+  {
+    "name": "item #65",
+    "points": 429,
+    "image": "items/64-151/platemail.png",
+    "xws": "platemail"
+  },
+  {
+    "name": "item #065",
+    "points": 430,
+    "image": "items/64-151/platemail.png",
+    "xws": "platemail"
+  },
+  {
+    "name": "item 66",
+    "points": 431,
+    "image": "items/64-151/mask-of-terror.png",
+    "xws": "maskofterror"
+  },
+  {
+    "name": "item 066",
+    "points": 432,
+    "image": "items/64-151/mask-of-terror.png",
+    "xws": "maskofterror"
+  },
+  {
+    "name": "item #66",
+    "points": 433,
+    "image": "items/64-151/mask-of-terror.png",
+    "xws": "maskofterror"
+  },
+  {
+    "name": "item #066",
+    "points": 434,
+    "image": "items/64-151/mask-of-terror.png",
+    "xws": "maskofterror"
+  },
+  {
+    "name": "item 67",
+    "points": 435,
+    "image": "items/64-151/balanced-blade.png",
+    "xws": "balancedblade"
+  },
+  {
+    "name": "item 067",
+    "points": 436,
+    "image": "items/64-151/balanced-blade.png",
+    "xws": "balancedblade"
+  },
+  {
+    "name": "item #67",
+    "points": 437,
+    "image": "items/64-151/balanced-blade.png",
+    "xws": "balancedblade"
+  },
+  {
+    "name": "item #067",
+    "points": 438,
+    "image": "items/64-151/balanced-blade.png",
+    "xws": "balancedblade"
+  },
+  {
+    "name": "item 68",
+    "points": 439,
+    "image": "items/64-151/halberd.png",
+    "xws": "halberd"
+  },
+  {
+    "name": "item 068",
+    "points": 440,
+    "image": "items/64-151/halberd.png",
+    "xws": "halberd"
+  },
+  {
+    "name": "item #68",
+    "points": 441,
+    "image": "items/64-151/halberd.png",
+    "xws": "halberd"
+  },
+  {
+    "name": "item #068",
+    "points": 442,
+    "image": "items/64-151/halberd.png",
+    "xws": "halberd"
+  },
+  {
+    "name": "item 69",
+    "points": 443,
+    "image": "items/64-151/star-earring.png",
+    "xws": "starearring"
+  },
+  {
+    "name": "item 069",
+    "points": 444,
+    "image": "items/64-151/star-earring.png",
+    "xws": "starearring"
+  },
+  {
+    "name": "item #69",
+    "points": 445,
+    "image": "items/64-151/star-earring.png",
+    "xws": "starearring"
+  },
+  {
+    "name": "item #069",
+    "points": 446,
+    "image": "items/64-151/star-earring.png",
+    "xws": "starearring"
+  },
+  {
+    "name": "item 70",
+    "points": 447,
+    "image": "items/64-151/second-chance-ring.png",
+    "xws": "secondchancering"
+  },
+  {
+    "name": "item 070",
+    "points": 448,
+    "image": "items/64-151/second-chance-ring.png",
+    "xws": "secondchancering"
+  },
+  {
+    "name": "item #70",
+    "points": 449,
+    "image": "items/64-151/second-chance-ring.png",
+    "xws": "secondchancering"
+  },
+  {
+    "name": "item #070",
+    "points": 450,
+    "image": "items/64-151/second-chance-ring.png",
+    "xws": "secondchancering"
+  },
+  {
+    "name": "item 71",
+    "points": 451,
+    "image": "items/64-151/boots-of-levitation.png",
+    "xws": "bootsoflevitation"
+  },
+  {
+    "name": "item 071",
+    "points": 452,
+    "image": "items/64-151/boots-of-levitation.png",
+    "xws": "bootsoflevitation"
+  },
+  {
+    "name": "item #71",
+    "points": 453,
+    "image": "items/64-151/boots-of-levitation.png",
+    "xws": "bootsoflevitation"
+  },
+  {
+    "name": "item #071",
+    "points": 454,
+    "image": "items/64-151/boots-of-levitation.png",
+    "xws": "bootsoflevitation"
+  },
+  {
+    "name": "item 72",
+    "points": 455,
+    "image": "items/64-151/shoes-of-happiness.png",
+    "xws": "shoesofhappiness"
+  },
+  {
+    "name": "item 072",
+    "points": 456,
+    "image": "items/64-151/shoes-of-happiness.png",
+    "xws": "shoesofhappiness"
+  },
+  {
+    "name": "item #72",
+    "points": 457,
+    "image": "items/64-151/shoes-of-happiness.png",
+    "xws": "shoesofhappiness"
+  },
+  {
+    "name": "item #072",
+    "points": 458,
+    "image": "items/64-151/shoes-of-happiness.png",
+    "xws": "shoesofhappiness"
+  },
+  {
+    "name": "item 73",
+    "points": 459,
+    "image": "items/64-151/blinking-cape.png",
+    "xws": "blinkingcape"
+  },
+  {
+    "name": "item 073",
+    "points": 460,
+    "image": "items/64-151/blinking-cape.png",
+    "xws": "blinkingcape"
+  },
+  {
+    "name": "item #73",
+    "points": 461,
+    "image": "items/64-151/blinking-cape.png",
+    "xws": "blinkingcape"
+  },
+  {
+    "name": "item #073",
+    "points": 462,
+    "image": "items/64-151/blinking-cape.png",
+    "xws": "blinkingcape"
+  },
+  {
+    "name": "item 74",
+    "points": 463,
+    "image": "items/64-151/swordedge-armor.png",
+    "xws": "swordedgearmor"
+  },
+  {
+    "name": "item 074",
+    "points": 464,
+    "image": "items/64-151/swordedge-armor.png",
+    "xws": "swordedgearmor"
+  },
+  {
+    "name": "item #74",
+    "points": 465,
+    "image": "items/64-151/swordedge-armor.png",
+    "xws": "swordedgearmor"
+  },
+  {
+    "name": "item #074",
+    "points": 466,
+    "image": "items/64-151/swordedge-armor.png",
+    "xws": "swordedgearmor"
+  },
+  {
+    "name": "item 75",
+    "points": 467,
+    "image": "items/64-151/circlet-of-elements.png",
+    "xws": "circletofelements"
+  },
+  {
+    "name": "item 075",
+    "points": 468,
+    "image": "items/64-151/circlet-of-elements.png",
+    "xws": "circletofelements"
+  },
+  {
+    "name": "item #75",
+    "points": 469,
+    "image": "items/64-151/circlet-of-elements.png",
+    "xws": "circletofelements"
+  },
+  {
+    "name": "item #075",
+    "points": 470,
+    "image": "items/64-151/circlet-of-elements.png",
+    "xws": "circletofelements"
+  },
+  {
+    "name": "item 76",
+    "points": 471,
+    "image": "items/64-151/chain-hood.png",
+    "xws": "chainhood"
+  },
+  {
+    "name": "item 076",
+    "points": 472,
+    "image": "items/64-151/chain-hood.png",
+    "xws": "chainhood"
+  },
+  {
+    "name": "item #76",
+    "points": 473,
+    "image": "items/64-151/chain-hood.png",
+    "xws": "chainhood"
+  },
+  {
+    "name": "item #076",
+    "points": 474,
+    "image": "items/64-151/chain-hood.png",
+    "xws": "chainhood"
+  },
+  {
+    "name": "item 77",
+    "points": 475,
+    "image": "items/64-151/frigid-blade.png",
+    "xws": "frigidblade"
+  },
+  {
+    "name": "item 077",
+    "points": 476,
+    "image": "items/64-151/frigid-blade.png",
+    "xws": "frigidblade"
+  },
+  {
+    "name": "item #77",
+    "points": 477,
+    "image": "items/64-151/frigid-blade.png",
+    "xws": "frigidblade"
+  },
+  {
+    "name": "item #077",
+    "points": 478,
+    "image": "items/64-151/frigid-blade.png",
+    "xws": "frigidblade"
+  },
+  {
+    "name": "item 78",
+    "points": 479,
+    "image": "items/64-151/storm-blade.png",
+    "xws": "stormblade"
+  },
+  {
+    "name": "item 078",
+    "points": 480,
+    "image": "items/64-151/storm-blade.png",
+    "xws": "stormblade"
+  },
+  {
+    "name": "item #78",
+    "points": 481,
+    "image": "items/64-151/storm-blade.png",
+    "xws": "stormblade"
+  },
+  {
+    "name": "item #078",
+    "points": 482,
+    "image": "items/64-151/storm-blade.png",
+    "xws": "stormblade"
+  },
+  {
+    "name": "item 79",
+    "points": 483,
+    "image": "items/64-151/inferno-blade.png",
+    "xws": "infernoblade"
+  },
+  {
+    "name": "item 079",
+    "points": 484,
+    "image": "items/64-151/inferno-blade.png",
+    "xws": "infernoblade"
+  },
+  {
+    "name": "item #79",
+    "points": 485,
+    "image": "items/64-151/inferno-blade.png",
+    "xws": "infernoblade"
+  },
+  {
+    "name": "item #079",
+    "points": 486,
+    "image": "items/64-151/inferno-blade.png",
+    "xws": "infernoblade"
+  },
+  {
+    "name": "item 80",
+    "points": 487,
+    "image": "items/64-151/tremor-blade.png",
+    "xws": "tremorblade"
+  },
+  {
+    "name": "item 080",
+    "points": 488,
+    "image": "items/64-151/tremor-blade.png",
+    "xws": "tremorblade"
+  },
+  {
+    "name": "item #80",
+    "points": 489,
+    "image": "items/64-151/tremor-blade.png",
+    "xws": "tremorblade"
+  },
+  {
+    "name": "item #080",
+    "points": 490,
+    "image": "items/64-151/tremor-blade.png",
+    "xws": "tremorblade"
+  },
+  {
+    "name": "item 81",
+    "points": 491,
+    "image": "items/64-151/brilliant-blade.png",
+    "xws": "brilliantblade"
+  },
+  {
+    "name": "item 081",
+    "points": 492,
+    "image": "items/64-151/brilliant-blade.png",
+    "xws": "brilliantblade"
+  },
+  {
+    "name": "item #81",
+    "points": 493,
+    "image": "items/64-151/brilliant-blade.png",
+    "xws": "brilliantblade"
+  },
+  {
+    "name": "item #081",
+    "points": 494,
+    "image": "items/64-151/brilliant-blade.png",
+    "xws": "brilliantblade"
+  },
+  {
+    "name": "item 82",
+    "points": 495,
+    "image": "items/64-151/night-blade.png",
+    "xws": "nightblade"
+  },
+  {
+    "name": "item 082",
+    "points": 496,
+    "image": "items/64-151/night-blade.png",
+    "xws": "nightblade"
+  },
+  {
+    "name": "item #82",
+    "points": 497,
+    "image": "items/64-151/night-blade.png",
+    "xws": "nightblade"
+  },
+  {
+    "name": "item #082",
+    "points": 498,
+    "image": "items/64-151/night-blade.png",
+    "xws": "nightblade"
+  },
+  {
+    "name": "item 83",
+    "points": 499,
+    "image": "items/64-151/wand-of-frost.png",
+    "xws": "wandoffrost"
+  },
+  {
+    "name": "item 083",
+    "points": 500,
+    "image": "items/64-151/wand-of-frost.png",
+    "xws": "wandoffrost"
+  },
+  {
+    "name": "item #83",
+    "points": 501,
+    "image": "items/64-151/wand-of-frost.png",
+    "xws": "wandoffrost"
+  },
+  {
+    "name": "item #083",
+    "points": 502,
+    "image": "items/64-151/wand-of-frost.png",
+    "xws": "wandoffrost"
+  },
+  {
+    "name": "item 84",
+    "points": 503,
+    "image": "items/64-151/wand-of-storms.png",
+    "xws": "wandofstorms"
+  },
+  {
+    "name": "item 084",
+    "points": 504,
+    "image": "items/64-151/wand-of-storms.png",
+    "xws": "wandofstorms"
+  },
+  {
+    "name": "item #84",
+    "points": 505,
+    "image": "items/64-151/wand-of-storms.png",
+    "xws": "wandofstorms"
+  },
+  {
+    "name": "item #084",
+    "points": 506,
+    "image": "items/64-151/wand-of-storms.png",
+    "xws": "wandofstorms"
+  },
+  {
+    "name": "item 85",
+    "points": 507,
+    "image": "items/64-151/wand-of-infernos.png",
+    "xws": "wandofinfernos"
+  },
+  {
+    "name": "item 085",
+    "points": 508,
+    "image": "items/64-151/wand-of-infernos.png",
+    "xws": "wandofinfernos"
+  },
+  {
+    "name": "item #85",
+    "points": 509,
+    "image": "items/64-151/wand-of-infernos.png",
+    "xws": "wandofinfernos"
+  },
+  {
+    "name": "item #085",
+    "points": 510,
+    "image": "items/64-151/wand-of-infernos.png",
+    "xws": "wandofinfernos"
+  },
+  {
+    "name": "item 86",
+    "points": 511,
+    "image": "items/64-151/wand-of-tremors.png",
+    "xws": "wandoftremors"
+  },
+  {
+    "name": "item 086",
+    "points": 512,
+    "image": "items/64-151/wand-of-tremors.png",
+    "xws": "wandoftremors"
+  },
+  {
+    "name": "item #86",
+    "points": 513,
+    "image": "items/64-151/wand-of-tremors.png",
+    "xws": "wandoftremors"
+  },
+  {
+    "name": "item #086",
+    "points": 514,
+    "image": "items/64-151/wand-of-tremors.png",
+    "xws": "wandoftremors"
+  },
+  {
+    "name": "item 87",
+    "points": 515,
+    "image": "items/64-151/wand-of-brilliance.png",
+    "xws": "wandofbrilliance"
+  },
+  {
+    "name": "item 087",
+    "points": 516,
+    "image": "items/64-151/wand-of-brilliance.png",
+    "xws": "wandofbrilliance"
+  },
+  {
+    "name": "item #87",
+    "points": 517,
+    "image": "items/64-151/wand-of-brilliance.png",
+    "xws": "wandofbrilliance"
+  },
+  {
+    "name": "item #087",
+    "points": 518,
+    "image": "items/64-151/wand-of-brilliance.png",
+    "xws": "wandofbrilliance"
+  },
+  {
+    "name": "item 88",
+    "points": 519,
+    "image": "items/64-151/wand-of-darkness.png",
+    "xws": "wandofdarkness"
+  },
+  {
+    "name": "item 088",
+    "points": 520,
+    "image": "items/64-151/wand-of-darkness.png",
+    "xws": "wandofdarkness"
+  },
+  {
+    "name": "item #88",
+    "points": 521,
+    "image": "items/64-151/wand-of-darkness.png",
+    "xws": "wandofdarkness"
+  },
+  {
+    "name": "item #088",
+    "points": 522,
+    "image": "items/64-151/wand-of-darkness.png",
+    "xws": "wandofdarkness"
+  },
+  {
+    "name": "item 89",
+    "points": 523,
+    "image": "items/64-151/minor-cure-potion.png",
+    "xws": "minorcurepotion"
+  },
+  {
+    "name": "item 089",
+    "points": 524,
+    "image": "items/64-151/minor-cure-potion.png",
+    "xws": "minorcurepotion"
+  },
+  {
+    "name": "item #89",
+    "points": 525,
+    "image": "items/64-151/minor-cure-potion.png",
+    "xws": "minorcurepotion"
+  },
+  {
+    "name": "item #089",
+    "points": 526,
+    "image": "items/64-151/minor-cure-potion.png",
+    "xws": "minorcurepotion"
+  },
+  {
+    "name": "item 90",
+    "points": 527,
+    "image": "items/64-151/major-cure-potion.png",
+    "xws": "majorcurepotion"
+  },
+  {
+    "name": "item 090",
+    "points": 528,
+    "image": "items/64-151/major-cure-potion.png",
+    "xws": "majorcurepotion"
+  },
+  {
+    "name": "item #90",
+    "points": 529,
+    "image": "items/64-151/major-cure-potion.png",
+    "xws": "majorcurepotion"
+  },
+  {
+    "name": "item #090",
+    "points": 530,
+    "image": "items/64-151/major-cure-potion.png",
+    "xws": "majorcurepotion"
+  },
+  {
+    "name": "item 91",
+    "points": 531,
+    "image": "items/64-151/steel-ring.png",
+    "xws": "steelring"
+  },
+  {
+    "name": "item 091",
+    "points": 532,
+    "image": "items/64-151/steel-ring.png",
+    "xws": "steelring"
+  },
+  {
+    "name": "item #91",
+    "points": 533,
+    "image": "items/64-151/steel-ring.png",
+    "xws": "steelring"
+  },
+  {
+    "name": "item #091",
+    "points": 534,
+    "image": "items/64-151/steel-ring.png",
+    "xws": "steelring"
+  },
+  {
+    "name": "item 92",
+    "points": 535,
+    "image": "items/64-151/dampening-ring.png",
+    "xws": "dampeningring"
+  },
+  {
+    "name": "item 092",
+    "points": 536,
+    "image": "items/64-151/dampening-ring.png",
+    "xws": "dampeningring"
+  },
+  {
+    "name": "item #92",
+    "points": 537,
+    "image": "items/64-151/dampening-ring.png",
+    "xws": "dampeningring"
+  },
+  {
+    "name": "item #092",
+    "points": 538,
+    "image": "items/64-151/dampening-ring.png",
+    "xws": "dampeningring"
+  },
+  {
+    "name": "item 93",
+    "points": 539,
+    "image": "items/64-151/scroll-of-power.png",
+    "xws": "scrollofpower"
+  },
+  {
+    "name": "item 093",
+    "points": 540,
+    "image": "items/64-151/scroll-of-power.png",
+    "xws": "scrollofpower"
+  },
+  {
+    "name": "item #93",
+    "points": 541,
+    "image": "items/64-151/scroll-of-power.png",
+    "xws": "scrollofpower"
+  },
+  {
+    "name": "item #093",
+    "points": 542,
+    "image": "items/64-151/scroll-of-power.png",
+    "xws": "scrollofpower"
+  },
+  {
+    "name": "item 94",
+    "points": 543,
+    "image": "items/64-151/scroll-of-healing.png",
+    "xws": "scrollofhealing"
+  },
+  {
+    "name": "item 094",
+    "points": 544,
+    "image": "items/64-151/scroll-of-healing.png",
+    "xws": "scrollofhealing"
+  },
+  {
+    "name": "item #94",
+    "points": 545,
+    "image": "items/64-151/scroll-of-healing.png",
+    "xws": "scrollofhealing"
+  },
+  {
+    "name": "item #094",
+    "points": 546,
+    "image": "items/64-151/scroll-of-healing.png",
+    "xws": "scrollofhealing"
+  },
+  {
+    "name": "item 95",
+    "points": 547,
+    "image": "items/64-151/scroll-of-stamina.png",
+    "xws": "scrollofstamina"
+  },
+  {
+    "name": "item 095",
+    "points": 548,
+    "image": "items/64-151/scroll-of-stamina.png",
+    "xws": "scrollofstamina"
+  },
+  {
+    "name": "item #95",
+    "points": 549,
+    "image": "items/64-151/scroll-of-stamina.png",
+    "xws": "scrollofstamina"
+  },
+  {
+    "name": "item #095",
+    "points": 550,
+    "image": "items/64-151/scroll-of-stamina.png",
+    "xws": "scrollofstamina"
+  },
+  {
+    "name": "item 96",
+    "points": 551,
+    "image": "items/64-151/rocket-boots.png",
+    "xws": "rocketboots"
+  },
+  {
+    "name": "item 096",
+    "points": 552,
+    "image": "items/64-151/rocket-boots.png",
+    "xws": "rocketboots"
+  },
+  {
+    "name": "item #96",
+    "points": 553,
+    "image": "items/64-151/rocket-boots.png",
+    "xws": "rocketboots"
+  },
+  {
+    "name": "item #096",
+    "points": 554,
+    "image": "items/64-151/rocket-boots.png",
+    "xws": "rocketboots"
+  },
+  {
+    "name": "item 97",
+    "points": 555,
+    "image": "items/64-151/endurance-footwraps.png",
+    "xws": "endurancefootwraps"
+  },
+  {
+    "name": "item 097",
+    "points": 556,
+    "image": "items/64-151/endurance-footwraps.png",
+    "xws": "endurancefootwraps"
+  },
+  {
+    "name": "item #97",
+    "points": 557,
+    "image": "items/64-151/endurance-footwraps.png",
+    "xws": "endurancefootwraps"
+  },
+  {
+    "name": "item #097",
+    "points": 558,
+    "image": "items/64-151/endurance-footwraps.png",
+    "xws": "endurancefootwraps"
+  },
+  {
+    "name": "item 98",
+    "points": 559,
+    "image": "items/64-151/drakescale-boots.png",
+    "xws": "drakescaleboots"
+  },
+  {
+    "name": "item 098",
+    "points": 560,
+    "image": "items/64-151/drakescale-boots.png",
+    "xws": "drakescaleboots"
+  },
+  {
+    "name": "item #98",
+    "points": 561,
+    "image": "items/64-151/drakescale-boots.png",
+    "xws": "drakescaleboots"
+  },
+  {
+    "name": "item #098",
+    "points": 562,
+    "image": "items/64-151/drakescale-boots.png",
+    "xws": "drakescaleboots"
+  },
+  {
+    "name": "item 99",
+    "points": 563,
+    "image": "items/64-151/magma-waders.png",
+    "xws": "magmawaders"
+  },
+  {
+    "name": "item 099",
+    "points": 564,
+    "image": "items/64-151/magma-waders.png",
+    "xws": "magmawaders"
+  },
+  {
+    "name": "item #99",
+    "points": 565,
+    "image": "items/64-151/magma-waders.png",
+    "xws": "magmawaders"
+  },
+  {
+    "name": "item #099",
+    "points": 566,
+    "image": "items/64-151/magma-waders.png",
+    "xws": "magmawaders"
+  },
+  {
+    "name": "item 100",
+    "points": 567,
+    "image": "items/64-151/robes-of-summoning.png",
+    "xws": "robesofsummoning"
+  },
+  {
+    "name": "item #100",
+    "points": 568,
+    "image": "items/64-151/robes-of-summoning.png",
+    "xws": "robesofsummoning"
+  },
+  {
+    "name": "item 101",
+    "points": 569,
+    "image": "items/64-151/second-skin.png",
+    "xws": "secondskin"
+  },
+  {
+    "name": "item #101",
+    "points": 570,
+    "image": "items/64-151/second-skin.png",
+    "xws": "secondskin"
+  },
+  {
+    "name": "item 102",
+    "points": 571,
+    "image": "items/64-151/sacrificial-robes.png",
+    "xws": "sacrificialrobes"
+  },
+  {
+    "name": "item #102",
+    "points": 572,
+    "image": "items/64-151/sacrificial-robes.png",
+    "xws": "sacrificialrobes"
+  },
+  {
+    "name": "item 103",
+    "points": 573,
+    "image": "items/64-151/drakescale-armor.png",
+    "xws": "drakescalearmor"
+  },
+  {
+    "name": "item #103",
+    "points": 574,
+    "image": "items/64-151/drakescale-armor.png",
+    "xws": "drakescalearmor"
+  },
+  {
+    "name": "item 104",
+    "points": 575,
+    "image": "items/64-151/steam-armor.png",
+    "xws": "steamarmor"
+  },
+  {
+    "name": "item #104",
+    "points": 576,
+    "image": "items/64-151/steam-armor.png",
+    "xws": "steamarmor"
+  },
+  {
+    "name": "flea bitten shawl",
+    "points": 577,
+    "image": "items/64-151/flea-bitten-shawl.png",
+    "xws": "fleabittenshawl"
+  },
+  {
+    "name": "item 105",
+    "points": 578,
+    "image": "items/64-151/flea-bitten-shawl.png",
+    "xws": "fleabittenshawl"
+  },
+  {
+    "name": "item #105",
+    "points": 579,
+    "image": "items/64-151/flea-bitten-shawl.png",
+    "xws": "fleabittenshawl"
+  },
+  {
+    "name": "item 106",
+    "points": 580,
+    "image": "items/64-151/necklace-of-teeth.png",
+    "xws": "necklaceofteeth"
+  },
+  {
+    "name": "item #106",
+    "points": 581,
+    "image": "items/64-151/necklace-of-teeth.png",
+    "xws": "necklaceofteeth"
+  },
+  {
+    "name": "item 107",
+    "points": 582,
+    "image": "items/64-151/horned-helm.png",
+    "xws": "hornedhelm"
+  },
+  {
+    "name": "item #107",
+    "points": 583,
+    "image": "items/64-151/horned-helm.png",
+    "xws": "hornedhelm"
+  },
+  {
+    "name": "item 108",
+    "points": 584,
+    "image": "items/64-151/drakescale-helm.png",
+    "xws": "drakescalehelm"
+  },
+  {
+    "name": "item #108",
+    "points": 585,
+    "image": "items/64-151/drakescale-helm.png",
+    "xws": "drakescalehelm"
+  },
+  {
+    "name": "item 109",
+    "points": 586,
+    "image": "items/64-151/thiefs-hood.png",
+    "xws": "thiefshood"
+  },
+  {
+    "name": "item #109",
+    "points": 587,
+    "image": "items/64-151/thiefs-hood.png",
+    "xws": "thiefshood"
+  },
+  {
+    "name": "item 110",
+    "points": 588,
+    "image": "items/64-151/helm-of-the-mountain.png",
+    "xws": "helmofthemountain"
+  },
+  {
+    "name": "item #110",
+    "points": 589,
+    "image": "items/64-151/helm-of-the-mountain.png",
+    "xws": "helmofthemountain"
+  },
+  {
+    "name": "item 111",
+    "points": 590,
+    "image": "items/64-151/wave-crest.png",
+    "xws": "wavecrest"
+  },
+  {
+    "name": "item #111",
+    "points": 591,
+    "image": "items/64-151/wave-crest.png",
+    "xws": "wavecrest"
+  },
+  {
+    "name": "item 112",
+    "points": 592,
+    "image": "items/64-151/ancient-drill.png",
+    "xws": "ancientdrill"
+  },
+  {
+    "name": "item #112",
+    "points": 593,
+    "image": "items/64-151/ancient-drill.png",
+    "xws": "ancientdrill"
+  },
+  {
+    "name": "item 113",
+    "points": 594,
+    "image": "items/64-151/skullbane-axe.png",
+    "xws": "skullbaneaxe"
+  },
+  {
+    "name": "item #113",
+    "points": 595,
+    "image": "items/64-151/skullbane-axe.png",
+    "xws": "skullbaneaxe"
+  },
+  {
+    "name": "item 114",
+    "points": 596,
+    "image": "items/64-151/staff-of-xorn.png",
+    "xws": "staffofxorn"
+  },
+  {
+    "name": "item #114",
+    "points": 597,
+    "image": "items/64-151/staff-of-xorn.png",
+    "xws": "staffofxorn"
+  },
+  {
+    "name": "item 115",
+    "points": 598,
+    "image": "items/64-151/mountain-hammer.png",
+    "xws": "mountainhammer"
+  },
+  {
+    "name": "item #115",
+    "points": 599,
+    "image": "items/64-151/mountain-hammer.png",
+    "xws": "mountainhammer"
+  },
+  {
+    "name": "item 116",
+    "points": 600,
+    "image": "items/64-151/fueled-falchion.png",
+    "xws": "fueledfalchion"
+  },
+  {
+    "name": "item #116",
+    "points": 601,
+    "image": "items/64-151/fueled-falchion.png",
+    "xws": "fueledfalchion"
+  },
+  {
+    "name": "item 117",
+    "points": 602,
+    "image": "items/64-151/bloody-axe.png",
+    "xws": "bloodyaxe"
+  },
+  {
+    "name": "item #117",
+    "points": 603,
+    "image": "items/64-151/bloody-axe.png",
+    "xws": "bloodyaxe"
+  },
+  {
+    "name": "item 118",
+    "points": 604,
+    "image": "items/64-151/staff-of-elements.png",
+    "xws": "staffofelements"
+  },
+  {
+    "name": "item #118",
+    "points": 605,
+    "image": "items/64-151/staff-of-elements.png",
+    "xws": "staffofelements"
+  },
+  {
+    "name": "item 119",
+    "points": 606,
+    "image": "items/64-151/skull-of-hatred.png",
+    "xws": "skullofhatred"
+  },
+  {
+    "name": "item #119",
+    "points": 607,
+    "image": "items/64-151/skull-of-hatred.png",
+    "xws": "skullofhatred"
+  },
+  {
+    "name": "item 120",
+    "points": 608,
+    "image": "items/64-151/staff-of-summoning.png",
+    "xws": "staffofsummoning"
+  },
+  {
+    "name": "item #120",
+    "points": 609,
+    "image": "items/64-151/staff-of-summoning.png",
+    "xws": "staffofsummoning"
+  },
+  {
+    "name": "item 121",
+    "points": 610,
+    "image": "items/64-151/orb-of-dawn.png",
+    "xws": "orbofdawn"
+  },
+  {
+    "name": "item #121",
+    "points": 611,
+    "image": "items/64-151/orb-of-dawn.png",
+    "xws": "orbofdawn"
+  },
+  {
+    "name": "item 122",
+    "points": 612,
+    "image": "items/64-151/orb-of-twilight.png",
+    "xws": "orboftwilight"
+  },
+  {
+    "name": "item #122",
+    "points": 613,
+    "image": "items/64-151/orb-of-twilight.png",
+    "xws": "orboftwilight"
+  },
+  {
+    "name": "item 123",
+    "points": 614,
+    "image": "items/64-151/ring-of-skulls.png",
+    "xws": "ringofskulls"
+  },
+  {
+    "name": "item #123",
+    "points": 615,
+    "image": "items/64-151/ring-of-skulls.png",
+    "xws": "ringofskulls"
+  },
+  {
+    "name": "item 124",
+    "points": 616,
+    "image": "items/64-151/doomed-compass.png",
+    "xws": "doomedcompass"
+  },
+  {
+    "name": "item #124",
+    "points": 617,
+    "image": "items/64-151/doomed-compass.png",
+    "xws": "doomedcompass"
+  },
+  {
+    "name": "item 125",
+    "points": 618,
+    "image": "items/64-151/curious-gear.png",
+    "xws": "curiousgear"
+  },
+  {
+    "name": "item #125",
+    "points": 619,
+    "image": "items/64-151/curious-gear.png",
+    "xws": "curiousgear"
+  },
+  {
+    "name": "item 126",
+    "points": 620,
+    "image": "items/64-151/remote-spider.png",
+    "xws": "remotespider"
+  },
+  {
+    "name": "item #126",
+    "points": 621,
+    "image": "items/64-151/remote-spider.png",
+    "xws": "remotespider"
+  },
+  {
+    "name": "item 127",
+    "points": 622,
+    "image": "items/64-151/giant-remote-spider.png",
+    "xws": "giantremotespider"
+  },
+  {
+    "name": "item #127",
+    "points": 623,
+    "image": "items/64-151/giant-remote-spider.png",
+    "xws": "giantremotespider"
+  },
+  {
+    "name": "item 128",
+    "points": 624,
+    "image": "items/64-151/black-censer.png",
+    "xws": "blackcenser"
+  },
+  {
+    "name": "item #128",
+    "points": 625,
+    "image": "items/64-151/black-censer.png",
+    "xws": "blackcenser"
+  },
+  {
+    "name": "item 129",
+    "points": 626,
+    "image": "items/64-151/black-card.png",
+    "xws": "blackcard"
+  },
+  {
+    "name": "item #129",
+    "points": 627,
+    "image": "items/64-151/black-card.png",
+    "xws": "blackcard"
+  },
+  {
+    "name": "item 130",
+    "points": 628,
+    "image": "items/64-151/helix-ring.png",
+    "xws": "helixring"
+  },
+  {
+    "name": "item #130",
+    "points": 629,
+    "image": "items/64-151/helix-ring.png",
+    "xws": "helixring"
+  },
+  {
+    "name": "item 131",
+    "points": 630,
+    "image": "items/64-151/heart-of-the-betrayer.png",
+    "xws": "heartofthebetrayer"
+  },
+  {
+    "name": "item #131",
+    "points": 631,
+    "image": "items/64-151/heart-of-the-betrayer.png",
+    "xws": "heartofthebetrayer"
+  },
+  {
+    "name": "item 132",
+    "points": 632,
+    "image": "items/64-151/power-core.png",
+    "xws": "powercore"
+  },
+  {
+    "name": "item #132",
+    "points": 633,
+    "image": "items/64-151/power-core.png",
+    "xws": "powercore"
+  },
+  {
+    "name": "item 133",
+    "points": 634,
+    "image": "items/64-151/resonant-crystal.png",
+    "xws": "resonantcrystal"
+  },
+  {
+    "name": "item #133",
+    "points": 635,
+    "image": "items/64-151/resonant-crystal.png",
+    "xws": "resonantcrystal"
+  },
+  {
+    "name": "item 134",
+    "points": 636,
+    "image": "items/64-151/imposing-blade.png",
+    "xws": "imposingblade"
+  },
+  {
+    "name": "item #134",
+    "points": 637,
+    "image": "items/64-151/imposing-blade.png",
+    "xws": "imposingblade"
+  },
+  {
+    "name": "item 135",
+    "points": 638,
+    "image": "items/64-151/focusing-ray.png",
+    "xws": "focusingray"
+  },
+  {
+    "name": "item #135",
+    "points": 639,
+    "image": "items/64-151/focusing-ray.png",
+    "xws": "focusingray"
+  },
+  {
+    "name": "item 136",
+    "points": 640,
+    "image": "items/64-151/volatile-elixir.png",
+    "xws": "volatileelixir"
+  },
+  {
+    "name": "item #136",
+    "points": 641,
+    "image": "items/64-151/volatile-elixir.png",
+    "xws": "volatileelixir"
+  },
+  {
+    "name": "item 137",
+    "points": 642,
+    "image": "items/64-151/silent-stiletto.png",
+    "xws": "silentstiletto"
+  },
+  {
+    "name": "item #137",
+    "points": 643,
+    "image": "items/64-151/silent-stiletto.png",
+    "xws": "silentstiletto"
+  },
+  {
+    "name": "item 138",
+    "points": 644,
+    "image": "items/64-151/stone-charm.png",
+    "xws": "stonecharm"
+  },
+  {
+    "name": "item #138",
+    "points": 645,
+    "image": "items/64-151/stone-charm.png",
+    "xws": "stonecharm"
+  },
+  {
+    "name": "item 139",
+    "points": 646,
+    "image": "items/64-151/psychic-knife.png",
+    "xws": "psychicknife"
+  },
+  {
+    "name": "item #139",
+    "points": 647,
+    "image": "items/64-151/psychic-knife.png",
+    "xws": "psychicknife"
+  },
+  {
+    "name": "item 140",
+    "points": 648,
+    "image": "items/64-151/sun-shield.png",
+    "xws": "sunshield"
+  },
+  {
+    "name": "item #140",
+    "points": 649,
+    "image": "items/64-151/sun-shield.png",
+    "xws": "sunshield"
+  },
+  {
+    "name": "item 141",
+    "points": 650,
+    "image": "items/64-151/utility-belt.png",
+    "xws": "utilitybelt"
+  },
+  {
+    "name": "item #141",
+    "points": 651,
+    "image": "items/64-151/utility-belt.png",
+    "xws": "utilitybelt"
+  },
+  {
+    "name": "item 142",
+    "points": 652,
+    "image": "items/64-151/phasing-idol.png",
+    "xws": "phasingidol"
+  },
+  {
+    "name": "item #142",
+    "points": 653,
+    "image": "items/64-151/phasing-idol.png",
+    "xws": "phasingidol"
+  },
+  {
+    "name": "item 143",
+    "points": 654,
+    "image": "items/64-151/smoke-elixir.png",
+    "xws": "smokeelixir"
+  },
+  {
+    "name": "item #143",
+    "points": 655,
+    "image": "items/64-151/smoke-elixir.png",
+    "xws": "smokeelixir"
+  },
+  {
+    "name": "item 144",
+    "points": 656,
+    "image": "items/64-151/pendant-of-the-plague.png",
+    "xws": "pendantoftheplague"
+  },
+  {
+    "name": "item #144",
+    "points": 657,
+    "image": "items/64-151/pendant-of-the-plague.png",
+    "xws": "pendantoftheplague"
+  },
+  {
+    "name": "item 145",
+    "points": 658,
+    "image": "items/64-151/mask-of-death.png",
+    "xws": "maskofdeath"
+  },
+  {
+    "name": "item #145",
+    "points": 659,
+    "image": "items/64-151/mask-of-death.png",
+    "xws": "maskofdeath"
+  },
+  {
+    "name": "item 146",
+    "points": 660,
+    "image": "items/64-151/masters-lute.png",
+    "xws": "masterslute"
+  },
+  {
+    "name": "item #146",
+    "points": 661,
+    "image": "items/64-151/masters-lute.png",
+    "xws": "masterslute"
+  },
+  {
+    "name": "item 147",
+    "points": 662,
+    "image": "items/64-151/cloak-of-the-hunter.png",
+    "xws": "cloakofthehunter"
+  },
+  {
+    "name": "item #147",
+    "points": 663,
+    "image": "items/64-151/cloak-of-the-hunter.png",
+    "xws": "cloakofthehunter"
+  },
+  {
+    "name": "item 148",
+    "points": 664,
+    "image": "items/64-151/doctors-coat.png",
+    "xws": "doctors coat"
+  },
+  {
+    "name": "item #148",
+    "points": 665,
+    "image": "items/64-151/doctors-coat.png",
+    "xws": "doctors coat"
+  },
+  {
+    "name": "item 149",
+    "points": 666,
+    "image": "items/64-151/elemental-boots.png",
+    "xws": "elementalboots"
+  },
+  {
+    "name": "item #149",
+    "points": 667,
+    "image": "items/64-151/elemental-boots.png",
+    "xws": "elementalboots"
+  },
+  {
+    "name": "item 150",
+    "points": 668,
+    "image": "items/64-151/staff-of-command.png",
+    "xws": "staffofcommand"
+  },
+  {
+    "name": "item #150",
+    "points": 669,
+    "image": "items/64-151/staff-of-command.png",
+    "xws": "staffofcommand"
+  },
+  {
+    "name": "item 151",
+    "points": 670,
+    "image": "items/64-151/sword-of-the-sands.png",
+    "xws": "swordofthesands"
+  },
+  {
+    "name": "item #151",
+    "points": 671,
+    "image": "items/64-151/sword-of-the-sands.png",
+    "xws": "swordofthesands"
+  },
+  {
+    "name": "jade falcon",
+    "points": 672,
+    "image": "items/29-35/falcon-figurine.png",
+    "xws": "falconfigurine"
+  }, 
+  {
+    "name": "warrior spirit",
+    "points": 673,
+    "image": "items/64-151/mountain-hammer.png",
+    "xws": "mountainhammer"
+  },
+  {
+    "name": "skeleton",
+    "points": 674,
+    "image": "items/64-151/ring-of-skulls.png",
+    "xws": "ringofskulls"
+  },
+  {
+    "name": "steel construct",
+    "points": 675,
+    "image": "items/64-151/power-core.png",
+    "xws": "powercore"
+  },
+  {
+    "name": "ancient bow",
+    "points": 676,
+    "image": "items/152-165/ancient-bow.png",
+    "xws": "ancientbow"
+  },
+  {
+    "name": "basin of prophecy",
+    "points": 677,
+    "image": "items/152-165/basin-of-prophecy.png",
+    "xws": "basinofprophecy"
+  },
+  {
+    "name": "crystal tiara",
+    "points": 678,
+    "image": "items/152-165/crystal-tiara.png",
+    "xws": "crystaltiara"
+  },
+  {
+    "name": "curseward armor",
+    "points": 679,
+    "image": "items/152-165/curseward-armor.png",
+    "xws": "cursewardarmor"
+  },
+  {
+    "name": "cutpurse dagger",
+    "points": 680,
+    "image": "items/152-165/cutpurse-dagger.png",
+    "xws": "cutpursedagger"
+  },
+  {
+    "name": "elemental claymore",
+    "points": 681,
+    "image": "items/152-165/elemental-claymore.png",
+    "xws": "elementalclaymore"
+  },
+  {
+    "name": "living armor",
+    "points": 682,
+    "image": "items/152-165/living-armor.png",
+    "xws": "livingarmor"
+  },
+  {
+    "name": "living armor instructions",
+    "points": 683,
+    "image": "items/152-165/living-armor-instructions.png",
+    "xws": "livingarmorinstructions"
+  },
+  {
+    "name": "major antidote",
+    "points": 684,
+    "image": "items/152-165/major-antidote.png",
+    "xws": "majorantidote"
+  },
+  {
+    "name": "minor antidote",
+    "points": 685,
+    "image": "items/152-165/minor-antidote.png",
+    "xws": "minorantidote"
+  },
+  {
+    "name": "rejuvenation greaves",
+    "points": 686,
+    "image": "items/152-165/rejuvenation-greaves.png",
+    "xws": "rejuvenationgreaves"
+  },
+  {
+    "name": "rift device",
+    "points": 687,
+    "image": "items/152-165/rift-device.png",
+    "xws": "riftdevice"
+  },
+  {
+    "name": "ring of duality",
+    "points": 688,
+    "image": "items/152-165/ring-of-duality.png",
+    "xws": "ringofduality"
+  },
+  {
+    "name": "scroll of haste",
+    "points": 689,
+    "image": "items/152-165/scroll-of-haste.png",
+    "xws": "scrollofhaste"
+  },
+  {
+    "name": "throwing axe",
+    "points": 690,
+    "image": "items/152-165/throwing-axe.png",
+    "xws": "throwingaxe"
+  },
+  {
+    "name": "item 152",
+    "points": 691,
+    "image": "items/152-165/ring-of-duality.png",
+    "xws": "ringofduality"
+  },
+  {
+    "name": "item #152",
+    "points": 692,
+    "image": "items/152-165/ring-of-duality.png",
+    "xws": "ringofduality"
+  },  
+  {
+    "name": "item 153",
+    "points": 693,
+    "image": "items/152-165/minor-antidote.png",
+    "xws": "minorantidote"
+  },
+  {
+    "name": "item #153",
+    "points": 694,
+    "image": "items/152-165/minor-antidote.png",
+    "xws": "minorantidote"
+  },  
+  {
+    "name": "item 154",
+    "points": 695,
+    "image": "items/152-165/major-antidote.png",
+    "xws": "majorantidote"
+  },
+  {
+    "name": "item #154",
+    "points": 696,
+    "image": "items/152-165/major-antidote.png",
+    "xws": "majorantidote"
+  },  
+  {
+    "name": "item 155",
+    "points": 697,
+    "image": "items/152-165/curseward-armor.png",
+    "xws": "cursewardarmor"
+  },
+  {
+    "name": "item #155",
+    "points": 698,
+    "image": "items/152-165/curseward-armor.png",
+    "xws": "cursewardarmor"
+  },  
+  {
+    "name": "item 156",
+    "points": 699,
+    "image": "items/152-165/elemental-claymore.png",
+    "xws": "elementalclaymore"
+  },
+  {
+    "name": "item #156",
+    "points": 700,
+    "image": "items/152-165/elemental-claymore.png",
+    "xws": "elementalclaymore"
+  },  
+  {
+    "name": "item 157",
+    "points": 701,
+    "image": "items/152-165/ancient-bow.png",
+    "xws": "ancientbow"
+  },
+  {
+    "name": "item #157",
+    "points": 702,
+    "image": "items/152-165/ancient-bow.png",
+    "xws": "ancientbow"
+  },  
+  {
+    "name": "item 158",
+    "points": 703,
+    "image": "items/152-165/rejuvenation-greaves.png",
+    "xws": "rejuvenationgreaves"
+  },
+  {
+    "name": "item #158",
+    "points": 704,
+    "image": "items/152-165/rejuvenation-greaves.png",
+    "xws": "rejuvenationgreaves"
+  },  
+  {
+    "name": "item 159",
+    "points": 705,
+    "image": "items/152-165/scroll-of-haste.png",
+    "xws": "scrollofhaste"
+  },
+  {
+    "name": "item #159",
+    "points": 706,
+    "image": "items/152-165/scroll-of-haste.png",
+    "xws": "scrollofhaste"
+  },  
+  {
+    "name": "item 160",
+    "points": 707,
+    "image": "items/152-165/cutpurse-dagger.png",
+    "xws": "cutpursedagger"
+  },
+  {
+    "name": "item #160",
+    "points": 708,
+    "image": "items/152-165/cutpurse-dagger.png",
+    "xws": "cutpursedagger"
+  },  
+  {
+    "name": "item 161",
+    "points": 709,
+    "image": "items/152-165/throwing-axe.png",
+    "xws": "throwingaxe"
+  },
+  {
+    "name": "item #161",
+    "points": 710,
+    "image": "items/152-165/throwing-axe.png",
+    "xws": "throwingaxe"
+  },  
+  {
+    "name": "item 162",
+    "points": 711,
+    "image": "items/152-165/rift-device.png",
+    "xws": "riftdevice"
+  },
+  {
+    "name": "item #162",
+    "points": 712,
+    "image": "items/152-165/rift-device.png",
+    "xws": "riftdevice"
+  },  
+  {
+    "name": "item 163",
+    "points": 713,
+    "image": "items/152-165/crystal-tiara.png",
+    "xws": "crystaltiara"
+  },
+  {
+    "name": "item #163",
+    "points": 714,
+    "image": "items/152-165/crystal-tiara.png",
+    "xws": "crystaltiara"
+  },  
+  {
+    "name": "item 164",
+    "points": 715,
+    "image": "items/152-165/basin-of-prophecy.png",
+    "xws": "basinofprophecy"
+  },
+  {
+    "name": "item #164",
+    "points": 716,
+    "image": "items/152-165/basin-of-prophecy.png",
+    "xws": "basinofprophecy"
+  },  
+  {
+    "name": "item 165",
+    "points": 717,
+    "image": "items/152-165/living-armor.png",
+    "xws": "livingarmor"
+  },
+  {
+    "name": "item #165",
+    "points": 718,
+    "image": "items/152-165/living-armor.png",
+    "xws": "livingarmor"
+  }
+]

--- a/data/map-tiles.json
+++ b/data/map-tiles.json
@@ -1,0 +1,362 @@
+[
+  {
+    "name": "a1a",
+    "points": 0,
+    "image": "map-tiles/a1a.png",
+    "xws": "a1a"
+  },
+  {
+    "name": "a1b",
+    "points": 1,
+    "image": "map-tiles/a1b.png",
+    "xws": "a1b"
+  },
+  {
+    "name": "a2a",
+    "points": 2,
+    "image": "map-tiles/a2a.png",
+    "xws": "a2a"
+  },
+  {
+    "name": "a2b",
+    "points": 3,
+    "image": "map-tiles/a2b.png",
+    "xws": "a2b"
+  },
+  {
+    "name": "a3a",
+    "points": 4,
+    "image": "map-tiles/a3a.png",
+    "xws": "a3a"
+  },
+  {
+    "name": "a3b",
+    "points": 5,
+    "image": "map-tiles/a3b.png",
+    "xws": "a3b"
+  },
+  {
+    "name": "a4a",
+    "points": 6,
+    "image": "map-tiles/a4a.png",
+    "xws": "a4a"
+  },
+  {
+    "name": "a4b",
+    "points": 7,
+    "image": "map-tiles/a4b.png",
+    "xws": "a4b"
+  },
+  {
+    "name": "b1a",
+    "points": 8,
+    "image": "map-tiles/b1a.png",
+    "xws": "b1a"
+  },
+  {
+    "name": "b1b",
+    "points": 9,
+    "image": "map-tiles/b1b.png",
+    "xws": "b1b"
+  },
+  {
+    "name": "b2a",
+    "points": 10,
+    "image": "map-tiles/b2a.png",
+    "xws": "b2a"
+  },
+  {
+    "name": "b2b",
+    "points": 11,
+    "image": "map-tiles/b2b.png",
+    "xws": "b2b"
+  },
+  {
+    "name": "b3a",
+    "points": 12,
+    "image": "map-tiles/b3a.png",
+    "xws": "b3a"
+  },
+  {
+    "name": "b3b",
+    "points": 13,
+    "image": "map-tiles/b3b.png",
+    "xws": "b3b"
+  },
+  {
+    "name": "b4a",
+    "points": 14,
+    "image": "map-tiles/b4a.png",
+    "xws": "b4a"
+  },
+  {
+    "name": "b4b",
+    "points": 15,
+    "image": "map-tiles/b4b.png",
+    "xws": "b4b"
+  },
+  {
+    "name": "c1a",
+    "points": 16,
+    "image": "map-tiles/c1a.png",
+    "xws": "c1a"
+  },
+  {
+    "name": "c1b",
+    "points": 17,
+    "image": "map-tiles/c1b.png",
+    "xws": "c1b"
+  },
+  {
+    "name": "c2a",
+    "points": 18,
+    "image": "map-tiles/c2a.png",
+    "xws": "c2a"
+  },
+  {
+    "name": "c2b",
+    "points": 19,
+    "image": "map-tiles/c2b.png",
+    "xws": "c2b"
+  },
+  {
+    "name": "d1a",
+    "points": 20,
+    "image": "map-tiles/d1a.png",
+    "xws": "d1a"
+  },
+  {
+    "name": "d1b",
+    "points": 21,
+    "image": "map-tiles/d1b.png",
+    "xws": "d1b"
+  },
+  {
+    "name": "d2a",
+    "points": 22,
+    "image": "map-tiles/d2a.png",
+    "xws": "d2a"
+  },
+  {
+    "name": "d2b",
+    "points": 23,
+    "image": "map-tiles/d2b.png",
+    "xws": "d2b"
+  },
+  {
+    "name": "e1a",
+    "points": 24,
+    "image": "map-tiles/e1a.png",
+    "xws": "e1a"
+  },
+  {
+    "name": "e1b",
+    "points": 25,
+    "image": "map-tiles/e1b.png",
+    "xws": "e1b"
+  },
+  {
+    "name": "f1a",
+    "points": 26,
+    "image": "map-tiles/f1a.png",
+    "xws": "f1a"
+  },
+  {
+    "name": "f1b",
+    "points": 27,
+    "image": "map-tiles/f1b.png",
+    "xws": "f1b"
+  },
+  {
+    "name": "g1a",
+    "points": 28,
+    "image": "map-tiles/g1a.png",
+    "xws": "g1a"
+  },
+  {
+    "name": "g1b",
+    "points": 29,
+    "image": "map-tiles/g1b.png",
+    "xws": "g1b"
+  },
+  {
+    "name": "g2a",
+    "points": 30,
+    "image": "map-tiles/g2a.png",
+    "xws": "g2a"
+  },
+  {
+    "name": "g2b",
+    "points": 31,
+    "image": "map-tiles/g2b.png",
+    "xws": "g2b"
+  },
+  {
+    "name": "h1a",
+    "points": 32,
+    "image": "map-tiles/h1a.png",
+    "xws": "h1a"
+  },
+  {
+    "name": "h1b",
+    "points": 33,
+    "image": "map-tiles/h1b.png",
+    "xws": "h1b"
+  },
+  {
+    "name": "h2a",
+    "points": 34,
+    "image": "map-tiles/h2a.png",
+    "xws": "h2a"
+  },
+  {
+    "name": "h2b",
+    "points": 35,
+    "image": "map-tiles/h2b.png",
+    "xws": "h2b"
+  },
+  {
+    "name": "h3a",
+    "points": 36,
+    "image": "map-tiles/h3a.png",
+    "xws": "h3a"
+  },
+  {
+    "name": "h3b",
+    "points": 37,
+    "image": "map-tiles/h3b.png",
+    "xws": "h3b"
+  },
+  {
+    "name": "i1a",
+    "points": 38,
+    "image": "map-tiles/i1a.png",
+    "xws": "i1a"
+  },
+  {
+    "name": "i1b",
+    "points": 39,
+    "image": "map-tiles/i1b.png",
+    "xws": "i1b"
+  },
+  {
+    "name": "i2a",
+    "points": 40,
+    "image": "map-tiles/i2a.png",
+    "xws": "i2a"
+  },
+  {
+    "name": "i2b",
+    "points": 41,
+    "image": "map-tiles/i2b.png",
+    "xws": "i2b"
+  },
+  {
+    "name": "j1a",
+    "points": 42,
+    "image": "map-tiles/j1a.png",
+    "xws": "j1a"
+  },
+  {
+    "name": "j1b",
+    "points": 43,
+    "image": "map-tiles/j1b.png",
+    "xws": "j1b"
+  },
+  {
+    "name": "j2a",
+    "points": 44,
+    "image": "map-tiles/j2a.png",
+    "xws": "j2a"
+  },
+  {
+    "name": "j2b",
+    "points": 45,
+    "image": "map-tiles/j2b.png",
+    "xws": "j2b"
+  },
+  {
+    "name": "k1a",
+    "points": 46,
+    "image": "map-tiles/k1a.png",
+    "xws": "k1a"
+  },
+  {
+    "name": "k1b",
+    "points": 47,
+    "image": "map-tiles/k1b.png",
+    "xws": "k1b"
+  },
+  {
+    "name": "k2a",
+    "points": 48,
+    "image": "map-tiles/k2a.png",
+    "xws": "k2a"
+  },
+  {
+    "name": "k2b",
+    "points": 49,
+    "image": "map-tiles/k2b.png",
+    "xws": "k2b"
+  },
+  {
+    "name": "l1a",
+    "points": 50,
+    "image": "map-tiles/l1a.png",
+    "xws": "l1a"
+  },
+  {
+    "name": "l1b",
+    "points": 51,
+    "image": "map-tiles/l1b.png",
+    "xws": "l1b"
+  },
+  {
+    "name": "l2a",
+    "points": 52,
+    "image": "map-tiles/l2a.png",
+    "xws": "l2a"
+  },
+  {
+    "name": "l2b",
+    "points": 53,
+    "image": "map-tiles/l2b.png",
+    "xws": "l2b"
+  },
+  {
+    "name": "l3a",
+    "points": 54,
+    "image": "map-tiles/l3a.png",
+    "xws": "l3a"
+  },
+  {
+    "name": "l3b",
+    "points": 55,
+    "image": "map-tiles/l3b.png",
+    "xws": "l3b"
+  },
+  {
+    "name": "m1a",
+    "points": 56,
+    "image": "map-tiles/m1a.png",
+    "xws": "m1a"
+  },
+  {
+    "name": "m1b",
+    "points": 57,
+    "image": "map-tiles/m1b.png",
+    "xws": "m1b"
+  },
+  {
+    "name": "n1a",
+    "points": 58,
+    "image": "map-tiles/n1a.png",
+    "xws": "n1a"
+  },
+  {
+    "name": "n1b",
+    "points": 59,
+    "image": "map-tiles/n1b.png",
+    "xws": "n1b"
+  }
+]

--- a/data/monster-ability-cards.json
+++ b/data/monster-ability-cards.json
@@ -1,0 +1,1856 @@
+[
+  {
+    "name": "ma-aa-1",
+    "points": 0,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-1.png",
+    "xws": "maaa1"
+  },
+  {
+    "name": "ma-aa-2",
+    "points": 1,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-2.png",
+    "xws": "maaa2"
+  },
+  {
+    "name": "ma-aa-3",
+    "points": 2,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-3.png",
+    "xws": "maaa3"
+  },
+  {
+    "name": "ma-aa-4",
+    "points": 3,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-4.png",
+    "xws": "maaa4"
+  },
+  {
+    "name": "ma-aa-5",
+    "points": 4,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-5.png",
+    "xws": "maaa5"
+  },
+  {
+    "name": "ma-aa-6",
+    "points": 5,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-6.png",
+    "xws": "maaa6"
+  },
+  {
+    "name": "ma-aa-7",
+    "points": 6,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-7.png",
+    "xws": "maaa7"
+  },
+  {
+    "name": "ma-aa-8",
+    "points": 7,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-8.png",
+    "xws": "maaa8"
+  },
+  {
+    "name": "ma-aa-back",
+    "points": 8,
+    "image": "monster-ability-cards/ancient-artillery/ma-aa-back.png",
+    "xws": "maaaback"
+  },
+  {
+    "name": "ma-ar-1",
+    "points": 9,
+    "image": "monster-ability-cards/archer/ma-ar-1.png",
+    "xws": "maar1"
+  },
+  {
+    "name": "ma-ar-2",
+    "points": 10,
+    "image": "monster-ability-cards/archer/ma-ar-2.png",
+    "xws": "maar2"
+  },
+  {
+    "name": "ma-ar-3",
+    "points": 11,
+    "image": "monster-ability-cards/archer/ma-ar-3.png",
+    "xws": "maar3"
+  },
+  {
+    "name": "ma-ar-4",
+    "points": 12,
+    "image": "monster-ability-cards/archer/ma-ar-4.png",
+    "xws": "maar4"
+  },
+  {
+    "name": "ma-ar-5",
+    "points": 13,
+    "image": "monster-ability-cards/archer/ma-ar-5.png",
+    "xws": "maar5"
+  },
+  {
+    "name": "ma-ar-6",
+    "points": 14,
+    "image": "monster-ability-cards/archer/ma-ar-6.png",
+    "xws": "maar6"
+  },
+  {
+    "name": "ma-ar-7",
+    "points": 15,
+    "image": "monster-ability-cards/archer/ma-ar-7.png",
+    "xws": "maar7"
+  },
+  {
+    "name": "ma-ar-8",
+    "points": 16,
+    "image": "monster-ability-cards/archer/ma-ar-8.png",
+    "xws": "maar8"
+  },
+  {
+    "name": "ma-ar-back",
+    "points": 17,
+    "image": "monster-ability-cards/archer/ma-ar-back.png",
+    "xws": "maarback"
+  },
+  {
+    "name": "ma-bo-1",
+    "points": 18,
+    "image": "monster-ability-cards/boss/ma-bo-1.png",
+    "xws": "mabo1"
+  },
+  {
+    "name": "ma-bo-2",
+    "points": 19,
+    "image": "monster-ability-cards/boss/ma-bo-2.png",
+    "xws": "mabo2"
+  },
+  {
+    "name": "ma-bo-3",
+    "points": 20,
+    "image": "monster-ability-cards/boss/ma-bo-3.png",
+    "xws": "mabo3"
+  },
+  {
+    "name": "ma-bo-4",
+    "points": 21,
+    "image": "monster-ability-cards/boss/ma-bo-4.png",
+    "xws": "mabo4"
+  },
+  {
+    "name": "ma-bo-5",
+    "points": 22,
+    "image": "monster-ability-cards/boss/ma-bo-5.png",
+    "xws": "mabo5"
+  },
+  {
+    "name": "ma-bo-6",
+    "points": 23,
+    "image": "monster-ability-cards/boss/ma-bo-6.png",
+    "xws": "mabo6"
+  },
+  {
+    "name": "ma-bo-7",
+    "points": 24,
+    "image": "monster-ability-cards/boss/ma-bo-7.png",
+    "xws": "mabo7"
+  },
+  {
+    "name": "ma-bo-8",
+    "points": 25,
+    "image": "monster-ability-cards/boss/ma-bo-8.png",
+    "xws": "mabo8"
+  },
+  {
+    "name": "ma-bo-back",
+    "points": 26,
+    "image": "monster-ability-cards/boss/ma-bo-back.png",
+    "xws": "maboback"
+  },
+  {
+    "name": "ma-cb-1",
+    "points": 27,
+    "image": "monster-ability-cards/cave-bear/ma-cb-1.png",
+    "xws": "macb1"
+  },
+  {
+    "name": "ma-cb-2",
+    "points": 28,
+    "image": "monster-ability-cards/cave-bear/ma-cb-2.png",
+    "xws": "macb2"
+  },
+  {
+    "name": "ma-cb-3",
+    "points": 29,
+    "image": "monster-ability-cards/cave-bear/ma-cb-3.png",
+    "xws": "macb3"
+  },
+  {
+    "name": "ma-cb-4",
+    "points": 30,
+    "image": "monster-ability-cards/cave-bear/ma-cb-4.png",
+    "xws": "macb4"
+  },
+  {
+    "name": "ma-cb-5",
+    "points": 31,
+    "image": "monster-ability-cards/cave-bear/ma-cb-5.png",
+    "xws": "macb5"
+  },
+  {
+    "name": "ma-cb-6",
+    "points": 32,
+    "image": "monster-ability-cards/cave-bear/ma-cb-6.png",
+    "xws": "macb6"
+  },
+  {
+    "name": "ma-cb-7",
+    "points": 33,
+    "image": "monster-ability-cards/cave-bear/ma-cb-7.png",
+    "xws": "macb7"
+  },
+  {
+    "name": "ma-cb-8",
+    "points": 34,
+    "image": "monster-ability-cards/cave-bear/ma-cb-8.png",
+    "xws": "macb8"
+  },
+  {
+    "name": "ma-cb-back",
+    "points": 35,
+    "image": "monster-ability-cards/cave-bear/ma-cb-back.png",
+    "xws": "macbback"
+  },
+  {
+    "name": "ma-cu-1",
+    "points": 36,
+    "image": "monster-ability-cards/cultist/ma-cu-1.png",
+    "xws": "macu1"
+  },
+  {
+    "name": "ma-cu-2",
+    "points": 37,
+    "image": "monster-ability-cards/cultist/ma-cu-2.png",
+    "xws": "macu2"
+  },
+  {
+    "name": "ma-cu-3",
+    "points": 38,
+    "image": "monster-ability-cards/cultist/ma-cu-3.png",
+    "xws": "macu3"
+  },
+  {
+    "name": "ma-cu-4",
+    "points": 39,
+    "image": "monster-ability-cards/cultist/ma-cu-4.png",
+    "xws": "macu4"
+  },
+  {
+    "name": "ma-cu-5",
+    "points": 40,
+    "image": "monster-ability-cards/cultist/ma-cu-5.png",
+    "xws": "macu5"
+  },
+  {
+    "name": "ma-cu-6",
+    "points": 41,
+    "image": "monster-ability-cards/cultist/ma-cu-6.png",
+    "xws": "macu6"
+  },
+  {
+    "name": "ma-cu-7",
+    "points": 42,
+    "image": "monster-ability-cards/cultist/ma-cu-7.png",
+    "xws": "macu7"
+  },
+  {
+    "name": "ma-cu-8",
+    "points": 43,
+    "image": "monster-ability-cards/cultist/ma-cu-8.png",
+    "xws": "macu8"
+  },
+  {
+    "name": "ma-cu-back",
+    "points": 44,
+    "image": "monster-ability-cards/cultist/ma-cu-back.png",
+    "xws": "macuback"
+  },
+  {
+    "name": "ma-dt-1",
+    "points": 45,
+    "image": "monster-ability-cards/deep-terror/ma-dt-1.png",
+    "xws": "madt1"
+  },
+  {
+    "name": "ma-dt-2",
+    "points": 46,
+    "image": "monster-ability-cards/deep-terror/ma-dt-2.png",
+    "xws": "madt2"
+  },
+  {
+    "name": "ma-dt-3",
+    "points": 47,
+    "image": "monster-ability-cards/deep-terror/ma-dt-3.png",
+    "xws": "madt3"
+  },
+  {
+    "name": "ma-dt-4",
+    "points": 48,
+    "image": "monster-ability-cards/deep-terror/ma-dt-4.png",
+    "xws": "madt4"
+  },
+  {
+    "name": "ma-dt-5",
+    "points": 49,
+    "image": "monster-ability-cards/deep-terror/ma-dt-5.png",
+    "xws": "madt5"
+  },
+  {
+    "name": "ma-dt-6",
+    "points": 50,
+    "image": "monster-ability-cards/deep-terror/ma-dt-6.png",
+    "xws": "madt6"
+  },
+  {
+    "name": "ma-dt-7",
+    "points": 51,
+    "image": "monster-ability-cards/deep-terror/ma-dt-7.png",
+    "xws": "madt7"
+  },
+  {
+    "name": "ma-dt-8",
+    "points": 52,
+    "image": "monster-ability-cards/deep-terror/ma-dt-8.png",
+    "xws": "madt8"
+  },
+  {
+    "name": "ma-dt-back",
+    "points": 53,
+    "image": "monster-ability-cards/deep-terror/ma-dt-back.png",
+    "xws": "madtback"
+  },
+  {
+    "name": "ma-ed-1",
+    "points": 54,
+    "image": "monster-ability-cards/earth-demon/ma-ed-1.png",
+    "xws": "maed1"
+  },
+  {
+    "name": "ma-ed-2",
+    "points": 55,
+    "image": "monster-ability-cards/earth-demon/ma-ed-2.png",
+    "xws": "maed2"
+  },
+  {
+    "name": "ma-ed-3",
+    "points": 56,
+    "image": "monster-ability-cards/earth-demon/ma-ed-3.png",
+    "xws": "maed3"
+  },
+  {
+    "name": "ma-ed-4",
+    "points": 57,
+    "image": "monster-ability-cards/earth-demon/ma-ed-4.png",
+    "xws": "maed4"
+  },
+  {
+    "name": "ma-ed-5",
+    "points": 58,
+    "image": "monster-ability-cards/earth-demon/ma-ed-5.png",
+    "xws": "maed5"
+  },
+  {
+    "name": "ma-ed-6",
+    "points": 59,
+    "image": "monster-ability-cards/earth-demon/ma-ed-6.png",
+    "xws": "maed6"
+  },
+  {
+    "name": "ma-ed-7",
+    "points": 60,
+    "image": "monster-ability-cards/earth-demon/ma-ed-7.png",
+    "xws": "maed7"
+  },
+  {
+    "name": "ma-ed-8",
+    "points": 61,
+    "image": "monster-ability-cards/earth-demon/ma-ed-8.png",
+    "xws": "maed8"
+  },
+  {
+    "name": "ma-ed-back",
+    "points": 62,
+    "image": "monster-ability-cards/earth-demon/ma-ed-back.png",
+    "xws": "maedback"
+  },
+  {
+    "name": "ma-fld-1",
+    "points": 63,
+    "image": "monster-ability-cards/flame-demon/ma-fld-1.png",
+    "xws": "mafld1"
+  },
+  {
+    "name": "ma-fld-2",
+    "points": 64,
+    "image": "monster-ability-cards/flame-demon/ma-fld-2.png",
+    "xws": "mafld2"
+  },
+  {
+    "name": "ma-fld-3",
+    "points": 65,
+    "image": "monster-ability-cards/flame-demon/ma-fld-3.png",
+    "xws": "mafld3"
+  },
+  {
+    "name": "ma-fld-4",
+    "points": 66,
+    "image": "monster-ability-cards/flame-demon/ma-fld-4.png",
+    "xws": "mafld4"
+  },
+  {
+    "name": "ma-fld-5",
+    "points": 67,
+    "image": "monster-ability-cards/flame-demon/ma-fld-5.png",
+    "xws": "mafld5"
+  },
+  {
+    "name": "ma-fld-6",
+    "points": 68,
+    "image": "monster-ability-cards/flame-demon/ma-fld-6.png",
+    "xws": "mafld6"
+  },
+  {
+    "name": "ma-fld-7",
+    "points": 69,
+    "image": "monster-ability-cards/flame-demon/ma-fld-7.png",
+    "xws": "mafld7"
+  },
+  {
+    "name": "ma-fld-8",
+    "points": 70,
+    "image": "monster-ability-cards/flame-demon/ma-fld-8.png",
+    "xws": "mafld8"
+  },
+  {
+    "name": "ma-fld-back",
+    "points": 71,
+    "image": "monster-ability-cards/flame-demon/ma-fld-back.png",
+    "xws": "mafldback"
+  },
+  {
+    "name": "ma-frd-1",
+    "points": 72,
+    "image": "monster-ability-cards/frost-demon/ma-frd-1.png",
+    "xws": "mafrd1"
+  },
+  {
+    "name": "ma-frd-2",
+    "points": 73,
+    "image": "monster-ability-cards/frost-demon/ma-frd-2.png",
+    "xws": "mafrd2"
+  },
+  {
+    "name": "ma-frd-3",
+    "points": 74,
+    "image": "monster-ability-cards/frost-demon/ma-frd-3.png",
+    "xws": "mafrd3"
+  },
+  {
+    "name": "ma-frd-4",
+    "points": 75,
+    "image": "monster-ability-cards/frost-demon/ma-frd-4.png",
+    "xws": "mafrd4"
+  },
+  {
+    "name": "ma-frd-5",
+    "points": 76,
+    "image": "monster-ability-cards/frost-demon/ma-frd-5.png",
+    "xws": "mafrd5"
+  },
+  {
+    "name": "ma-frd-6",
+    "points": 77,
+    "image": "monster-ability-cards/frost-demon/ma-frd-6.png",
+    "xws": "mafrd6"
+  },
+  {
+    "name": "ma-frd-7",
+    "points": 78,
+    "image": "monster-ability-cards/frost-demon/ma-frd-7.png",
+    "xws": "mafrd7"
+  },
+  {
+    "name": "ma-frd-8",
+    "points": 79,
+    "image": "monster-ability-cards/frost-demon/ma-frd-8.png",
+    "xws": "mafrd8"
+  },
+  {
+    "name": "ma-frd-back",
+    "points": 80,
+    "image": "monster-ability-cards/frost-demon/ma-frd-back.png",
+    "xws": "mafrdback"
+  },
+  {
+    "name": "ma-gv-1",
+    "points": 81,
+    "image": "monster-ability-cards/giant-viper/ma-gv-1.png",
+    "xws": "magv1"
+  },
+  {
+    "name": "ma-gv-2",
+    "points": 82,
+    "image": "monster-ability-cards/giant-viper/ma-gv-2.png",
+    "xws": "magv2"
+  },
+  {
+    "name": "ma-gv-3",
+    "points": 83,
+    "image": "monster-ability-cards/giant-viper/ma-gv-3.png",
+    "xws": "magv3"
+  },
+  {
+    "name": "ma-gv-4",
+    "points": 84,
+    "image": "monster-ability-cards/giant-viper/ma-gv-4.png",
+    "xws": "magv4"
+  },
+  {
+    "name": "ma-gv-5",
+    "points": 85,
+    "image": "monster-ability-cards/giant-viper/ma-gv-5.png",
+    "xws": "magv5"
+  },
+  {
+    "name": "ma-gv-6",
+    "points": 86,
+    "image": "monster-ability-cards/giant-viper/ma-gv-6.png",
+    "xws": "magv6"
+  },
+  {
+    "name": "ma-gv-7",
+    "points": 87,
+    "image": "monster-ability-cards/giant-viper/ma-gv-7.png",
+    "xws": "magv7"
+  },
+  {
+    "name": "ma-gv-8",
+    "points": 88,
+    "image": "monster-ability-cards/giant-viper/ma-gv-8.png",
+    "xws": "magv8"
+  },
+  {
+    "name": "ma-gv-back",
+    "points": 89,
+    "image": "monster-ability-cards/giant-viper/ma-gv-back.png",
+    "xws": "magvback"
+  },
+  {
+    "name": "ma-gu-1",
+    "points": 90,
+    "image": "monster-ability-cards/guard/ma-gu-1.png",
+    "xws": "magu1"
+  },
+  {
+    "name": "ma-gu-2",
+    "points": 91,
+    "image": "monster-ability-cards/guard/ma-gu-2.png",
+    "xws": "magu2"
+  },
+  {
+    "name": "ma-gu-3",
+    "points": 92,
+    "image": "monster-ability-cards/guard/ma-gu-3.png",
+    "xws": "magu3"
+  },
+  {
+    "name": "ma-gu-4",
+    "points": 93,
+    "image": "monster-ability-cards/guard/ma-gu-4.png",
+    "xws": "magu4"
+  },
+  {
+    "name": "ma-gu-5",
+    "points": 94,
+    "image": "monster-ability-cards/guard/ma-gu-5.png",
+    "xws": "magu5"
+  },
+  {
+    "name": "ma-gu-6",
+    "points": 95,
+    "image": "monster-ability-cards/guard/ma-gu-6.png",
+    "xws": "magu6"
+  },
+  {
+    "name": "ma-gu-7",
+    "points": 96,
+    "image": "monster-ability-cards/guard/ma-gu-7.png",
+    "xws": "magu7"
+  },
+  {
+    "name": "ma-gu-8",
+    "points": 97,
+    "image": "monster-ability-cards/guard/ma-gu-8.png",
+    "xws": "magu8"
+  },
+  {
+    "name": "ma-gu-back",
+    "points": 98,
+    "image": "monster-ability-cards/guard/ma-gu-back.png",
+    "xws": "maguback"
+  },
+  {
+    "name": "ma-hi-1",
+    "points": 99,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-1.png",
+    "xws": "mahi1"
+  },
+  {
+    "name": "ma-hi-2",
+    "points": 100,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-2.png",
+    "xws": "mahi2"
+  },
+  {
+    "name": "ma-hi-3",
+    "points": 101,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-3.png",
+    "xws": "mahi3"
+  },
+  {
+    "name": "ma-hi-4",
+    "points": 102,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-4.png",
+    "xws": "mahi4"
+  },
+  {
+    "name": "ma-hi-5",
+    "points": 103,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-5.png",
+    "xws": "mahi5"
+  },
+  {
+    "name": "ma-hi-6",
+    "points": 104,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-6.png",
+    "xws": "mahi6"
+  },
+  {
+    "name": "ma-hi-7",
+    "points": 105,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-7.png",
+    "xws": "mahi7"
+  },
+  {
+    "name": "ma-hi-8",
+    "points": 106,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-8.png",
+    "xws": "mahi8"
+  },
+  {
+    "name": "ma-hi-back",
+    "points": 107,
+    "image": "monster-ability-cards/harrower-infester/ma-hi-back.png",
+    "xws": "mahiback"
+  },
+  {
+    "name": "ma-ho-1",
+    "points": 108,
+    "image": "monster-ability-cards/hound/ma-ho-1.png",
+    "xws": "maho1"
+  },
+  {
+    "name": "ma-ho-2",
+    "points": 109,
+    "image": "monster-ability-cards/hound/ma-ho-2.png",
+    "xws": "maho2"
+  },
+  {
+    "name": "ma-ho-3",
+    "points": 110,
+    "image": "monster-ability-cards/hound/ma-ho-3.png",
+    "xws": "maho3"
+  },
+  {
+    "name": "ma-ho-4",
+    "points": 111,
+    "image": "monster-ability-cards/hound/ma-ho-4.png",
+    "xws": "maho4"
+  },
+  {
+    "name": "ma-ho-5",
+    "points": 112,
+    "image": "monster-ability-cards/hound/ma-ho-5.png",
+    "xws": "maho5"
+  },
+  {
+    "name": "ma-ho-6",
+    "points": 113,
+    "image": "monster-ability-cards/hound/ma-ho-6.png",
+    "xws": "maho6"
+  },
+  {
+    "name": "ma-ho-7",
+    "points": 114,
+    "image": "monster-ability-cards/hound/ma-ho-7.png",
+    "xws": "maho7"
+  },
+  {
+    "name": "ma-ho-8",
+    "points": 115,
+    "image": "monster-ability-cards/hound/ma-ho-8.png",
+    "xws": "maho8"
+  },
+  {
+    "name": "ma-ho-back",
+    "points": 116,
+    "image": "monster-ability-cards/hound/ma-ho-back.png",
+    "xws": "mahoback"
+  },
+  {
+    "name": "ma-im-1",
+    "points": 117,
+    "image": "monster-ability-cards/imp/ma-im-1.png",
+    "xws": "maim1"
+  },
+  {
+    "name": "ma-im-2",
+    "points": 118,
+    "image": "monster-ability-cards/imp/ma-im-2.png",
+    "xws": "maim2"
+  },
+  {
+    "name": "ma-im-3",
+    "points": 119,
+    "image": "monster-ability-cards/imp/ma-im-3.png",
+    "xws": "maim3"
+  },
+  {
+    "name": "ma-im-4",
+    "points": 120,
+    "image": "monster-ability-cards/imp/ma-im-4.png",
+    "xws": "maim4"
+  },
+  {
+    "name": "ma-im-5",
+    "points": 121,
+    "image": "monster-ability-cards/imp/ma-im-5.png",
+    "xws": "maim5"
+  },
+  {
+    "name": "ma-im-6",
+    "points": 122,
+    "image": "monster-ability-cards/imp/ma-im-6.png",
+    "xws": "maim6"
+  },
+  {
+    "name": "ma-im-7",
+    "points": 123,
+    "image": "monster-ability-cards/imp/ma-im-7.png",
+    "xws": "maim7"
+  },
+  {
+    "name": "ma-im-8",
+    "points": 124,
+    "image": "monster-ability-cards/imp/ma-im-8.png",
+    "xws": "maim8"
+  },
+  {
+    "name": "ma-im-back",
+    "points": 125,
+    "image": "monster-ability-cards/imp/ma-im-back.png",
+    "xws": "maimback"
+  },
+  {
+    "name": "ma-lb-1",
+    "points": 126,
+    "image": "monster-ability-cards/living-bones/ma-lb-1.png",
+    "xws": "malb1"
+  },
+  {
+    "name": "ma-lb-2",
+    "points": 127,
+    "image": "monster-ability-cards/living-bones/ma-lb-2.png",
+    "xws": "malb2"
+  },
+  {
+    "name": "ma-lb-3",
+    "points": 128,
+    "image": "monster-ability-cards/living-bones/ma-lb-3.png",
+    "xws": "malb3"
+  },
+  {
+    "name": "ma-lb-4",
+    "points": 129,
+    "image": "monster-ability-cards/living-bones/ma-lb-4.png",
+    "xws": "malb4"
+  },
+  {
+    "name": "ma-lb-5",
+    "points": 130,
+    "image": "monster-ability-cards/living-bones/ma-lb-5.png",
+    "xws": "malb5"
+  },
+  {
+    "name": "ma-lb-6",
+    "points": 131,
+    "image": "monster-ability-cards/living-bones/ma-lb-6.png",
+    "xws": "malb6"
+  },
+  {
+    "name": "ma-lb-7",
+    "points": 132,
+    "image": "monster-ability-cards/living-bones/ma-lb-7.png",
+    "xws": "malb7"
+  },
+  {
+    "name": "ma-lb-8",
+    "points": 133,
+    "image": "monster-ability-cards/living-bones/ma-lb-8.png",
+    "xws": "malb8"
+  },
+  {
+    "name": "ma-lb-back",
+    "points": 134,
+    "image": "monster-ability-cards/living-bones/ma-lb-back.png",
+    "xws": "malbback"
+  },
+  {
+    "name": "ma-lc-1",
+    "points": 135,
+    "image": "monster-ability-cards/living-corpse/ma-lc-1.png",
+    "xws": "malc1"
+  },
+  {
+    "name": "ma-lc-2",
+    "points": 136,
+    "image": "monster-ability-cards/living-corpse/ma-lc-2.png",
+    "xws": "malc2"
+  },
+  {
+    "name": "ma-lc-3",
+    "points": 137,
+    "image": "monster-ability-cards/living-corpse/ma-lc-3.png",
+    "xws": "malc3"
+  },
+  {
+    "name": "ma-lc-4",
+    "points": 138,
+    "image": "monster-ability-cards/living-corpse/ma-lc-4.png",
+    "xws": "malc4"
+  },
+  {
+    "name": "ma-lc-5",
+    "points": 139,
+    "image": "monster-ability-cards/living-corpse/ma-lc-5.png",
+    "xws": "malc5"
+  },
+  {
+    "name": "ma-lc-6",
+    "points": 140,
+    "image": "monster-ability-cards/living-corpse/ma-lc-6.png",
+    "xws": "malc6"
+  },
+  {
+    "name": "ma-lc-7",
+    "points": 141,
+    "image": "monster-ability-cards/living-corpse/ma-lc-7.png",
+    "xws": "malc7"
+  },
+  {
+    "name": "ma-lc-8",
+    "points": 142,
+    "image": "monster-ability-cards/living-corpse/ma-lc-8.png",
+    "xws": "malc8"
+  },
+  {
+    "name": "ma-lc-back",
+    "points": 143,
+    "image": "monster-ability-cards/living-corpse/ma-lc-back.png",
+    "xws": "malcback"
+  },
+  {
+    "name": "ma-ls-1",
+    "points": 144,
+    "image": "monster-ability-cards/living-spirit/ma-ls-1.png",
+    "xws": "mals1"
+  },
+  {
+    "name": "ma-ls-2",
+    "points": 145,
+    "image": "monster-ability-cards/living-spirit/ma-ls-2.png",
+    "xws": "mals2"
+  },
+  {
+    "name": "ma-ls-3",
+    "points": 146,
+    "image": "monster-ability-cards/living-spirit/ma-ls-3.png",
+    "xws": "mals3"
+  },
+  {
+    "name": "ma-ls-4",
+    "points": 147,
+    "image": "monster-ability-cards/living-spirit/ma-ls-4.png",
+    "xws": "mals4"
+  },
+  {
+    "name": "ma-ls-5",
+    "points": 148,
+    "image": "monster-ability-cards/living-spirit/ma-ls-5.png",
+    "xws": "mals5"
+  },
+  {
+    "name": "ma-ls-6",
+    "points": 149,
+    "image": "monster-ability-cards/living-spirit/ma-ls-6.png",
+    "xws": "mals6"
+  },
+  {
+    "name": "ma-ls-7",
+    "points": 150,
+    "image": "monster-ability-cards/living-spirit/ma-ls-7.png",
+    "xws": "mals7"
+  },
+  {
+    "name": "ma-ls-8",
+    "points": 151,
+    "image": "monster-ability-cards/living-spirit/ma-ls-8.png",
+    "xws": "mals8"
+  },
+  {
+    "name": "ma-ls-back",
+    "points": 152,
+    "image": "monster-ability-cards/living-spirit/ma-ls-back.png",
+    "xws": "malsback"
+  },
+  {
+    "name": "ma-lu-1",
+    "points": 153,
+    "image": "monster-ability-cards/lurker/ma-lu-1.png",
+    "xws": "malu1"
+  },
+  {
+    "name": "ma-lu-2",
+    "points": 154,
+    "image": "monster-ability-cards/lurker/ma-lu-2.png",
+    "xws": "malu2"
+  },
+  {
+    "name": "ma-lu-3",
+    "points": 155,
+    "image": "monster-ability-cards/lurker/ma-lu-3.png",
+    "xws": "malu3"
+  },
+  {
+    "name": "ma-lu-4",
+    "points": 156,
+    "image": "monster-ability-cards/lurker/ma-lu-4.png",
+    "xws": "malu4"
+  },
+  {
+    "name": "ma-lu-5",
+    "points": 157,
+    "image": "monster-ability-cards/lurker/ma-lu-5.png",
+    "xws": "malu5"
+  },
+  {
+    "name": "ma-lu-6",
+    "points": 158,
+    "image": "monster-ability-cards/lurker/ma-lu-6.png",
+    "xws": "malu6"
+  },
+  {
+    "name": "ma-lu-7",
+    "points": 159,
+    "image": "monster-ability-cards/lurker/ma-lu-7.png",
+    "xws": "malu7"
+  },
+  {
+    "name": "ma-lu-8",
+    "points": 160,
+    "image": "monster-ability-cards/lurker/ma-lu-8.png",
+    "xws": "malu8"
+  },
+  {
+    "name": "ma-lu-back",
+    "points": 161,
+    "image": "monster-ability-cards/lurker/ma-lu-back.png",
+    "xws": "maluback"
+  },
+  {
+    "name": "ma-nd-1",
+    "points": 162,
+    "image": "monster-ability-cards/night-demon/ma-nd-1.png",
+    "xws": "mand1"
+  },
+  {
+    "name": "ma-nd-2",
+    "points": 163,
+    "image": "monster-ability-cards/night-demon/ma-nd-2.png",
+    "xws": "mand2"
+  },
+  {
+    "name": "ma-nd-3",
+    "points": 164,
+    "image": "monster-ability-cards/night-demon/ma-nd-3.png",
+    "xws": "mand3"
+  },
+  {
+    "name": "ma-nd-4",
+    "points": 165,
+    "image": "monster-ability-cards/night-demon/ma-nd-4.png",
+    "xws": "mand4"
+  },
+  {
+    "name": "ma-nd-5",
+    "points": 166,
+    "image": "monster-ability-cards/night-demon/ma-nd-5.png",
+    "xws": "mand5"
+  },
+  {
+    "name": "ma-nd-6",
+    "points": 167,
+    "image": "monster-ability-cards/night-demon/ma-nd-6.png",
+    "xws": "mand6"
+  },
+  {
+    "name": "ma-nd-7",
+    "points": 168,
+    "image": "monster-ability-cards/night-demon/ma-nd-7.png",
+    "xws": "mand7"
+  },
+  {
+    "name": "ma-nd-8",
+    "points": 169,
+    "image": "monster-ability-cards/night-demon/ma-nd-8.png",
+    "xws": "mand8"
+  },
+  {
+    "name": "ma-nd-back",
+    "points": 170,
+    "image": "monster-ability-cards/night-demon/ma-nd-back.png",
+    "xws": "mandback"
+  },
+  {
+    "name": "ma-oo-1",
+    "points": 171,
+    "image": "monster-ability-cards/ooze/ma-oo-1.png",
+    "xws": "maoo1"
+  },
+  {
+    "name": "ma-oo-2",
+    "points": 172,
+    "image": "monster-ability-cards/ooze/ma-oo-2.png",
+    "xws": "maoo2"
+  },
+  {
+    "name": "ma-oo-3",
+    "points": 173,
+    "image": "monster-ability-cards/ooze/ma-oo-3.png",
+    "xws": "maoo3"
+  },
+  {
+    "name": "ma-oo-4",
+    "points": 174,
+    "image": "monster-ability-cards/ooze/ma-oo-4.png",
+    "xws": "maoo4"
+  },
+  {
+    "name": "ma-oo-5",
+    "points": 175,
+    "image": "monster-ability-cards/ooze/ma-oo-5.png",
+    "xws": "maoo5"
+  },
+  {
+    "name": "ma-oo-6",
+    "points": 176,
+    "image": "monster-ability-cards/ooze/ma-oo-6.png",
+    "xws": "maoo6"
+  },
+  {
+    "name": "ma-oo-7",
+    "points": 177,
+    "image": "monster-ability-cards/ooze/ma-oo-7.png",
+    "xws": "maoo7"
+  },
+  {
+    "name": "ma-oo-8",
+    "points": 178,
+    "image": "monster-ability-cards/ooze/ma-oo-8.png",
+    "xws": "maoo8"
+  },
+  {
+    "name": "ma-oo-back",
+    "points": 179,
+    "image": "monster-ability-cards/ooze/ma-oo-back.png",
+    "xws": "maooback"
+  },
+  {
+    "name": "ma-rd-1",
+    "points": 180,
+    "image": "monster-ability-cards/rending-drake/ma-rd-1.png",
+    "xws": "mard1"
+  },
+  {
+    "name": "ma-rd-2",
+    "points": 181,
+    "image": "monster-ability-cards/rending-drake/ma-rd-2.png",
+    "xws": "mard2"
+  },
+  {
+    "name": "ma-rd-3",
+    "points": 182,
+    "image": "monster-ability-cards/rending-drake/ma-rd-3.png",
+    "xws": "mard3"
+  },
+  {
+    "name": "ma-rd-4",
+    "points": 183,
+    "image": "monster-ability-cards/rending-drake/ma-rd-4.png",
+    "xws": "mard4"
+  },
+  {
+    "name": "ma-rd-5",
+    "points": 184,
+    "image": "monster-ability-cards/rending-drake/ma-rd-5.png",
+    "xws": "mard5"
+  },
+  {
+    "name": "ma-rd-6",
+    "points": 185,
+    "image": "monster-ability-cards/rending-drake/ma-rd-6.png",
+    "xws": "mard6"
+  },
+  {
+    "name": "ma-rd-7",
+    "points": 186,
+    "image": "monster-ability-cards/rending-drake/ma-rd-7.png",
+    "xws": "mard7"
+  },
+  {
+    "name": "ma-rd-8",
+    "points": 187,
+    "image": "monster-ability-cards/rending-drake/ma-rd-8.png",
+    "xws": "mard8"
+  },
+  {
+    "name": "ma-rd-back",
+    "points": 188,
+    "image": "monster-ability-cards/rending-drake/ma-rd-back.png",
+    "xws": "mardback"
+  },
+  {
+    "name": "ma-si-1",
+    "points": 189,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-1.png",
+    "xws": "masi1"
+  },
+  {
+    "name": "ma-si-2",
+    "points": 190,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-2.png",
+    "xws": "masi2"
+  },
+  {
+    "name": "ma-si-3",
+    "points": 191,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-3.png",
+    "xws": "masi3"
+  },
+  {
+    "name": "ma-si-4",
+    "points": 192,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-4.png",
+    "xws": "masi4"
+  },
+  {
+    "name": "ma-si-5",
+    "points": 193,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-5.png",
+    "xws": "masi5"
+  },
+  {
+    "name": "ma-si-6",
+    "points": 194,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-6.png",
+    "xws": "masi6"
+  },
+  {
+    "name": "ma-si-7",
+    "points": 195,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-7.png",
+    "xws": "masi7"
+  },
+  {
+    "name": "ma-si-8",
+    "points": 196,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-8.png",
+    "xws": "masi8"
+  },
+  {
+    "name": "ma-si-back",
+    "points": 197,
+    "image": "monster-ability-cards/savvas-icestorm/ma-si-back.png",
+    "xws": "masiback"
+  },
+  {
+    "name": "ma-sl-1",
+    "points": 198,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-1.png",
+    "xws": "masl1"
+  },
+  {
+    "name": "ma-sl-2",
+    "points": 199,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-2.png",
+    "xws": "masl2"
+  },
+  {
+    "name": "ma-sl-3",
+    "points": 200,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-3.png",
+    "xws": "masl3"
+  },
+  {
+    "name": "ma-sl-4",
+    "points": 201,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-4.png",
+    "xws": "masl4"
+  },
+  {
+    "name": "ma-sl-5",
+    "points": 202,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-5.png",
+    "xws": "masl5"
+  },
+  {
+    "name": "ma-sl-6",
+    "points": 203,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-6.png",
+    "xws": "masl6"
+  },
+  {
+    "name": "ma-sl-7",
+    "points": 204,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-7.png",
+    "xws": "masl7"
+  },
+  {
+    "name": "ma-sl-8",
+    "points": 205,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-8.png",
+    "xws": "masl8"
+  },
+  {
+    "name": "ma-sl-back",
+    "points": 206,
+    "image": "monster-ability-cards/savvas-lavaflow/ma-sl-back.png",
+    "xws": "maslback"
+  },
+  {
+    "name": "ma-sc-1",
+    "points": 207,
+    "image": "monster-ability-cards/scout/ma-sc-1.png",
+    "xws": "masc1"
+  },
+  {
+    "name": "ma-sc-2",
+    "points": 208,
+    "image": "monster-ability-cards/scout/ma-sc-2.png",
+    "xws": "masc2"
+  },
+  {
+    "name": "ma-sc-3",
+    "points": 209,
+    "image": "monster-ability-cards/scout/ma-sc-3.png",
+    "xws": "masc3"
+  },
+  {
+    "name": "ma-sc-4",
+    "points": 210,
+    "image": "monster-ability-cards/scout/ma-sc-4.png",
+    "xws": "masc4"
+  },
+  {
+    "name": "ma-sc-5",
+    "points": 211,
+    "image": "monster-ability-cards/scout/ma-sc-5.png",
+    "xws": "masc5"
+  },
+  {
+    "name": "ma-sc-6",
+    "points": 212,
+    "image": "monster-ability-cards/scout/ma-sc-6.png",
+    "xws": "masc6"
+  },
+  {
+    "name": "ma-sc-7",
+    "points": 213,
+    "image": "monster-ability-cards/scout/ma-sc-7.png",
+    "xws": "masc7"
+  },
+  {
+    "name": "ma-sc-8",
+    "points": 214,
+    "image": "monster-ability-cards/scout/ma-sc-8.png",
+    "xws": "masc8"
+  },
+  {
+    "name": "ma-sc-back",
+    "points": 215,
+    "image": "monster-ability-cards/scout/ma-sc-back.png",
+    "xws": "mascback"
+  },
+  {
+    "name": "ma-sh-1",
+    "points": 216,
+    "image": "monster-ability-cards/shaman/ma-sh-1.png",
+    "xws": "mash1"
+  },
+  {
+    "name": "ma-sh-2",
+    "points": 217,
+    "image": "monster-ability-cards/shaman/ma-sh-2.png",
+    "xws": "mash2"
+  },
+  {
+    "name": "ma-sh-3",
+    "points": 218,
+    "image": "monster-ability-cards/shaman/ma-sh-3.png",
+    "xws": "mash3"
+  },
+  {
+    "name": "ma-sh-4",
+    "points": 219,
+    "image": "monster-ability-cards/shaman/ma-sh-4.png",
+    "xws": "mash4"
+  },
+  {
+    "name": "ma-sh-5",
+    "points": 220,
+    "image": "monster-ability-cards/shaman/ma-sh-5.png",
+    "xws": "mash5"
+  },
+  {
+    "name": "ma-sh-6",
+    "points": 221,
+    "image": "monster-ability-cards/shaman/ma-sh-6.png",
+    "xws": "mash6"
+  },
+  {
+    "name": "ma-sh-7",
+    "points": 222,
+    "image": "monster-ability-cards/shaman/ma-sh-7.png",
+    "xws": "mash7"
+  },
+  {
+    "name": "ma-sh-8",
+    "points": 223,
+    "image": "monster-ability-cards/shaman/ma-sh-8.png",
+    "xws": "mash8"
+  },
+  {
+    "name": "ma-sh-back",
+    "points": 224,
+    "image": "monster-ability-cards/shaman/ma-sh-back.png",
+    "xws": "mashback"
+  },
+  {
+    "name": "ma-spd-1",
+    "points": 225,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-1.png",
+    "xws": "maspd1"
+  },
+  {
+    "name": "ma-spd-2",
+    "points": 226,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-2.png",
+    "xws": "maspd2"
+  },
+  {
+    "name": "ma-spd-3",
+    "points": 227,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-3.png",
+    "xws": "maspd3"
+  },
+  {
+    "name": "ma-spd-4",
+    "points": 228,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-4.png",
+    "xws": "maspd4"
+  },
+  {
+    "name": "ma-spd-5",
+    "points": 229,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-5.png",
+    "xws": "maspd5"
+  },
+  {
+    "name": "ma-spd-6",
+    "points": 230,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-6.png",
+    "xws": "maspd6"
+  },
+  {
+    "name": "ma-spd-7",
+    "points": 231,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-7.png",
+    "xws": "maspd7"
+  },
+  {
+    "name": "ma-spd-8",
+    "points": 232,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-8.png",
+    "xws": "maspd8"
+  },
+  {
+    "name": "ma-spd-back",
+    "points": 233,
+    "image": "monster-ability-cards/spitting-drake/ma-spd-back.png",
+    "xws": "maspdback"
+  },
+  {
+    "name": "ma-sg-1",
+    "points": 234,
+    "image": "monster-ability-cards/stone-golem/ma-sg-1.png",
+    "xws": "masg1"
+  },
+  {
+    "name": "ma-sg-2",
+    "points": 235,
+    "image": "monster-ability-cards/stone-golem/ma-sg-2.png",
+    "xws": "masg2"
+  },
+  {
+    "name": "ma-sg-3",
+    "points": 236,
+    "image": "monster-ability-cards/stone-golem/ma-sg-3.png",
+    "xws": "masg3"
+  },
+  {
+    "name": "ma-sg-4",
+    "points": 237,
+    "image": "monster-ability-cards/stone-golem/ma-sg-4.png",
+    "xws": "masg4"
+  },
+  {
+    "name": "ma-sg-5",
+    "points": 238,
+    "image": "monster-ability-cards/stone-golem/ma-sg-5.png",
+    "xws": "masg5"
+  },
+  {
+    "name": "ma-sg-6",
+    "points": 239,
+    "image": "monster-ability-cards/stone-golem/ma-sg-6.png",
+    "xws": "masg6"
+  },
+  {
+    "name": "ma-sg-7",
+    "points": 240,
+    "image": "monster-ability-cards/stone-golem/ma-sg-7.png",
+    "xws": "masg7"
+  },
+  {
+    "name": "ma-sg-8",
+    "points": 241,
+    "image": "monster-ability-cards/stone-golem/ma-sg-8.png",
+    "xws": "masg8"
+  },
+  {
+    "name": "ma-sg-back",
+    "points": 242,
+    "image": "monster-ability-cards/stone-golem/ma-sg-back.png",
+    "xws": "masgback"
+  },
+  {
+    "name": "ma-sud-1",
+    "points": 243,
+    "image": "monster-ability-cards/sun-demon/ma-sud-1.png",
+    "xws": "masud1"
+  },
+  {
+    "name": "ma-sud-2",
+    "points": 244,
+    "image": "monster-ability-cards/sun-demon/ma-sud-2.png",
+    "xws": "masud2"
+  },
+  {
+    "name": "ma-sud-3",
+    "points": 245,
+    "image": "monster-ability-cards/sun-demon/ma-sud-3.png",
+    "xws": "masud3"
+  },
+  {
+    "name": "ma-sud-4",
+    "points": 246,
+    "image": "monster-ability-cards/sun-demon/ma-sud-4.png",
+    "xws": "masud4"
+  },
+  {
+    "name": "ma-sud-5",
+    "points": 247,
+    "image": "monster-ability-cards/sun-demon/ma-sud-5.png",
+    "xws": "masud5"
+  },
+  {
+    "name": "ma-sud-6",
+    "points": 248,
+    "image": "monster-ability-cards/sun-demon/ma-sud-6.png",
+    "xws": "masud6"
+  },
+  {
+    "name": "ma-sud-7",
+    "points": 249,
+    "image": "monster-ability-cards/sun-demon/ma-sud-7.png",
+    "xws": "masud7"
+  },
+  {
+    "name": "ma-sud-8",
+    "points": 250,
+    "image": "monster-ability-cards/sun-demon/ma-sud-8.png",
+    "xws": "masud8"
+  },
+  {
+    "name": "ma-sud-back",
+    "points": 251,
+    "image": "monster-ability-cards/sun-demon/ma-sud-back.png",
+    "xws": "masudback"
+  },
+  {
+    "name": "ma-wd-1",
+    "points": 252,
+    "image": "monster-ability-cards/wind-demon/ma-wd-1.png",
+    "xws": "mawd1"
+  },
+  {
+    "name": "ma-wd-2",
+    "points": 253,
+    "image": "monster-ability-cards/wind-demon/ma-wd-2.png",
+    "xws": "mawd2"
+  },
+  {
+    "name": "ma-wd-3",
+    "points": 254,
+    "image": "monster-ability-cards/wind-demon/ma-wd-3.png",
+    "xws": "mawd3"
+  },
+  {
+    "name": "ma-wd-4",
+    "points": 255,
+    "image": "monster-ability-cards/wind-demon/ma-wd-4.png",
+    "xws": "mawd4"
+  },
+  {
+    "name": "ma-wd-5",
+    "points": 256,
+    "image": "monster-ability-cards/wind-demon/ma-wd-5.png",
+    "xws": "mawd5"
+  },
+  {
+    "name": "ma-wd-6",
+    "points": 257,
+    "image": "monster-ability-cards/wind-demon/ma-wd-6.png",
+    "xws": "mawd6"
+  },
+  {
+    "name": "ma-wd-7",
+    "points": 258,
+    "image": "monster-ability-cards/wind-demon/ma-wd-7.png",
+    "xws": "mawd7"
+  },
+  {
+    "name": "ma-wd-8",
+    "points": 259,
+    "image": "monster-ability-cards/wind-demon/ma-wd-8.png",
+    "xws": "mawd8"
+  },
+  {
+    "name": "ma-wd-back",
+    "points": 260,
+    "image": "monster-ability-cards/wind-demon/ma-wd-back.png",
+    "xws": "mawdback"
+  },
+  {
+    "name": "ma-ab-1",
+    "points": 261,
+    "image": "monster-ability-cards/ashblade/ma-ab-1.png",
+    "xws": "maab1"
+  },
+  {
+    "name": "ma-ab-2",
+    "points": 262,
+    "image": "monster-ability-cards/ashblade/ma-ab-2.png",
+    "xws": "maab2"
+  },
+  {
+    "name": "ma-ab-3",
+    "points": 263,
+    "image": "monster-ability-cards/ashblade/ma-ab-3.png",
+    "xws": "maab3"
+  },
+  {
+    "name": "ma-ab-4",
+    "points": 264,
+    "image": "monster-ability-cards/ashblade/ma-ab-4.png",
+    "xws": "maab4"
+  },
+  {
+    "name": "ma-ab-5",
+    "points": 265,
+    "image": "monster-ability-cards/ashblade/ma-ab-5.png",
+    "xws": "maab5"
+  },
+  {
+    "name": "ma-ab-6",
+    "points": 266,
+    "image": "monster-ability-cards/ashblade/ma-ab-6.png",
+    "xws": "maab6"
+  },
+  {
+    "name": "ma-ab-7",
+    "points": 267,
+    "image": "monster-ability-cards/ashblade/ma-ab-7.png",
+    "xws": "maab7"
+  },
+  {
+    "name": "ma-ab-8",
+    "points": 268,
+    "image": "monster-ability-cards/ashblade/ma-ab-8.png",
+    "xws": "maab8"
+  },
+  {
+    "name": "ma-ab-back",
+    "points": 269,
+    "image": "monster-ability-cards/ashblade/ma-ab-back.png",
+    "xws": "maabback"
+  },
+  {
+    "name": "ma-sv-1",
+    "points": 270,
+    "image": "monster-ability-cards/savage/ma-sv-1.png",
+    "xws": "masv1"
+  },
+  {
+    "name": "ma-sv-2",
+    "points": 271,
+    "image": "monster-ability-cards/savage/ma-sv-2.png",
+    "xws": "masv2"
+  },
+  {
+    "name": "ma-sv-3",
+    "points": 272,
+    "image": "monster-ability-cards/savage/ma-sv-3.png",
+    "xws": "masv3"
+  },
+  {
+    "name": "ma-sv-4",
+    "points": 273,
+    "image": "monster-ability-cards/savage/ma-sv-4.png",
+    "xws": "masv4"
+  },
+  {
+    "name": "ma-sv-5",
+    "points": 274,
+    "image": "monster-ability-cards/savage/ma-sv-5.png",
+    "xws": "masv5"
+  },
+  {
+    "name": "ma-sv-6",
+    "points": 275,
+    "image": "monster-ability-cards/savage/ma-sv-6.png",
+    "xws": "masv6"
+  },
+  {
+    "name": "ma-sv-7",
+    "points": 276,
+    "image": "monster-ability-cards/savage/ma-sv-7.png",
+    "xws": "masv7"
+  },
+  {
+    "name": "ma-sv-8",
+    "points": 277,
+    "image": "monster-ability-cards/savage/ma-sv-8.png",
+    "xws": "masv8"
+  },
+  {
+    "name": "ma-sv-back",
+    "points": 278,
+    "image": "monster-ability-cards/savage/ma-sv-back.png",
+    "xws": "masvback"
+  },
+  {
+    "name": "ma-tr-1",
+    "points": 279,
+    "image": "monster-ability-cards/tracker/ma-tr-1.png",
+    "xws": "matr1"
+  },
+  {
+    "name": "ma-tr-2",
+    "points": 280,
+    "image": "monster-ability-cards/tracker/ma-tr-2.png",
+    "xws": "matr2"
+  },
+  {
+    "name": "ma-tr-3",
+    "points": 281,
+    "image": "monster-ability-cards/tracker/ma-tr-3.png",
+    "xws": "matr3"
+  },
+  {
+    "name": "ma-tr-4",
+    "points": 282,
+    "image": "monster-ability-cards/tracker/ma-tr-4.png",
+    "xws": "matr4"
+  },
+  {
+    "name": "ma-tr-5",
+    "points": 283,
+    "image": "monster-ability-cards/tracker/ma-tr-5.png",
+    "xws": "matr5"
+  },
+  {
+    "name": "ma-tr-6",
+    "points": 284,
+    "image": "monster-ability-cards/tracker/ma-tr-6.png",
+    "xws": "matr6"
+  },
+  {
+    "name": "ma-tr-7",
+    "points": 285,
+    "image": "monster-ability-cards/tracker/ma-tr-7.png",
+    "xws": "matr7"
+  },
+  {
+    "name": "ma-tr-8",
+    "points": 286,
+    "image": "monster-ability-cards/tracker/ma-tr-8.png",
+    "xws": "matr8"
+  },
+  {
+    "name": "ma-tr-back",
+    "points": 287,
+    "image": "monster-ability-cards/tracker/ma-tr-back.png",
+    "xws": "matrback"
+  },
+  {
+    "name": "blistering heat",
+    "points": 288,
+    "image": "monster-ability-cards/manifestation-of-corruption/blistering-heat.png",
+    "xws": "blisteringheat"
+  },
+  {
+    "name": "corrupting presence",
+    "points": 289,
+    "image": "monster-ability-cards/manifestation-of-corruption/corrupting-presence.png",
+    "xws": "corruptingpresence"
+  },
+  {
+    "name": "endless legions",
+    "points": 290,
+    "image": "monster-ability-cards/manifestation-of-corruption/endless-legions.png",
+    "xws": "endlesslegions"
+  },
+  {
+    "name": "flame lance",
+    "points": 291,
+    "image": "monster-ability-cards/manifestation-of-corruption/flame-lance.png",
+    "xws": "flamelance"
+  },
+  {
+    "name": "harsh entrapment",
+    "points": 292,
+    "image": "monster-ability-cards/manifestation-of-corruption/harsh-entrapment.png",
+    "xws": "harshentrapment"
+  },
+  {
+    "name": "heed my call",
+    "points": 293,
+    "image": "monster-ability-cards/manifestation-of-corruption/heed-my-call.png",
+    "xws": "heedmycall"
+  },
+  {
+    "name": "legendary - domination",
+    "points": 294,
+    "image": "monster-ability-cards/manifestation-of-corruption/legendary-domination.png",
+    "xws": "legendarydomination"
+  },
+  {
+    "name": "legendary - gloom",
+    "points": 295,
+    "image": "monster-ability-cards/manifestation-of-corruption/legendary-gloom.png",
+    "xws": "legendarygloom"
+  },
+  {
+    "name": "legendary - shadows",
+    "points": 296,
+    "image": "monster-ability-cards/manifestation-of-corruption/legendary-shadows.png",
+    "xws": "legendaryshadows"
+  },
+  {
+    "name": "legendary - void",
+    "points": 297,
+    "image": "monster-ability-cards/manifestation-of-corruption/legendary-void.png",
+    "xws": "legendaryvoid"
+  },
+  {
+    "name": "lure them in",
+    "points": 298,
+    "image": "monster-ability-cards/manifestation-of-corruption/lure-them-in.png",
+    "xws": "lurethemin"
+  },
+  {
+    "name": "marked for death",
+    "points": 299,
+    "image": "monster-ability-cards/manifestation-of-corruption/marked-for-death.png",
+    "xws": "markedfordeath"
+  },
+  {
+    "name": "mc-back",
+    "points": 300,
+    "image": "monster-ability-cards/manifestation-of-corruption/mc-back.png",
+    "xws": "mcback"
+  },
+  {
+    "name": "nightmare spheres",
+    "points": 301,
+    "image": "monster-ability-cards/manifestation-of-corruption/nightmare-spheres.png",
+    "xws": "nightmarespheres"
+  },
+  {
+    "name": "plague their dreams",
+    "points": 302,
+    "image": "monster-ability-cards/manifestation-of-corruption/plague-their-dreams.png",
+    "xws": "plaguetheirdreams"
+  },
+  {
+    "name": "pulse of malice",
+    "points": 303,
+    "image": "monster-ability-cards/manifestation-of-corruption/pulse-of-malice.png",
+    "xws": "pulseofmalice"
+  },
+  {
+    "name": "searing vapors",
+    "points": 304,
+    "image": "monster-ability-cards/manifestation-of-corruption/searing vapors.png",
+    "xws": "searingvapors"
+  },
+  {
+    "name": "toxic blast",
+    "points": 305,
+    "image": "monster-ability-cards/manifestation-of-corruption/toxic-blast.png",
+    "xws": "toxicblast"
+  },
+  {
+    "name": "unfathomable fortitude",
+    "points": 306,
+    "image": "monster-ability-cards/manifestation-of-corruption/unfathomable-fortitude.png",
+    "xws": "unfathomablefortitude"
+  },
+  {
+    "name": "what's yours is mine",
+    "points": 307,
+    "image": "monster-ability-cards/manifestation-of-corruption/whats-yours-is-mine.png",
+    "xws": "whatsyoursismine"
+  },
+  {
+    "name": "you dare to defy me",
+    "points": 308,
+    "image": "monster-ability-cards/manifestation-of-corruption/you-dare-to-defy-me.png",
+    "xws": "youdaretodefyme"
+  }
+]

--- a/data/monster-stat-cards.json
+++ b/data/monster-stat-cards.json
@@ -1,0 +1,650 @@
+[
+  {
+    "name": "ancient artillery",
+    "points": 0,
+    "image": "monster-stat-cards/ancient-artillery-0.png",
+    "xws": "ancientartillery"
+  },
+  {
+    "name": "ancient artillery",
+    "points": 1,
+    "image": "monster-stat-cards/ancient-artillery-4.png",
+    "xws": "ancientartillery"
+  },
+  {
+    "name": "bandit archer",
+    "points": 2,
+    "image": "monster-stat-cards/bandit-archer-0.png",
+    "xws": "banditarcher"
+  },
+  {
+    "name": "bandit archer",
+    "points": 3,
+    "image": "monster-stat-cards/bandit-archer-4.png",
+    "xws": "banditarcher"
+  },
+  {
+    "name": "bandit commander",
+    "points": 4,
+    "image": "monster-stat-cards/bandit-commander-0.png",
+    "xws": "banditcommander"
+  },
+  {
+    "name": "bandit commander",
+    "points": 5,
+    "image": "monster-stat-cards/bandit-commander-4.png",
+    "xws": "banditcommander"
+  },
+  {
+    "name": "bandit guard",
+    "points": 6,
+    "image": "monster-stat-cards/bandit-guard-0.png",
+    "xws": "banditguard"
+  },
+  {
+    "name": "bandit guard",
+    "points": 7,
+    "image": "monster-stat-cards/bandit-guard-4.png",
+    "xws": "banditguard"
+  },
+  {
+    "name": "black imp",
+    "points": 8,
+    "image": "monster-stat-cards/black-imp-0.png",
+    "xws": "blackimp"
+  },
+  {
+    "name": "black imp",
+    "points": 9,
+    "image": "monster-stat-cards/black-imp-4.png",
+    "xws": "blackimp"
+  },
+  {
+    "name": "captain of the guard",
+    "points": 10,
+    "image": "monster-stat-cards/captain-of-the-guard-0.png",
+    "xws": "captainoftheguard"
+  },
+  {
+    "name": "captain of the guard",
+    "points": 11,
+    "image": "monster-stat-cards/captain-of-the-guard-4.png",
+    "xws": "captainoftheguard"
+  },
+  {
+    "name": "cave bear",
+    "points": 12,
+    "image": "monster-stat-cards/cave-bear-0.png",
+    "xws": "cavebear"
+  },
+  {
+    "name": "cave bear",
+    "points": 13,
+    "image": "monster-stat-cards/cave-bear-4.png",
+    "xws": "cavebear"
+  },
+  {
+    "name": "city archer",
+    "points": 14,
+    "image": "monster-stat-cards/city-archer-0.png",
+    "xws": "cityarcher"
+  },
+  {
+    "name": "city archer",
+    "points": 15,
+    "image": "monster-stat-cards/city-archer-4.png",
+    "xws": "cityarcher"
+  },
+  {
+    "name": "city guard",
+    "points": 16,
+    "image": "monster-stat-cards/city-guard-0.png",
+    "xws": "cityguard"
+  },
+  {
+    "name": "city guard",
+    "points": 17,
+    "image": "monster-stat-cards/city-guard-4.png",
+    "xws": "cityguard"
+  },
+  {
+    "name": "cultist",
+    "points": 18,
+    "image": "monster-stat-cards/cultist-0.png",
+    "xws": "cultist"
+  },
+  {
+    "name": "cultist",
+    "points": 19,
+    "image": "monster-stat-cards/cultist-4.png",
+    "xws": "cultist"
+  },
+  {
+    "name": "dark rider",
+    "points": 20,
+    "image": "monster-stat-cards/dark-rider-0.png",
+    "xws": "darkrider"
+  },
+  {
+    "name": "dark rider",
+    "points": 21,
+    "image": "monster-stat-cards/dark-rider-4.png",
+    "xws": "darkrider"
+  },
+  {
+    "name": "deep terror",
+    "points": 22,
+    "image": "monster-stat-cards/deep-terror-0.png",
+    "xws": "deepterror"
+  },
+  {
+    "name": "deep terror",
+    "points": 23,
+    "image": "monster-stat-cards/deep-terror-4.png",
+    "xws": "deepterror"
+  },
+  {
+    "name": "earth demon",
+    "points": 24,
+    "image": "monster-stat-cards/earth-demon-0.png",
+    "xws": "earthdemon"
+  },
+  {
+    "name": "earth demon",
+    "points": 25,
+    "image": "monster-stat-cards/earth-demon-4.png",
+    "xws": "earthdemon"
+  },
+  {
+    "name": "elder drake",
+    "points": 26,
+    "image": "monster-stat-cards/elder-drake-0.png",
+    "xws": "elderdrake"
+  },
+  {
+    "name": "elder drake",
+    "points": 27,
+    "image": "monster-stat-cards/elder-drake-4.png",
+    "xws": "elderdrake"
+  },
+  {
+    "name": "flame demon",
+    "points": 28,
+    "image": "monster-stat-cards/flame-demon-0.png",
+    "xws": "flamedemon"
+  },
+  {
+    "name": "flame demon",
+    "points": 29,
+    "image": "monster-stat-cards/flame-demon-4.png",
+    "xws": "flamedemon"
+  },
+  {
+    "name": "forest imp",
+    "points": 30,
+    "image": "monster-stat-cards/forest-imp-0.png",
+    "xws": "forestimp"
+  },
+  {
+    "name": "forest imp",
+    "points": 31,
+    "image": "monster-stat-cards/forest-imp-4.png",
+    "xws": "forestimp"
+  },
+  {
+    "name": "frost demon",
+    "points": 32,
+    "image": "monster-stat-cards/frost-demon-0.png",
+    "xws": "frostdemon"
+  },
+  {
+    "name": "frost demon",
+    "points": 33,
+    "image": "monster-stat-cards/frost-demon-4.png",
+    "xws": "frostdemon"
+  },
+  {
+    "name": "giant viper",
+    "points": 34,
+    "image": "monster-stat-cards/giant-viper-0.png",
+    "xws": "giantviper"
+  },
+  {
+    "name": "giant viper",
+    "points": 35,
+    "image": "monster-stat-cards/giant-viper-4.png",
+    "xws": "giantviper"
+  },
+  {
+    "name": "harrower infester",
+    "points": 36,
+    "image": "monster-stat-cards/harrower-infester-0.png",
+    "xws": "harrowerinfester"
+  },
+  {
+    "name": "harrower infester",
+    "points": 37,
+    "image": "monster-stat-cards/harrower-infester-4.png",
+    "xws": "harrowerinfester"
+  },
+  {
+    "name": "hound",
+    "points": 38,
+    "image": "monster-stat-cards/hound-0.png",
+    "xws": "hound"
+  },
+  {
+    "name": "hound",
+    "points": 39,
+    "image": "monster-stat-cards/hound-4.png",
+    "xws": "hound"
+  },
+  {
+    "name": "inox archer",
+    "points": 40,
+    "image": "monster-stat-cards/inox-archer-0.png",
+    "xws": "inoxarcher"
+  },
+  {
+    "name": "inox archer",
+    "points": 41,
+    "image": "monster-stat-cards/inox-archer-4.png",
+    "xws": "inoxarcher"
+  },
+  {
+    "name": "inox bodyguard",
+    "points": 42,
+    "image": "monster-stat-cards/inox-bodyguard-0.png",
+    "xws": "inoxbodyguard"
+  },
+  {
+    "name": "inox bodyguard",
+    "points": 43,
+    "image": "monster-stat-cards/inox-bodyguard-4.png",
+    "xws": "inoxbodyguard"
+  },
+  {
+    "name": "inox guard",
+    "points": 44,
+    "image": "monster-stat-cards/inox-guard-0.png",
+    "xws": "inoxguard"
+  },
+  {
+    "name": "inox guard",
+    "points": 45,
+    "image": "monster-stat-cards/inox-guard-4.png",
+    "xws": "inoxguard"
+  },
+  {
+    "name": "inox shaman",
+    "points": 46,
+    "image": "monster-stat-cards/inox-shaman-0.png",
+    "xws": "inoxshaman"
+  },
+  {
+    "name": "inox shaman",
+    "points": 47,
+    "image": "monster-stat-cards/inox-shaman-4.png",
+    "xws": "inoxshaman"
+  },
+  {
+    "name": "jekserah",
+    "points": 48,
+    "image": "monster-stat-cards/jekserah-0.png",
+    "xws": "jekserah"
+  },
+  {
+    "name": "jekserah",
+    "points": 49,
+    "image": "monster-stat-cards/jekserah-4.png",
+    "xws": "jekserah"
+  },
+  {
+    "name": "living bones",
+    "points": 50,
+    "image": "monster-stat-cards/living-bones-0.png",
+    "xws": "livingbones"
+  },
+  {
+    "name": "living bones",
+    "points": 51,
+    "image": "monster-stat-cards/living-bones-4.png",
+    "xws": "livingbones"
+  },
+  {
+    "name": "living corpse",
+    "points": 52,
+    "image": "monster-stat-cards/living-corpse-0.png",
+    "xws": "livingcorpse"
+  },
+  {
+    "name": "living corpse",
+    "points": 53,
+    "image": "monster-stat-cards/living-corpse-4.png",
+    "xws": "livingcorpse"
+  },
+  {
+    "name": "living spirit",
+    "points": 54,
+    "image": "monster-stat-cards/living-spirit-0.png",
+    "xws": "livingspirit"
+  },
+  {
+    "name": "living spirit",
+    "points": 55,
+    "image": "monster-stat-cards/living-spirit-4.png",
+    "xws": "livingspirit"
+  },
+  {
+    "name": "lurker",
+    "points": 56,
+    "image": "monster-stat-cards/lurker-0.png",
+    "xws": "lurker"
+  },
+  {
+    "name": "lurker",
+    "points": 57,
+    "image": "monster-stat-cards/lurker-4.png",
+    "xws": "lurker"
+  },
+  {
+    "name": "merciless overseer",
+    "points": 58,
+    "image": "monster-stat-cards/merciless-overseer-0.png",
+    "xws": "mercilessoverseer"
+  },
+  {
+    "name": "merciless overseer",
+    "points": 59,
+    "image": "monster-stat-cards/merciless-overseer-4.png",
+    "xws": "mercilessoverseer"
+  },
+  {
+    "name": "night demon",
+    "points": 60,
+    "image": "monster-stat-cards/night-demon-0.png",
+    "xws": "nightdemon"
+  },
+  {
+    "name": "night demon",
+    "points": 61,
+    "image": "monster-stat-cards/night-demon-4.png",
+    "xws": "nightdemon"
+  },
+  {
+    "name": "ooze",
+    "points": 62,
+    "image": "monster-stat-cards/ooze-0.png",
+    "xws": "ooze"
+  },
+  {
+    "name": "ooze",
+    "points": 63,
+    "image": "monster-stat-cards/ooze-4.png",
+    "xws": "ooze"
+  },
+  {
+    "name": "prime demon",
+    "points": 64,
+    "image": "monster-stat-cards/prime-demon-0.png",
+    "xws": "primedemon"
+  },
+  {
+    "name": "prime demon",
+    "points": 65,
+    "image": "monster-stat-cards/prime-demon-4.png",
+    "xws": "primedemon"
+  },
+  {
+    "name": "rending drake",
+    "points": 66,
+    "image": "monster-stat-cards/rending-drake-0.png",
+    "xws": "rendingdrake"
+  },
+  {
+    "name": "rending drake",
+    "points": 67,
+    "image": "monster-stat-cards/rending-drake-4.png",
+    "xws": "rendingdrake"
+  },
+  {
+    "name": "savvas icestorm",
+    "points": 68,
+    "image": "monster-stat-cards/savvas-icestorm-0.png",
+    "xws": "savvasicestorm"
+  },
+  {
+    "name": "savvas icestorm",
+    "points": 69,
+    "image": "monster-stat-cards/savvas-icestorm-4.png",
+    "xws": "savvasicestorm"
+  },
+  {
+    "name": "savvas lavaflow",
+    "points": 70,
+    "image": "monster-stat-cards/savvas-lavaflow-0.png",
+    "xws": "savvaslavaflow"
+  },
+  {
+    "name": "savvas lavaflow",
+    "points": 71,
+    "image": "monster-stat-cards/savvas-lavaflow-4.png",
+    "xws": "savvaslavaflow"
+  },
+  {
+    "name": "spitting drake",
+    "points": 72,
+    "image": "monster-stat-cards/spitting-drake-0.png",
+    "xws": "spittingdrake"
+  },
+  {
+    "name": "spitting drake",
+    "points": 73,
+    "image": "monster-stat-cards/spitting-drake-4.png",
+    "xws": "spittingdrake"
+  },
+  {
+    "name": "stone golem",
+    "points": 74,
+    "image": "monster-stat-cards/stone-golem-0.png",
+    "xws": "stonegolem"
+  },
+  {
+    "name": "stone golem",
+    "points": 75,
+    "image": "monster-stat-cards/stone-golem-4.png",
+    "xws": "stonegolem"
+  },
+  {
+    "name": "sun demon",
+    "points": 76,
+    "image": "monster-stat-cards/sun-demon-0.png",
+    "xws": "sundemon"
+  },
+  {
+    "name": "sun demon",
+    "points": 77,
+    "image": "monster-stat-cards/sun-demon-4.png",
+    "xws": "sundemon"
+  },
+  {
+    "name": "the betrayer",
+    "points": 78,
+    "image": "monster-stat-cards/the-betrayer-0.png",
+    "xws": "thebetrayer"
+  },
+  {
+    "name": "the betrayer",
+    "points": 79,
+    "image": "monster-stat-cards/the-betrayer-4.png",
+    "xws": "thebetrayer"
+  },
+  {
+    "name": "the colorless",
+    "points": 80,
+    "image": "monster-stat-cards/the-colorless-0.png",
+    "xws": "thecolorless"
+  },
+  {
+    "name": "the colorless",
+    "points": 81,
+    "image": "monster-stat-cards/the-colorless-4.png",
+    "xws": "thecolorless"
+  },
+  {
+    "name": "the gloom",
+    "points": 82,
+    "image": "monster-stat-cards/the-gloom-0.png",
+    "xws": "thegloom"
+  },
+  {
+    "name": "the gloom",
+    "points": 83,
+    "image": "monster-stat-cards/the-gloom-4.png",
+    "xws": "thegloom"
+  },
+  {
+    "name": "the sightless eye",
+    "points": 84,
+    "image": "monster-stat-cards/the-sightless-eye-0.png",
+    "xws": "thesightlesseye"
+  },
+  {
+    "name": "the sightless eye",
+    "points": 85,
+    "image": "monster-stat-cards/the-sightless-eye-4.png",
+    "xws": "thesightlesseye"
+  },
+  {
+    "name": "vermling scout",
+    "points": 86,
+    "image": "monster-stat-cards/vermling-scout-0.png",
+    "xws": "vermlingscout"
+  },
+  {
+    "name": "vermling scout",
+    "points": 87,
+    "image": "monster-stat-cards/vermling-scout-4.png",
+    "xws": "vermlingscout"
+  },
+  {
+    "name": "vermling shaman",
+    "points": 88,
+    "image": "monster-stat-cards/vermling-shaman-0.png",
+    "xws": "vermlingshaman"
+  },
+  {
+    "name": "vermling shaman",
+    "points": 89,
+    "image": "monster-stat-cards/vermling-shaman-4.png",
+    "xws": "vermlingshaman"
+  },
+  {
+    "name": "wind demon",
+    "points": 90,
+    "image": "monster-stat-cards/wind-demon-0.png",
+    "xws": "winddemon"
+  },
+  {
+    "name": "wind demon",
+    "points": 91,
+    "image": "monster-stat-cards/wind-demon-4.png",
+    "xws": "winddemon"
+  },
+  {
+    "name": "winged horror",
+    "points": 92,
+    "image": "monster-stat-cards/winged-horror-0.png",
+    "xws": "wingedhorror"
+  },
+  {
+    "name": "winged horror",
+    "points": 93,
+    "image": "monster-stat-cards/winged-horror-4.png",
+    "xws": "wingedhorror"
+  },
+  {
+    "name": "aesther ashblade",
+    "points": 94,
+    "image": "monster-stat-cards/aesther-ashblade-0.png",
+    "xws": "aestherashblade"
+  },
+  {
+    "name": "aesther ashblade",
+    "points": 95,
+    "image": "monster-stat-cards/aesther-ashblade-4.png",
+    "xws": "aestherashblade"
+  },
+  {
+    "name": "aesther scout",
+    "points": 96,
+    "image": "monster-stat-cards/aesther-scout-0.png",
+    "xws": "aestherscout"
+  },
+  {
+    "name": "aesther scout",
+    "points": 97,
+    "image": "monster-stat-cards/aesther-scout-4.png",
+    "xws": "aestherscout"
+  },
+  {
+    "name": "valrath savage",
+    "points": 98,
+    "image": "monster-stat-cards/valrath-savage-0.png",
+    "xws": "valrathsavage"
+  },
+  {
+    "name": "valrath savage",
+    "points": 99,
+    "image": "monster-stat-cards/valrath-savage-4.png",
+    "xws": "valrathsavage"
+  },
+  {
+    "name": "valrath tracker",
+    "points": 100,
+    "image": "monster-stat-cards/valrath-tracker-0.png",
+    "xws": "valrathtracker"
+  },
+  {
+    "name": "valrath tracker",
+    "points": 101,
+    "image": "monster-stat-cards/valrath-tracker-4.png",
+    "xws": "valrathtracker"
+  },
+  {
+    "name": "human commander",
+    "points": 102,
+    "image": "monster-stat-cards/human-commander-0.png",
+    "xws": "humancommander"
+  },
+  {
+    "name": "human commander",
+    "points": 103,
+    "image": "monster-stat-cards/human-commander-4.png",
+    "xws": "humancommander"
+  },
+  {
+    "name": "manifestation of corruption",
+    "points": 104,
+    "image": "monster-stat-cards/manifestation-of-corruption-0.png",
+    "xws": "manifestationofcorruption"
+  },
+  {
+    "name": "manifestation of corruption",
+    "points": 105,
+    "image": "monster-stat-cards/manifestation-of-corruption-4.png",
+    "xws": "manifestationofcorruption"
+  },
+  {
+    "name": "valrath commander",
+    "points": 106,
+    "image": "monster-stat-cards/valrath-commander-0.png",
+    "xws": "valrathcommander"
+  },
+  {
+    "name": "valrath commander",
+    "points": 107,
+    "image": "monster-stat-cards/valrath-commander-4.png",
+    "xws": "valrathcommander"
+  }
+]

--- a/data/world-map.json
+++ b/data/world-map.json
@@ -1,0 +1,1148 @@
+[
+  {
+    "name": "scenario 1",
+    "points": 0,
+    "image": "world-map/1.png",
+    "xws": "scenario1"
+  },
+  {
+    "name": "scenario 2",
+    "points": 1,
+    "image": "world-map/2.png",
+    "xws": "scenario2"
+  },
+  {
+    "name": "scenario 3",
+    "points": 2,
+    "image": "world-map/3.png",
+    "xws": "scenario3"
+  },
+  {
+    "name": "scenario 4",
+    "points": 3,
+    "image": "world-map/4.png",
+    "xws": "scenario4"
+  },
+  {
+    "name": "scenario 5",
+    "points": 4,
+    "image": "world-map/5.png",
+    "xws": "scenario5"
+  },
+  {
+    "name": "scenario 6",
+    "points": 5,
+    "image": "world-map/6.png",
+    "xws": "scenario6"
+  },
+  {
+    "name": "scenario 7",
+    "points": 6,
+    "image": "world-map/7.png",
+    "xws": "scenario7"
+  },
+  {
+    "name": "scenario 8",
+    "points": 7,
+    "image": "world-map/8.png",
+    "xws": "scenario8"
+  },
+  {
+    "name": "scenario 9",
+    "points": 8,
+    "image": "world-map/9.png",
+    "xws": "scenario9"
+  },
+  {
+    "name": "scenario 10",
+    "points": 9,
+    "image": "world-map/10.png",
+    "xws": "scenario10"
+  },
+  {
+    "name": "scenario 11",
+    "points": 10,
+    "image": "world-map/11-12.png",
+    "xws": "scenario11"
+  },
+  {
+    "name": "scenario 12",
+    "points": 11,
+    "image": "world-map/11-12.png",
+    "xws": "scenario12"
+  },
+  {
+    "name": "scenario 13",
+    "points": 12,
+    "image": "world-map/13.png",
+    "xws": "scenario13"
+  },
+  {
+    "name": "scenario 14",
+    "points": 13,
+    "image": "world-map/14.png",
+    "xws": "scenario14"
+  },
+  {
+    "name": "scenario 15",
+    "points": 14,
+    "image": "world-map/15.png",
+    "xws": "scenario15"
+  },
+  {
+    "name": "scenario 16",
+    "points": 15,
+    "image": "world-map/16.png",
+    "xws": "scenario16"
+  },
+  {
+    "name": "scenario 17",
+    "points": 16,
+    "image": "world-map/17.png",
+    "xws": "scenario17"
+  },
+  {
+    "name": "scenario 18",
+    "points": 17,
+    "image": "world-map/18.png",
+    "xws": "scenario18"
+  },
+  {
+    "name": "scenario 19",
+    "points": 18,
+    "image": "world-map/19.png",
+    "xws": "scenario19"
+  },
+  {
+    "name": "scenario 20",
+    "points": 19,
+    "image": "world-map/20.png",
+    "xws": "scenario20"
+  },
+  {
+    "name": "scenario 21",
+    "points": 20,
+    "image": "world-map/21.png",
+    "xws": "scenario21"
+  },
+  {
+    "name": "scenario 22",
+    "points": 21,
+    "image": "world-map/22.png",
+    "xws": "scenario22"
+  },
+  {
+    "name": "scenario 23",
+    "points": 22,
+    "image": "world-map/23.png",
+    "xws": "scenario23"
+  },
+  {
+    "name": "scenario 24",
+    "points": 23,
+    "image": "world-map/24.png",
+    "xws": "scenario24"
+  },
+  {
+    "name": "scenario 25",
+    "points": 24,
+    "image": "world-map/25.png",
+    "xws": "scenario25"
+  },
+  {
+    "name": "scenario 26",
+    "points": 25,
+    "image": "world-map/26.png",
+    "xws": "scenario26"
+  },
+  {
+    "name": "scenario 27",
+    "points": 26,
+    "image": "world-map/27.png",
+    "xws": "scenario27"
+  },
+  {
+    "name": "scenario 28",
+    "points": 27,
+    "image": "world-map/28.png",
+    "xws": "scenario28"
+  },
+  {
+    "name": "scenario 29",
+    "points": 28,
+    "image": "world-map/29.png",
+    "xws": "scenario29"
+  },
+  {
+    "name": "scenario 30",
+    "points": 29,
+    "image": "world-map/30.png",
+    "xws": "scenario30"
+  },
+  {
+    "name": "scenario 31",
+    "points": 30,
+    "image": "world-map/31.png",
+    "xws": "scenario31"
+  },
+  {
+    "name": "scenario 32",
+    "points": 31,
+    "image": "world-map/32.png",
+    "xws": "scenario32"
+  },
+  {
+    "name": "scenario 33",
+    "points": 32,
+    "image": "world-map/33.png",
+    "xws": "scenario33"
+  },
+  {
+    "name": "scenario 34",
+    "points": 33,
+    "image": "world-map/34.png",
+    "xws": "scenario34"
+  },
+  {
+    "name": "scenario 35",
+    "points": 34,
+    "image": "world-map/35-36.png",
+    "xws": "scenario35"
+  },
+  {
+    "name": "scenario 36",
+    "points": 35,
+    "image": "world-map/35-36.png",
+    "xws": "scenario36"
+  },
+  {
+    "name": "scenario 37",
+    "points": 36,
+    "image": "world-map/37.png",
+    "xws": "scenario37"
+  },
+  {
+    "name": "scenario 38",
+    "points": 37,
+    "image": "world-map/38.png",
+    "xws": "scenario38"
+  },
+  {
+    "name": "scenario 39",
+    "points": 38,
+    "image": "world-map/39.png",
+    "xws": "scenario39"
+  },
+  {
+    "name": "scenario 40",
+    "points": 39,
+    "image": "world-map/40.png",
+    "xws": "scenario40"
+  },
+  {
+    "name": "scenario 41",
+    "points": 40,
+    "image": "world-map/41.png",
+    "xws": "scenario41"
+  },
+  {
+    "name": "scenario 42",
+    "points": 41,
+    "image": "world-map/42.png",
+    "xws": "scenario42"
+  },
+  {
+    "name": "scenario 43",
+    "points": 42,
+    "image": "world-map/43.png",
+    "xws": "scenario43"
+  },
+  {
+    "name": "scenario 44",
+    "points": 43,
+    "image": "world-map/44.png",
+    "xws": "scenario44"
+  },
+  {
+    "name": "scenario 45",
+    "points": 44,
+    "image": "world-map/45.png",
+    "xws": "scenario45"
+  },
+  {
+    "name": "scenario 46",
+    "points": 45,
+    "image": "world-map/46.png",
+    "xws": "scenario46"
+  },
+  {
+    "name": "scenario 47",
+    "points": 46,
+    "image": "world-map/47.png",
+    "xws": "scenario47"
+  },
+  {
+    "name": "scenario 48",
+    "points": 47,
+    "image": "world-map/48.png",
+    "xws": "scenario48"
+  },
+  {
+    "name": "scenario 49",
+    "points": 48,
+    "image": "world-map/49.png",
+    "xws": "scenario49"
+  },
+  {
+    "name": "scenario 50",
+    "points": 49,
+    "image": "world-map/50.png",
+    "xws": "scenario50"
+  },
+  {
+    "name": "scenario 51",
+    "points": 50,
+    "image": "world-map/51.png",
+    "xws": "scenario51"
+  },
+  {
+    "name": "scenario 52",
+    "points": 51,
+    "image": "world-map/52.png",
+    "xws": "scenario52"
+  },
+  {
+    "name": "scenario 53",
+    "points": 52,
+    "image": "world-map/53.png",
+    "xws": "scenario53"
+  },
+  {
+    "name": "scenario 54",
+    "points": 53,
+    "image": "world-map/54.png",
+    "xws": "scenario54"
+  },
+  {
+    "name": "scenario 55",
+    "points": 54,
+    "image": "world-map/55.png",
+    "xws": "scenario55"
+  },
+  {
+    "name": "scenario 56",
+    "points": 55,
+    "image": "world-map/56.png",
+    "xws": "scenario56"
+  },
+  {
+    "name": "scenario 57",
+    "points": 56,
+    "image": "world-map/57.png",
+    "xws": "scenario57"
+  },
+  {
+    "name": "scenario 58",
+    "points": 57,
+    "image": "world-map/58.png",
+    "xws": "scenario58"
+  },
+  {
+    "name": "scenario 59",
+    "points": 58,
+    "image": "world-map/59.png",
+    "xws": "scenario59"
+  },
+  {
+    "name": "scenario 60",
+    "points": 59,
+    "image": "world-map/60.png",
+    "xws": "scenario60"
+  },
+  {
+    "name": "scenario 61",
+    "points": 60,
+    "image": "world-map/61.png",
+    "xws": "scenario61"
+  },
+  {
+    "name": "scenario 62",
+    "points": 61,
+    "image": "world-map/62.png",
+    "xws": "scenario62"
+  },
+  {
+    "name": "scenario 63",
+    "points": 62,
+    "image": "world-map/63.png",
+    "xws": "scenario63"
+  },
+  {
+    "name": "scenario 64",
+    "points": 63,
+    "image": "world-map/64.png",
+    "xws": "scenario64"
+  },
+  {
+    "name": "scenario 65",
+    "points": 64,
+    "image": "world-map/65.png",
+    "xws": "scenario65"
+  },
+  {
+    "name": "scenario 66",
+    "points": 65,
+    "image": "world-map/66.png",
+    "xws": "scenario66"
+  },
+  {
+    "name": "scenario 67",
+    "points": 66,
+    "image": "world-map/67.png",
+    "xws": "scenario67"
+  },
+  {
+    "name": "scenario 68",
+    "points": 67,
+    "image": "world-map/68.png",
+    "xws": "scenario68"
+  },
+  {
+    "name": "scenario 69",
+    "points": 68,
+    "image": "world-map/69.png",
+    "xws": "scenario69"
+  },
+  {
+    "name": "scenario 70",
+    "points": 69,
+    "image": "world-map/70.png",
+    "xws": "scenario70"
+  },
+  {
+    "name": "scenario 71",
+    "points": 70,
+    "image": "world-map/71.png",
+    "xws": "scenario71"
+  },
+  {
+    "name": "scenario 72",
+    "points": 71,
+    "image": "world-map/72.png",
+    "xws": "scenario72"
+  },
+  {
+    "name": "scenario 73",
+    "points": 72,
+    "image": "world-map/73.png",
+    "xws": "scenario73"
+  },
+  {
+    "name": "scenario 74",
+    "points": 73,
+    "image": "world-map/74.png",
+    "xws": "scenario74"
+  },
+  {
+    "name": "scenario 75",
+    "points": 74,
+    "image": "world-map/75.png",
+    "xws": "scenario75"
+  },
+  {
+    "name": "scenario 76",
+    "points": 75,
+    "image": "world-map/76.png",
+    "xws": "scenario76"
+  },
+  {
+    "name": "scenario 77",
+    "points": 76,
+    "image": "world-map/77.png",
+    "xws": "scenario77"
+  },
+  {
+    "name": "scenario 78",
+    "points": 77,
+    "image": "world-map/78.png",
+    "xws": "scenario78"
+  },
+  {
+    "name": "scenario 79",
+    "points": 78,
+    "image": "world-map/79.png",
+    "xws": "scenario79"
+  },
+  {
+    "name": "scenario 80",
+    "points": 79,
+    "image": "world-map/80.png",
+    "xws": "scenario80"
+  },
+  {
+    "name": "scenario 81",
+    "points": 80,
+    "image": "world-map/81.png",
+    "xws": "scenario81"
+  },
+  {
+    "name": "scenario 82",
+    "points": 81,
+    "image": "world-map/82.png",
+    "xws": "scenario82"
+  },
+  {
+    "name": "scenario 83",
+    "points": 82,
+    "image": "world-map/83.png",
+    "xws": "scenario83"
+  },
+  {
+    "name": "scenario 84",
+    "points": 83,
+    "image": "world-map/84.png",
+    "xws": "scenario84"
+  },
+  {
+    "name": "scenario 85",
+    "points": 84,
+    "image": "world-map/85.png",
+    "xws": "scenario85"
+  },
+  {
+    "name": "scenario 86",
+    "points": 85,
+    "image": "world-map/86.png",
+    "xws": "scenario86"
+  },
+  {
+    "name": "scenario 87",
+    "points": 86,
+    "image": "world-map/87.png",
+    "xws": "scenario87"
+  },
+  {
+    "name": "scenario 88",
+    "points": 87,
+    "image": "world-map/88.png",
+    "xws": "scenario88"
+  },
+  {
+    "name": "scenario 89",
+    "points": 88,
+    "image": "world-map/89.png",
+    "xws": "scenario89"
+  },
+  {
+    "name": "scenario 90",
+    "points": 89,
+    "image": "world-map/90.png",
+    "xws": "scenario90"
+  },
+  {
+    "name": "scenario 91",
+    "points": 90,
+    "image": "world-map/91.png",
+    "xws": "scenario91"
+  },
+  {
+    "name": "scenario 92",
+    "points": 91,
+    "image": "world-map/92.png",
+    "xws": "scenario92"
+  },
+  {
+    "name": "scenario 93",
+    "points": 92,
+    "image": "world-map/93.png",
+    "xws": "scenario93"
+  },
+  {
+    "name": "scenario 94",
+    "points": 93,
+    "image": "world-map/94.png",
+    "xws": "scenario94"
+  },
+  {
+    "name": "scenario 95",
+    "points": 94,
+    "image": "world-map/95.png",
+    "xws": "scenario95"
+  },
+  {
+    "name": "black barrow",
+    "points": 95,
+    "image": "world-map/1.png",
+    "xws": "scenario1"
+  },
+  {
+    "name": "barrow lair",
+    "points": 96,
+    "image": "world-map/2.png",
+    "xws": "scenario2"
+  },
+  {
+    "name": "inox encampment",
+    "points": 97,
+    "image": "world-map/3.png",
+    "xws": "scenario3"
+  },
+  {
+    "name": "crypt of the damned",
+    "points": 98,
+    "image": "world-map/4.png",
+    "xws": "scenario4"
+  },
+  {
+    "name": "ruinous crypt",
+    "points": 99,
+    "image": "world-map/5.png",
+    "xws": "scenario5"
+  },
+  {
+    "name": "decaying crypt",
+    "points": 100,
+    "image": "world-map/6.png",
+    "xws": "scenario6"
+  },
+  {
+    "name": "vibrant grotto",
+    "points": 101,
+    "image": "world-map/7.png",
+    "xws": "scenario7"
+  },
+  {
+    "name": "gloomhaven warehouse",
+    "points": 102,
+    "image": "world-map/8.png",
+    "xws": "scenario8"
+  },
+  {
+    "name": "diamond mine",
+    "points": 103,
+    "image": "world-map/9.png",
+    "xws": "scenario9"
+  },
+  {
+    "name": "plane of elemental power",
+    "points": 104,
+    "image": "world-map/10.png",
+    "xws": "scenario10"
+  },
+  {
+    "name": "gloomhaven square a",
+    "points": 105,
+    "image": "world-map/11-12.png",
+    "xws": "scenario11"
+  },
+  {
+    "name": "gloomhaven square b",
+    "points": 106,
+    "image": "world-map/11-12.png",
+    "xws": "scenario12"
+  },
+  {
+    "name": "temple of the seer",
+    "points": 107,
+    "image": "world-map/13.png",
+    "xws": "scenario13"
+  },
+  {
+    "name": "frozen hollow",
+    "points": 108,
+    "image": "world-map/14.png",
+    "xws": "scenario14"
+  },
+  {
+    "name": "shrine of strength",
+    "points": 109,
+    "image": "world-map/15.png",
+    "xws": "scenario15"
+  },
+  {
+    "name": "mountain pass",
+    "points": 110,
+    "image": "world-map/16.png",
+    "xws": "scenario16"
+  },
+  {
+    "name": "lost island",
+    "points": 111,
+    "image": "world-map/17.png",
+    "xws": "scenario17"
+  },
+  {
+    "name": "abandoned sewers",
+    "points": 112,
+    "image": "world-map/18.png",
+    "xws": "scenario18"
+  },
+  {
+    "name": "forgotten crypt",
+    "points": 113,
+    "image": "world-map/19.png",
+    "xws": "scenario19"
+  },
+  {
+    "name": "necromancer's sanctum",
+    "points": 114,
+    "image": "world-map/20.png",
+    "xws": "scenario20"
+  },
+  {
+    "name": "infernal throne",
+    "points": 115,
+    "image": "world-map/21.png",
+    "xws": "scenario21"
+  },
+  {
+    "name": "temple of the elements",
+    "points": 116,
+    "image": "world-map/22.png",
+    "xws": "scenario22"
+  },
+  {
+    "name": "deep ruins",
+    "points": 117,
+    "image": "world-map/23.png",
+    "xws": "scenario23"
+  },
+  {
+    "name": "echo chamber",
+    "points": 118,
+    "image": "world-map/24.png",
+    "xws": "scenario24"
+  },
+  {
+    "name": "icecrag ascent",
+    "points": 119,
+    "image": "world-map/25.png",
+    "xws": "scenario25"
+  },
+  {
+    "name": "ancient cistern",
+    "points": 120,
+    "image": "world-map/26.png",
+    "xws": "scenario26"
+  },
+  {
+    "name": "ruinous rift",
+    "points": 121,
+    "image": "world-map/27.png",
+    "xws": "scenario27"
+  },
+  {
+    "name": "outer ritual chamber",
+    "points": 122,
+    "image": "world-map/28.png",
+    "xws": "scenario28"
+  },
+  {
+    "name": "sanctuary of gloom",
+    "points": 123,
+    "image": "world-map/29.png",
+    "xws": "scenario29"
+  },
+  {
+    "name": "shrine of the depths",
+    "points": 124,
+    "image": "world-map/30.png",
+    "xws": "scenario30"
+  },
+  {
+    "name": "plane of night",
+    "points": 125,
+    "image": "world-map/31.png",
+    "xws": "scenario31"
+  },
+  {
+    "name": "decrepit wood",
+    "points": 126,
+    "image": "world-map/32.png",
+    "xws": "scenario32"
+  },
+  {
+    "name": "savvas armory",
+    "points": 127,
+    "image": "world-map/33.png",
+    "xws": "scenario33"
+  },
+  {
+    "name": "scorched summit",
+    "points": 128,
+    "image": "world-map/34.png",
+    "xws": "scenario34"
+  },
+  {
+    "name": "gloomhaven battlements a",
+    "points": 129,
+    "image": "world-map/35-36.png",
+    "xws": "scenario35"
+  },
+  {
+    "name": "gloomhaven battlements b",
+    "points": 130,
+    "image": "world-map/35-36.png",
+    "xws": "scenario36"
+  },
+  {
+    "name": "doom trench",
+    "points": 131,
+    "image": "world-map/37.png",
+    "xws": "scenario37"
+  },
+  {
+    "name": "slave pens",
+    "points": 132,
+    "image": "world-map/38.png",
+    "xws": "scenario38"
+  },
+  {
+    "name": "treacherous divide",
+    "points": 133,
+    "image": "world-map/39.png",
+    "xws": "scenario39"
+  },
+  {
+    "name": "ancient defense network",
+    "points": 134,
+    "image": "world-map/40.png",
+    "xws": "scenario40"
+  },
+  {
+    "name": "timeworn tomb",
+    "points": 135,
+    "image": "world-map/41.png",
+    "xws": "scenario41"
+  },
+  {
+    "name": "realm of the voice",
+    "points": 136,
+    "image": "world-map/42.png",
+    "xws": "scenario42"
+  },
+  {
+    "name": "drake nest",
+    "points": 137,
+    "image": "world-map/43.png",
+    "xws": "scenario43"
+  },
+  {
+    "name": "tribal assault",
+    "points": 138,
+    "image": "world-map/44.png",
+    "xws": "scenario44"
+  },
+  {
+    "name": "rebel swamp",
+    "points": 139,
+    "image": "world-map/45.png",
+    "xws": "scenario45"
+  },
+  {
+    "name": "nightmare peak",
+    "points": 140,
+    "image": "world-map/46.png",
+    "xws": "scenario46"
+  },
+  {
+    "name": "lair of the unseeing eye",
+    "points": 141,
+    "image": "world-map/47.png",
+    "xws": "scenario47"
+  },
+  {
+    "name": "shadow weald",
+    "points": 142,
+    "image": "world-map/48.png",
+    "xws": "scenario48"
+  },
+  {
+    "name": "rebel's stand",
+    "points": 143,
+    "image": "world-map/49.png",
+    "xws": "scenario49"
+  },
+  {
+    "name": "ghost fortress",
+    "points": 144,
+    "image": "world-map/50.png",
+    "xws": "scenario50"
+  },
+  {
+    "name": "the void",
+    "points": 145,
+    "image": "world-map/51.png",
+    "xws": "scenario51"
+  },
+  {
+    "name": "noxious cellar",
+    "points": 146,
+    "image": "world-map/52.png",
+    "xws": "scenario52"
+  },
+  {
+    "name": "crypt basement",
+    "points": 147,
+    "image": "world-map/53.png",
+    "xws": "scenario53"
+  },
+  {
+    "name": "palace of ice",
+    "points": 148,
+    "image": "world-map/54.png",
+    "xws": "scenario54"
+  },
+  {
+    "name": "foggy thicket",
+    "points": 149,
+    "image": "world-map/55.png",
+    "xws": "scenario55"
+  },
+  {
+    "name": "bandit's wood",
+    "points": 150,
+    "image": "world-map/56.png",
+    "xws": "scenario56"
+  },
+  {
+    "name": "investigation",
+    "points": 151,
+    "image": "world-map/57.png",
+    "xws": "scenario57"
+  },
+  {
+    "name": "bloody shack",
+    "points": 152,
+    "image": "world-map/58.png",
+    "xws": "scenario58"
+  },
+  {
+    "name": "forgotten grove",
+    "points": 153,
+    "image": "world-map/59.png",
+    "xws": "scenario59"
+  },
+  {
+    "name": "alchemy lab",
+    "points": 154,
+    "image": "world-map/60.png",
+    "xws": "scenario60"
+  },
+  {
+    "name": "fading lighthouse",
+    "points": 155,
+    "image": "world-map/61.png",
+    "xws": "scenario61"
+  },
+  {
+    "name": "pit of souls",
+    "points": 156,
+    "image": "world-map/62.png",
+    "xws": "scenario62"
+  },
+  {
+    "name": "magma pit",
+    "points": 157,
+    "image": "world-map/63.png",
+    "xws": "scenario63"
+  },
+  {
+    "name": "underwater lagoon",
+    "points": 158,
+    "image": "world-map/64.png",
+    "xws": "scenario64"
+  },
+  {
+    "name": "sulfur mine",
+    "points": 159,
+    "image": "world-map/65.png",
+    "xws": "scenario65"
+  },
+  {
+    "name": "clockwork cove",
+    "points": 160,
+    "image": "world-map/66.png",
+    "xws": "scenario66"
+  },
+  {
+    "name": "arcane library",
+    "points": 161,
+    "image": "world-map/67.png",
+    "xws": "scenario67"
+  },
+  {
+    "name": "toxic moor",
+    "points": 162,
+    "image": "world-map/68.png",
+    "xws": "scenario68"
+  },
+  {
+    "name": "well of the unfortunate",
+    "points": 163,
+    "image": "world-map/69.png",
+    "xws": "scenario69"
+  },
+  {
+    "name": "chained isle",
+    "points": 164,
+    "image": "world-map/70.png",
+    "xws": "scenario70"
+  },
+  {
+    "name": "windswept highlands",
+    "points": 165,
+    "image": "world-map/71.png",
+    "xws": "scenario71"
+  },
+  {
+    "name": "oozing grove",
+    "points": 166,
+    "image": "world-map/72.png",
+    "xws": "scenario72"
+  },
+  {
+    "name": "rockslide ridge",
+    "points": 167,
+    "image": "world-map/73.png",
+    "xws": "scenario73"
+  },
+  {
+    "name": "merchant ship",
+    "points": 168,
+    "image": "world-map/74.png",
+    "xws": "scenario74"
+  },
+  {
+    "name": "overgrown graveyard",
+    "points": 169,
+    "image": "world-map/75.png",
+    "xws": "scenario75"
+  },
+  {
+    "name": "harrower hive",
+    "points": 170,
+    "image": "world-map/76.png",
+    "xws": "scenario76"
+  },
+  {
+    "name": "vault of secrets",
+    "points": 171,
+    "image": "world-map/77.png",
+    "xws": "scenario77"
+  },
+  {
+    "name": "sacrifice pit",
+    "points": 172,
+    "image": "world-map/78.png",
+    "xws": "scenario78"
+  },
+  {
+    "name": "lost temple",
+    "points": 173,
+    "image": "world-map/79.png",
+    "xws": "scenario79"
+  },
+  {
+    "name": "vigil keep",
+    "points": 174,
+    "image": "world-map/80.png",
+    "xws": "scenario80"
+  },
+  {
+    "name": "temple of the eclipse",
+    "points": 175,
+    "image": "world-map/81.png",
+    "xws": "scenario81"
+  },
+  {
+    "name": "burning mountain",
+    "points": 176,
+    "image": "world-map/82.png",
+    "xws": "scenario82"
+  },
+  {
+    "name": "shadows within",
+    "points": 177,
+    "image": "world-map/83.png",
+    "xws": "scenario83"
+  },
+  {
+    "name": "crystalline cave",
+    "points": 178,
+    "image": "world-map/84.png",
+    "xws": "scenario84"
+  },
+  {
+    "name": "sun temple",
+    "points": 179,
+    "image": "world-map/85.png",
+    "xws": "scenario85"
+  },
+  {
+    "name": "harried village",
+    "points": 180,
+    "image": "world-map/86.png",
+    "xws": "scenario86"
+  },
+  {
+    "name": "corrupted cove",
+    "points": 181,
+    "image": "world-map/87.png",
+    "xws": "scenario87"
+  },
+  {
+    "name": "plane of water",
+    "points": 182,
+    "image": "world-map/88.png",
+    "xws": "scenario88"
+  },
+  {
+    "name": "syndicate hideout",
+    "points": 183,
+    "image": "world-map/89.png",
+    "xws": "scenario89"
+  },
+  {
+    "name": "demonic rift",
+    "points": 184,
+    "image": "world-map/90.png",
+    "xws": "scenario90"
+  },
+  {
+    "name": "wild melee",
+    "points": 185,
+    "image": "world-map/91.png",
+    "xws": "scenario91"
+  },
+  {
+    "name": "back alley brawl",
+    "points": 186,
+    "image": "world-map/92.png",
+    "xws": "scenario92"
+  },
+  {
+    "name": "sunken vessel",
+    "points": 187,
+    "image": "world-map/93.png",
+    "xws": "scenario93"
+  },
+  {
+    "name": "vermling nest",
+    "points": 188,
+    "image": "world-map/94.png",
+    "xws": "scenario94"
+  },
+  {
+    "name": "payment due",
+    "points": 189,
+    "image": "world-map/95.png",
+    "xws": "scenario95"
+  },
+  {
+    "name": "gloomhaven map",
+    "points": 190,
+    "image": "world-map/gloomhaven-map.png",
+    "xws": "gloomhavenmap"
+  }
+]

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -81,7 +81,7 @@
   }
 
   function cardValue(card: AttackModifierCard): string {
-    return card.value === undefined ? "Special" : String(card.value);
+    return card.value === undefined || card.value === "special" ? "Special" : String(card.value);
   }
 
   $: classOptions = controller?.classOptions ?? [];

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -4,7 +4,9 @@ The modern Vite/Svelte shell imports normalized data through `src/data/`.
 
 - `data/attack-modifiers.json` is the canonical modern copy of legacy `data/attack-modifiers.js`.
 - `data/character-perks-plus.json` is the canonical modern copy of legacy `data/character-perks+.js`.
+- `data/items.json`, `data/events.json`, `data/monster-*.json`, `data/character-ability-cards*.json`, `data/map-tiles.json`, and `data/world-map.json` are canonical modern copies of their JSON-shaped legacy `.js` catalog files.
 - `src/data/app-data.ts` validates and exports the data used by the modern deck workflow.
+- `src/data/catalog-data.ts` validates and exports broader card, item, event, monster, and map catalog data for future UI workflows.
 - `src/data/character-classes.ts` owns class ids, abbreviations, names, and icon paths.
 
 The previous `legacy.html` flow has been removed, but the original JSON-shaped `.js` data files remain for downstream consumers and historical compatibility. Keep each modern JSON file semantically in sync with its legacy source until those legacy data exports are intentionally retired. The parity tests in `tests/data/parity.test.ts` enforce that split.

--- a/src/data/catalog-data.ts
+++ b/src/data/catalog-data.ts
@@ -1,0 +1,79 @@
+import characterAbilityCards from "../../data/character-ability-cards.json" with { type: "json" };
+import characterAbilityCardsRevised from "../../data/character-ability-cards-revised.json" with { type: "json" };
+import events from "../../data/events.json" with { type: "json" };
+import items from "../../data/items.json" with { type: "json" };
+import mapTiles from "../../data/map-tiles.json" with { type: "json" };
+import monsterAbilityCards from "../../data/monster-ability-cards.json" with { type: "json" };
+import monsterStatCards from "../../data/monster-stat-cards.json" with { type: "json" };
+import worldMap from "../../data/world-map.json" with { type: "json" };
+
+export interface CatalogItem {
+  name: string;
+  points: number;
+  image: string;
+  xws: string;
+}
+
+export interface CatalogData {
+  characterAbilityCards: CatalogItem[];
+  characterAbilityCardsRevised: CatalogItem[];
+  events: CatalogItem[];
+  items: CatalogItem[];
+  mapTiles: CatalogItem[];
+  monsterAbilityCards: CatalogItem[];
+  monsterStatCards: CatalogItem[];
+  worldMap: CatalogItem[];
+}
+
+export const catalogData: CatalogData = {
+  characterAbilityCards: normalizeCatalogItems(characterAbilityCards, "character ability cards"),
+  characterAbilityCardsRevised: normalizeCatalogItems(
+    characterAbilityCardsRevised,
+    "revised character ability cards",
+  ),
+  events: normalizeCatalogItems(events, "events"),
+  items: normalizeCatalogItems(items, "items"),
+  mapTiles: normalizeCatalogItems(mapTiles, "map tiles"),
+  monsterAbilityCards: normalizeCatalogItems(monsterAbilityCards, "monster ability cards"),
+  monsterStatCards: normalizeCatalogItems(monsterStatCards, "monster stat cards"),
+  worldMap: normalizeCatalogItems(worldMap, "world map"),
+};
+
+export function normalizeCatalogItems(input: unknown, label: string): CatalogItem[] {
+  if (!Array.isArray(input)) {
+    throw new Error(`${label} catalog must be an array`);
+  }
+
+  return input.map((item, index) => normalizeCatalogItem(item, `${label}[${index}]`));
+}
+
+function normalizeCatalogItem(input: unknown, path: string): CatalogItem {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    throw new Error(`${path} must be an object`);
+  }
+
+  const item = input as Record<string, unknown>;
+
+  if (typeof item.name !== "string") {
+    throw new Error(`${path}.name must be a string`);
+  }
+
+  if (typeof item.points !== "number") {
+    throw new Error(`${path}.points must be a number`);
+  }
+
+  if (typeof item.image !== "string") {
+    throw new Error(`${path}.image must be a string`);
+  }
+
+  if (typeof item.xws !== "string") {
+    throw new Error(`${path}.xws must be a string`);
+  }
+
+  return {
+    name: item.name,
+    points: item.points,
+    image: item.image,
+    xws: item.xws,
+  };
+}

--- a/src/data/validation.ts
+++ b/src/data/validation.ts
@@ -2,13 +2,14 @@ import type { AppData } from "../domain/app-data.ts";
 import type { AttackModifierCard, CharacterSheet, ModifierValue, Perk, PerkAction } from "../domain/types.ts";
 import type { CharacterClassData } from "./character-classes.ts";
 
-const modifierValues = new Set<ModifierValue>(["x2", "miss", "bless", "curse", "rolling"]);
+const modifierValues = new Set<ModifierValue>(["x2", "miss", "bless", "curse", "rolling", "special"]);
 const perkActionTypes = new Set<PerkAction["type"]>(["add", "remove"]);
 
 export function normalizeAppData(input: { cards: unknown; sheets: unknown; classes?: Record<string, CharacterClassData> }): AppData {
   const cards = normalizeAttackModifierCards(input.cards);
   const sheets = normalizeCharacterSheets(input.sheets);
 
+  validateAttackModifierMetadata(cards);
   validatePerkCardReferences(sheets, cards);
   if (input.classes) {
     validateClassDataReferences(input.classes, sheets, cards);
@@ -175,6 +176,18 @@ function validatePerkCardReferences(sheets: CharacterSheet[], cards: AttackModif
           }
         }
       }
+    }
+  }
+}
+
+function validateAttackModifierMetadata(cards: AttackModifierCard[]): void {
+  for (const card of cards) {
+    if (card.value === undefined) {
+      throw new Error(`Attack modifier "${card.name}" is missing value metadata`);
+    }
+
+    if (!Array.isArray(card.conditions)) {
+      throw new Error(`Attack modifier "${card.name}" is missing conditions metadata`);
     }
   }
 }

--- a/src/domain/types.ts
+++ b/src/domain/types.ts
@@ -1,4 +1,4 @@
-export type ModifierValue = number | "x2" | "miss" | "bless" | "curse" | "rolling";
+export type ModifierValue = number | "x2" | "miss" | "bless" | "curse" | "rolling" | "special";
 
 export interface AttackModifierCard {
   name: string;

--- a/tests/data/catalog-data.test.ts
+++ b/tests/data/catalog-data.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { catalogData, normalizeCatalogItems } from "../../src/data/catalog-data.ts";
+
+test("catalogData normalizes broader legacy datasets", () => {
+  assert.equal(catalogData.items.length, 719);
+  assert.equal(catalogData.events.length, 378);
+  assert.equal(catalogData.monsterStatCards.length, 108);
+  assert.equal(catalogData.monsterAbilityCards.length, 309);
+  assert.equal(catalogData.characterAbilityCards.length, 617);
+  assert.equal(catalogData.characterAbilityCardsRevised.length, 14);
+  assert.equal(catalogData.mapTiles.length, 60);
+  assert.equal(catalogData.worldMap.length, 191);
+});
+
+test("catalogData validates core catalog item shape", () => {
+  assert.throws(
+    () => normalizeCatalogItems([{ name: "broken", points: 0, image: "items/broken.png" }], "items"),
+    /items\[0\]\.xws must be a string/,
+  );
+});
+
+test("catalog image paths are normalized relative asset paths", () => {
+  for (const [catalogName, items] of Object.entries(catalogData)) {
+    for (const item of items) {
+      assert.equal(item.image.startsWith("/"), false, `${catalogName} image should be relative: ${item.image}`);
+      assert.equal(item.image.includes("\\"), false, `${catalogName} image should use web separators: ${item.image}`);
+      assert.match(item.image, /\.png$/, `${catalogName} image should reference a PNG: ${item.image}`);
+    }
+  }
+});

--- a/tests/data/parity.test.ts
+++ b/tests/data/parity.test.ts
@@ -13,6 +13,21 @@ test("modern character perks JSON stays in sync with the legacy data file", () =
   assert.deepEqual(loadJson("data/character-perks-plus.json"), loadJson("data/character-perks+.js"));
 });
 
+test("modern catalog JSON files stay in sync with legacy data files", () => {
+  for (const file of [
+    "character-ability-cards",
+    "character-ability-cards-revised",
+    "events",
+    "items",
+    "map-tiles",
+    "monster-ability-cards",
+    "monster-stat-cards",
+    "world-map",
+  ]) {
+    assert.deepEqual(loadJson(`data/${file}.json`), loadJson(`data/${file}.js`), file);
+  }
+});
+
 function loadJson(path: string): unknown {
   return JSON.parse(readFileSync(resolve(repoRoot, path), "utf8")) as unknown;
 }

--- a/tests/data/validation.test.ts
+++ b/tests/data/validation.test.ts
@@ -12,7 +12,7 @@ test("normalizeAppData validates perk card references against attack modifier ca
   assert.throws(
     () =>
       normalizeAppData({
-        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png" }],
+        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png", value: 0, conditions: [] }],
         sheets: [
           {
             name: "brute perks",
@@ -33,10 +33,30 @@ test("normalizeAppData rejects unsupported modifier values", () => {
   assert.throws(
     () =>
       normalizeAppData({
-        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png", value: "triple" }],
+        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png", value: "triple", conditions: [] }],
         sheets: [],
       }),
     /unsupported modifier value/,
+  );
+});
+
+test("normalizeAppData requires complete attack modifier metadata", () => {
+  assert.throws(
+    () =>
+      normalizeAppData({
+        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png", value: 0 }],
+        sheets: [],
+      }),
+    /missing conditions metadata/,
+  );
+
+  assert.throws(
+    () =>
+      normalizeAppData({
+        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png", conditions: [] }],
+        sheets: [],
+      }),
+    /missing value metadata/,
   );
 });
 
@@ -55,7 +75,7 @@ test("normalizeAppData validates character sheets against class metadata", () =>
   assert.throws(
     () =>
       normalizeAppData({
-        cards: [{ name: "am-br-01", image: "attack-modifiers/BR/am-br-01.png" }],
+        cards: [{ name: "am-br-01", image: "attack-modifiers/BR/am-br-01.png", value: 1, conditions: [] }],
         sheets: [{ name: "unknown perks", perks: [] }],
         classes: {
           brute: { name: "brute", abbr: "br", iconPath: "/images/class-icons/brute.png" },
@@ -69,7 +89,7 @@ test("normalizeAppData validates class modifier card prefixes against class meta
   assert.throws(
     () =>
       normalizeAppData({
-        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png" }],
+        cards: [{ name: "am-p-01", image: "attack-modifiers/base/player/am-p-01.png", value: 0, conditions: [] }],
         sheets: [{ name: "brute perks", perks: [] }],
         classes: {
           brute: { name: "brute", abbr: "br", iconPath: "/images/class-icons/brute.png" },

--- a/tests/domain/real-data.test.ts
+++ b/tests/domain/real-data.test.ts
@@ -28,6 +28,14 @@ test("real player terminal cards are identified as shuffle triggers", () => {
   assert.deepEqual(shuffleCards, ["am-p-19", "am-p-20"]);
 });
 
+test("real attack modifier data has value and conditions metadata for every card", () => {
+  const cards = loadAttackModifierCards();
+
+  assert.equal(cards.every((card) => card.value !== undefined), true);
+  assert.equal(cards.every((card) => Array.isArray(card.conditions)), true);
+  assert.equal(cards.find((card) => card.name === "am-p-17")?.value, -2);
+});
+
 test("real Brute perk data can remove base cards", () => {
   const character = new Character("base");
 

--- a/to-do.md
+++ b/to-do.md
@@ -7,5 +7,5 @@
   - [x] Base deck
   - [x] Character
 - [x] Add auto removal of curse and bless cards when drawn
-- [ ] Add a value attribute to all attack modifier cards
-- [ ] Add a conditions array attribute to all attack modifier cards
+- [x] Add a value attribute to all attack modifier cards
+- [x] Add a conditions array attribute to all attack modifier cards


### PR DESCRIPTION
## Summary

- Add explicit `value` and `conditions` metadata to every attack modifier card in the modern and legacy attack modifier data files.
- Correct `am-p-17` to `-2` based on the card image.
- Add canonical JSON copies for broader catalog data: items, events, monster cards, character ability cards, map tiles, and world map assets.
- Add `src/data/catalog-data.ts` typed normalization plus catalog shape/path tests and parity coverage.
- Update modernization docs and the project checklist.

## Notes

Some attack modifier cards are marked with `value: "special"` where the existing repo data does not encode a precise numeric or rolling value. This avoids inventing false numeric metadata while still making the value field explicit for every card.

## Validation

- `npm test` — 54 tests passed
- `npm run build` — passed
- `npm run test:e2e` — 13 tests passed
- `git diff --check` — passed

`npx tsc --noEmit` still reports missing Node type declarations for existing test files (`node:test`, `node:assert`, etc.), which appears to be pre-existing TypeScript config/dependency work outside the current npm scripts.